### PR TITLE
Allow unique reset to avoid overflow exception.

### DIFF
--- a/docs/factories.md
+++ b/docs/factories.md
@@ -280,3 +280,52 @@ CakeGeneratorFactory::registerAdapter('custom', MyCustomAdapter::class);
 ```php
 Configure::write('FixtureFactories.generatorType', 'custom');
 ```
+
+### Unique Value Generation
+
+Both Faker and DummyGenerator support generating unique values through the `unique()` modifier:
+
+```php
+$generator = $this->getGenerator();
+$email = $generator->unique()->email(); // Guaranteed to be unique
+```
+
+#### Resetting Unique State in Tests
+
+When using `unique()`, the generator maintains an internal state of previously generated values to ensure uniqueness.
+In test environments where data is truncated between tests, this state can accumulate and eventually cause `OverflowException` when the generator runs out of unique values.
+
+To prevent this, **always reset the generator state** between tests by calling:
+
+```php
+use CakephpFixtureFactories\Generator\CakeGeneratorFactory;
+
+// In your test's tearDown() method or test listener:
+CakeGeneratorFactory::clearInstances();
+```
+
+This method automatically resets the unique state before clearing the cached generator instances.
+
+If you only want to reset the unique state without clearing the cache:
+
+```php
+CakeGeneratorFactory::resetUniqueState();
+```
+
+**Best Practice**: Add this to a test listener or base test case to automatically reset between tests:
+
+```php
+namespace App\Test;
+
+use Cake\TestSuite\TestCase;
+use CakephpFixtureFactories\Generator\CakeGeneratorFactory;
+
+abstract class AppTestCase extends TestCase
+{
+    protected function tearDown(): void
+    {
+        CakeGeneratorFactory::clearInstances();
+        parent::tearDown();
+    }
+}
+```

--- a/src/Generator/CakeGeneratorFactory.php
+++ b/src/Generator/CakeGeneratorFactory.php
@@ -116,12 +116,38 @@ class CakeGeneratorFactory
     }
 
     /**
-     * Clear all cached instances
+     * Reset unique state on all cached generator instances
+     *
+     * This resets the unique value tracking for all cached generators,
+     * allowing unique values to be regenerated in subsequent tests.
      *
      * @return void
      */
-    public static function clearInstances(): void
+    public static function resetUniqueState(): void
     {
+        foreach (self::$instances as $instance) {
+            if (method_exists($instance, 'resetUnique')) {
+                $instance->resetUnique();
+            }
+        }
+    }
+
+    /**
+     * Clear all cached instances
+     *
+     * This will reset unique state before clearing the cache to prevent
+     * unique value accumulation across test runs.
+     *
+     * @param bool $resetUnique Whether to reset unique state before clearing (default: true)
+     *
+     * @return void
+     */
+    public static function clearInstances(bool $resetUnique = true): void
+    {
+        if ($resetUnique) {
+            self::resetUniqueState();
+        }
+
         self::$instances = [];
     }
 }

--- a/src/Generator/DummyGeneratorAdapter.php
+++ b/src/Generator/DummyGeneratorAdapter.php
@@ -227,10 +227,19 @@ class DummyGeneratorAdapter implements GeneratorInterface
     /**
      * Reset unique values tracking
      *
+     * This resets both the adapter's unique values tracking and
+     * recreates the DummyGenerator with a fresh UniqueStrategy.
+     *
      * @return void
      */
     public function resetUnique(): void
     {
         $this->uniqueValues = [];
+
+        // Recreate the generator with a fresh UniqueStrategy
+        // This is necessary because DummyGenerator's UniqueStrategy
+        // maintains its own internal state
+        $strategy = new UniqueStrategy(retries: 1000);
+        $this->generator = new DummyGenerator($this->container, $strategy);
     }
 }

--- a/src/Generator/FakerAdapter.php
+++ b/src/Generator/FakerAdapter.php
@@ -140,4 +140,24 @@ class FakerAdapter implements GeneratorInterface
     {
         return new FakerOptionalAdapter($this->generator->optional($weight));
     }
+
+    /**
+     * Reset unique values tracking
+     *
+     * This resets Faker's internal unique generator state by accessing
+     * the generator's unique property and clearing it.
+     *
+     * @return void
+     */
+    public function resetUnique(): void
+    {
+        // Access Faker's unique generator property
+        $reflection = new \ReflectionObject($this->generator);
+        if ($reflection->hasProperty('unique')) {
+            $uniqueProperty = $reflection->getProperty('unique');
+            // Reset the unique generator by setting it to null
+            // Next time unique() is called, a fresh one will be created
+            $uniqueProperty->setValue($this->generator, null);
+        }
+    }
 }

--- a/tests/TestCase/Generator/GeneratorAdapterTest.php
+++ b/tests/TestCase/Generator/GeneratorAdapterTest.php
@@ -357,4 +357,83 @@ class GeneratorAdapterTest extends TestCase
         Configure::delete('FixtureFactories.generatorType');
         CakeGeneratorFactory::clearInstances();
     }
+
+    /**
+     * Test that unique state is reset when clearing instances
+     *
+     * @return void
+     */
+    public function testUniqueStateResetWithClearInstances(): void
+    {
+        // Test with DummyGenerator
+        Configure::write('FixtureFactories.generatorType', 'dummy');
+        CakeGeneratorFactory::clearInstances();
+
+        $generator = CakeGeneratorFactory::create();
+        $unique = $generator->unique();
+
+        // Generate some unique digits (0-9, so we have limited values)
+        $values1 = [];
+        for ($i = 0; $i < 10; $i++) {
+            $values1[] = $unique->randomDigit();
+        }
+        $this->assertCount(10, array_unique($values1));
+
+        // Now clear instances with reset
+        CakeGeneratorFactory::clearInstances();
+
+        // Get a fresh generator and unique adapter
+        $generator2 = CakeGeneratorFactory::create();
+        $unique2 = $generator2->unique();
+
+        // Should be able to generate the same values again since state was reset
+        $values2 = [];
+        for ($i = 0; $i < 10; $i++) {
+            $values2[] = $unique2->randomDigit();
+        }
+        $this->assertCount(10, array_unique($values2));
+
+        // Reset config
+        Configure::delete('FixtureFactories.generatorType');
+        CakeGeneratorFactory::clearInstances();
+    }
+
+    /**
+     * Test that resetUniqueState() method works correctly
+     *
+     * @return void
+     */
+    public function testResetUniqueState(): void
+    {
+        Configure::write('FixtureFactories.generatorType', 'dummy');
+        CakeGeneratorFactory::clearInstances();
+
+        $generator = CakeGeneratorFactory::create();
+        $unique = $generator->unique();
+
+        // Generate 10 unique digits
+        $values = [];
+        for ($i = 0; $i < 10; $i++) {
+            $values[] = $unique->randomDigit();
+        }
+        $this->assertCount(10, array_unique($values));
+
+        // Reset unique state only (don't clear instances)
+        CakeGeneratorFactory::resetUniqueState();
+
+        // Get the same cached generator
+        $generator2 = CakeGeneratorFactory::create();
+        $unique2 = $generator2->unique();
+
+        // Should be able to generate digits again after reset
+        $values2 = [];
+        for ($i = 0; $i < 10; $i++) {
+            $values2[] = $unique2->randomDigit();
+        }
+        $this->assertCount(10, array_unique($values2));
+
+        // Reset config
+        Configure::delete('FixtureFactories.generatorType');
+        CakeGeneratorFactory::clearInstances();
+    }
 }


### PR DESCRIPTION

  Problem

  The DummyGenerator's UniqueStrategy maintains state across the entire test suite, accumulating all generated unique values until hitting the 1000 retry limit and throwing an OverflowException. This happens because:
  1. Generator instances are cached in CakeGeneratorFactory::$instances
  2. Both the DummyGenerator's internal UniqueStrategy and the adapter's $uniqueValues array maintain state
  3. Even though tables are truncated between tests, the unique state was never reset

  Solution

  1. Enhanced CakeGeneratorFactory (src/Generator/CakeGeneratorFactory.php:118-152)
  - Added resetUniqueState() method to reset unique state on all cached generators
  - Modified clearInstances() to automatically reset unique state before clearing (opt-out with parameter)

  2. Fixed DummyGeneratorAdapter (src/Generator/DummyGeneratorAdapter.php:235-244)
  - Enhanced resetUnique() to recreate the DummyGenerator with a fresh UniqueStrategy
  - This clears both the adapter's tracking AND the library's internal state

  3. Fixed FakerAdapter (src/Generator/FakerAdapter.php:152-162)
  - Added resetUnique() method to reset Faker's internal unique generator state

  4. Added comprehensive tests (tests/TestCase/Generator/GeneratorAdapterTest.php:366-438)
  - testUniqueStateResetWithClearInstances() - verifies reset works when clearing instances
  - testResetUniqueState() - verifies manual reset without clearing cache

  5. Updated documentation (docs/factories.md:284-330)
  - Added section explaining unique value generation
  - Documented the issue and how to prevent it
  - Provided best practice example for base test case

  Usage

  Simply call CakeGeneratorFactory::clearInstances() in your test's tearDown() method:
```php
  protected function tearDown(): void
  {
      CakeGeneratorFactory::clearInstances();
      parent::tearDown();
  }
```
  This automatically resets the unique state, preventing accumulation across tests.
