### PR TITLE
FactoryTransactionStrategy to reset without $fixtures.

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -29,47 +29,98 @@ protected function bootstrapCli(): void
 Generated fixtures usually must be removed from the database in between tests in order to avoid collisions between entities, which can cause unexpected test results.
 There are several ways to manage this behavior when using fixtures and fixture factories.
 
-### CakePHP 3 or < 4.3
-For CakePHP anterior to 4.3 applications, you will need to use the [CakePHP test suite light plugin](https://github.com/vierge-noire/cakephp-test-suite-light#cakephp-test-suite-light)
-to clean up the test database prior to each test.
-
-Make sure you **replace** the native CakePHP listener with the following one inside your `phpunit.xml` (or `phpunit.xml.dist`) config file,
-per default located in the root folder of your application:
-
-```xml
-<!-- Setup a listener for fixtures -->
-     <listeners>
-         <listener class="CakephpTestSuiteLight\FixtureInjector">
-             <arguments>
-                 <object class="CakephpTestSuiteLight\FixtureManager"/>
-             </arguments>
-         </listener>
-     </listeners>
-``` 
-
-*Hint: The following command will make the required changes for you:*
-
-```css
-bin/cake fixture_factories_setup
-```
-
-You can specify a plugin (`-p`) and a specific file (`-f`), if different from `phpunit.xml.dist`.
-
-Between each test, the package will truncate all the test tables that have been used during the previous test.
-
-### CakePHP 4.3+
-CakePHP 4.3 ships with [Fixture State Managers](https://book.cakephp.org/4/en/development/testing.html#fixture-state-managers) and provides the `TruncateStrategy`
+CakePHP ships with [Fixture State Managers](https://book.cakephp.org/5/en/development/testing.html#fixture-state-managers) and provides the `TruncateStrategy`
 (truncate all tables after test run) as well as the `TransactionStrategy` (create a transaction and roll it back after each test run).
 
-The [CakePHP test suite light plugin](https://github.com/vierge-noire/cakephp-test-suite-light#cakephp-test-suite-light) provides the `TriggerStrategy` 
-which will set up a trigger in your database to clean up the tables after each test run. **We recommend using this fixture strategy alongside this plugin.**
-
-To use it, add this to the top of each test case that manages fixtures:
+The [CakePHP test suite light plugin](https://github.com/vierge-noire/cakephp-test-suite-light#cakephp-test-suite-light) provides the `TriggerStrategy`
+which will set up a trigger in your database to clean up the tables after each test run.
+This might require admin/root permission access, so this is not necessarily possible on all setups.
 ```php
-use TruncateDirtyTables
-``` 
+// In config/app.php
+    'TestSuite' => [
+        'fixtureStrategy' => \CakephpFixtureFactories\TestSuite\TriggerStrategy::class,
+    ],
+```
 
-No modification to your PHPUnit configuration is required when using the trait.
+#### Factory Transaction Strategy (Recommended)
+
+This plugin provides the `FactoryTransactionStrategy` which automatically:
+- Wraps **all** database operations in transactions
+- Rolls back after each test (both factory and application data)
+- **Resets unique generator state** (fixes OverflowException issues)
+- Tracks which tables are written to by fixture factories
+
+Unlike the standard `TransactionStrategy`, this doesn't require manually listing fixtures.
+
+##### CakePHP 5.2+ (Global Configuration)
+
+In CakePHP 5.2+, you can configure the fixture strategy globally in your `config/app_local.php` or `tests/bootstrap.php`:
+
+```php
+// In config/app.php
+    'TestSuite' => [
+        'fixtureStrategy' => \CakephpFixtureFactories\TestSuite\FactoryTransactionStrategy::class,
+    ],
+```
+
+This applies the strategy to **all test cases** automatically. No traits needed!
+
+##### CakePHP 5.0 - 5.1 (Trait-based)
+
+For older CakePHP versions, use the trait in your test cases:
+
+```php
+use CakephpFixtureFactories\TestSuite\FactoryTransactionTrait;
+
+class MyTest extends TestCase
+{
+    use FactoryTransactionTrait;
+
+    public function testSomething()
+    {
+        // Factory data - automatically tracked and rolled back
+        $article = ArticleFactory::make()->persist();
+
+        // Application code saves - also rolled back (but not tracked)
+        $this->Articles->save($article);
+
+        // ALL data is rolled back, generator state is reset
+    }
+}
+```
+
+Alternatively, create a base test class with the trait:
+
+```php
+namespace App\Test;
+
+use Cake\TestSuite\TestCase;
+use CakephpFixtureFactories\TestSuite\FactoryTransactionTrait;
+
+abstract class AppTestCase extends TestCase
+{
+    use FactoryTransactionTrait;
+}
+```
+
+Then extend it in all your tests:
+
+```php
+class MyTest extends AppTestCase
+{
+    // Strategy is automatically applied
+}
+```
+
+##### Benefits
+
+- No need to manually list `$fixtures`
+- **All data is rolled back** - factory data AND application code modifications
+- Faster than truncation strategies
+- **Solves unique generator state accumulation** - the strategy resets generator state after each test, preventing `OverflowException` when using `unique()` modifiers
+- Works seamlessly with nested associations
+
+**Note:** Table tracking only captures tables written via `factory->persist()`. However, the transaction rollback handles ALL data modifications regardless of source (factories, controllers, models, etc.).
 
 **We recommend using migrations for managing the schema of your test DB with the [CakePHP Migrator tool.](https://book.cakephp.org/migrations/3/en/index.html#using-migrations-for-tests)**
 

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -26,6 +26,7 @@ use CakephpFixtureFactories\Error\FixtureFactoryException;
 use CakephpFixtureFactories\Error\PersistenceException;
 use CakephpFixtureFactories\Generator\CakeGeneratorFactory;
 use CakephpFixtureFactories\Generator\GeneratorInterface;
+use CakephpFixtureFactories\TestSuite\FactoryTableTracker;
 use Closure;
 use InvalidArgumentException;
 use Psr\SimpleCache\CacheInterface;
@@ -381,12 +382,16 @@ abstract class BaseFactory
             $this->getDataCompiler()->endPersistMode();
         }
 
+        // Track this table for transaction/cleanup strategies
+        $table = $this->getTable();
+        FactoryTableTracker::getInstance()->trackTable($table);
+
         try {
             if (count($entities) === 1) {
-                return $this->getTable()->saveOrFail($entities[0], $this->getSaveOptions());
+                return $table->saveOrFail($entities[0], $this->getSaveOptions());
             }
 
-            return $this->getTable()->saveManyOrFail($entities, $this->getSaveOptions());
+            return $table->saveManyOrFail($entities, $this->getSaveOptions());
         } catch (Throwable $exception) {
             $factory = static::class;
             $message = $exception->getMessage();

--- a/src/TestSuite/FactoryTableTracker.php
+++ b/src/TestSuite/FactoryTableTracker.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CakephpFixtureFactories\TestSuite;
+
+use Cake\ORM\Table;
+
+/**
+ * Tracks which tables are being written to by fixture factories
+ *
+ * This singleton class maintains a registry of all tables that have been
+ * modified by fixture factories during test execution. This information can
+ * be used by transaction strategies to automatically manage database state.
+ */
+class FactoryTableTracker
+{
+    /**
+     * Singleton instance
+     *
+     * @var self|null
+     */
+    private static ?self $instance = null;
+
+    /**
+     * Map of table names to connections
+     *
+     * @var array<string, string> Table name => connection name
+     */
+    private array $tables = [];
+
+    /**
+     * Private constructor to enforce singleton pattern
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Get the singleton instance
+     *
+     * @return self
+     */
+    public static function getInstance(): self
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * Track a table that has been written to
+     *
+     * @param \Cake\ORM\Table $table The table being written to
+     *
+     * @return void
+     */
+    public function trackTable(Table $table): void
+    {
+        $tableName = $table->getTable();
+        $connectionName = $table->getConnection()->configName();
+
+        $this->tables[$tableName] = $connectionName;
+    }
+
+    /**
+     * Get all tracked tables
+     *
+     * @return array<string, string> Table name => connection name mapping
+     */
+    public function getTables(): array
+    {
+        return $this->tables;
+    }
+
+    /**
+     * Get tracked table names only
+     *
+     * @return array<string>
+     */
+    public function getTableNames(): array
+    {
+        return array_keys($this->tables);
+    }
+
+    /**
+     * Get tables grouped by connection
+     *
+     * @return array<string, array<string>> Connection name => table names
+     */
+    public function getTablesByConnection(): array
+    {
+        $grouped = [];
+        foreach ($this->tables as $table => $connection) {
+            if (!isset($grouped[$connection])) {
+                $grouped[$connection] = [];
+            }
+            $grouped[$connection][] = $table;
+        }
+
+        return $grouped;
+    }
+
+    /**
+     * Clear all tracked tables
+     *
+     * @return void
+     */
+    public function clear(): void
+    {
+        $this->tables = [];
+    }
+
+    /**
+     * Check if any tables have been tracked
+     *
+     * @return bool
+     */
+    public function hasTables(): bool
+    {
+        return !empty($this->tables);
+    }
+}

--- a/src/TestSuite/FactoryTransactionStrategy.php
+++ b/src/TestSuite/FactoryTransactionStrategy.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CakephpFixtureFactories\TestSuite;
+
+use Cake\Database\Connection;
+use Cake\Datasource\ConnectionManager;
+use Cake\TestSuite\Fixture\FixtureStrategyInterface;
+use CakephpFixtureFactories\Generator\CakeGeneratorFactory;
+
+/**
+ * Fixture strategy that uses transactions with automatic table tracking
+ *
+ * This strategy automatically tracks which tables are written to by fixture
+ * factories and wraps them in transactions that are rolled back after each test.
+ * It also resets the unique generator state to prevent accumulation.
+ *
+ * Unlike the standard TransactionStrategy, this doesn't require manually listing
+ * fixtures - it automatically detects which tables were used via FactoryTableTracker.
+ *
+ * Usage (CakePHP 5.2+):
+ * Configure globally in config/app.php:
+ * ```php
+ *     'TestSuite' => [
+ *         'fixtureStrategy' => \CakephpFixtureFactories\TestSuite\FactoryTransactionStrategy::class,
+ *     ],
+ * ```
+ *
+ * Usage (CakePHP 5.0 - 5.1):
+ * Use the FactoryTransactionTrait in your test cases.
+ */
+class FactoryTransactionStrategy implements FixtureStrategyInterface
+{
+    /**
+     * Active connections with transactions
+     *
+     * @var array<string, \Cake\Database\Connection>
+     */
+    protected array $connections = [];
+
+    /**
+     * @inheritDoc
+     */
+    public function setupTest(array $fixtureNames): void
+    {
+        // Start transactions on all configured connections
+        // We do this upfront since we don't know which connections
+        // the factories will use until they persist data
+        $this->startTransactions();
+
+        // Clear any previously tracked tables
+        FactoryTableTracker::getInstance()->clear();
+
+        // Reset generator unique state
+        CakeGeneratorFactory::clearInstances();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function teardownTest(): void
+    {
+        // Rollback all active transactions
+        foreach ($this->connections as $connection) {
+            if ($connection->inTransaction()) {
+                $connection->rollback(true);
+            }
+        }
+
+        // Clear connections
+        $this->connections = [];
+
+        // Clear tracked tables
+        FactoryTableTracker::getInstance()->clear();
+
+        // Reset generator unique state for next test
+        CakeGeneratorFactory::clearInstances();
+    }
+
+    /**
+     * Start transactions on all configured database connections
+     *
+     * @return void
+     */
+    protected function startTransactions(): void
+    {
+        $connectionNames = ConnectionManager::configured();
+
+        foreach ($connectionNames as $name) {
+            try {
+                $connection = ConnectionManager::get($name);
+
+                if (!($connection instanceof Connection)) {
+                    continue;
+                }
+
+                // Skip if already in transaction
+                if ($connection->inTransaction()) {
+                    continue;
+                }
+
+                // Enable savepoints for nested transaction support
+                $connection->enableSavePoints();
+
+                // Begin transaction
+                $connection->begin();
+
+                // Create a savepoint that we can rollback to
+                $connection->createSavePoint('__fixture_factories__');
+
+                $this->connections[$name] = $connection;
+            } catch (\Exception $e) {
+                // Skip connections that can't be accessed or don't support transactions
+                continue;
+            }
+        }
+    }
+}

--- a/src/TestSuite/FactoryTransactionTrait.php
+++ b/src/TestSuite/FactoryTransactionTrait.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CakephpFixtureFactories\TestSuite;
+
+use Cake\TestSuite\Fixture\FixtureStrategyInterface;
+
+/**
+ * Trait for test cases that use fixture factories with automatic transaction management
+ *
+ * Add this trait to your test case to automatically:
+ * - Track which tables are written to by fixture factories
+ * - Wrap database operations in transactions
+ * - Rollback after each test
+ * - Reset unique generator state
+ *
+ * CakePHP 5.2+ Note:
+ * This trait is only needed for CakePHP 4.3 - 5.1. In CakePHP 5.2+, you can configure
+ * the strategy globally instead:
+ *
+ * ```php
+ * // config/app_local.php or tests/bootstrap.php
+ * return [
+ *     'TestSuite' => [
+ *         'fixtureStrategy' => \CakephpFixtureFactories\TestSuite\FactoryTransactionStrategy::class,
+ *     ],
+ * ];
+ * ```
+ *
+ * Important notes:
+ * - Table tracking only captures tables written via factory->persist()
+ * - Transaction rollback handles ALL data (factory and application code)
+ * - Unique generator state is reset regardless of table usage
+ *
+ * Example (CakePHP 4.3 - 5.1):
+ * ```php
+ * use Cake\TestSuite\TestCase;
+ * use CakephpFixtureFactories\TestSuite\FactoryTransactionTrait;
+ *
+ * class MyTest extends TestCase
+ * {
+ *     use FactoryTransactionTrait;
+ *
+ *     public function testSomething()
+ *     {
+ *         // Factory data is tracked and rolled back
+ *         $article = ArticleFactory::make()->persist();
+ *
+ *         // Application code saves are also rolled back (but not tracked)
+ *         $this->Articles->save($article);
+ *
+ *         // All data is rolled back, generator state is reset
+ *     }
+ * }
+ * ```
+ */
+trait FactoryTransactionTrait
+{
+    /**
+     * Get the fixture strategy for this test case
+     *
+     * @return \Cake\TestSuite\Fixture\FixtureStrategyInterface
+     */
+    public function getFixtureStrategy(): FixtureStrategyInterface
+    {
+        return new FactoryTransactionStrategy();
+    }
+}

--- a/tests/TestCase/TestSuite/FactoryTransactionStrategyTest.php
+++ b/tests/TestCase/TestSuite/FactoryTransactionStrategyTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CakephpFixtureFactories\Test\TestCase\TestSuite;
+
+use Cake\Datasource\ConnectionManager;
+use Cake\TestSuite\TestCase;
+use CakephpFixtureFactories\Test\Factory\CityFactory;
+use CakephpFixtureFactories\Test\Factory\CountryFactory;
+use CakephpFixtureFactories\TestSuite\FactoryTableTracker;
+use CakephpFixtureFactories\TestSuite\FactoryTransactionStrategy;
+
+/**
+ * Test that the FactoryTransactionStrategy properly manages transactions
+ * and tracks tables used by factories
+ */
+class FactoryTransactionStrategyTest extends TestCase
+{
+    /**
+     * We don't use the FactoryTransactionTrait here because we're testing
+     * the strategy itself and need more control
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Ensure we're starting with a clean state
+        FactoryTableTracker::getInstance()->clear();
+    }
+
+    protected function tearDown(): void
+    {
+        FactoryTableTracker::getInstance()->clear();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test that FactoryTableTracker records tables when factories persist
+     *
+     * @return void
+     */
+    public function testTableTrackingRecordsTables(): void
+    {
+        $tracker = FactoryTableTracker::getInstance();
+        $tracker->clear();
+
+        $this->assertFalse($tracker->hasTables(), 'Tracker should start empty');
+
+        // Persist a city
+        CityFactory::make()->persist();
+
+        $this->assertTrue($tracker->hasTables(), 'Tracker should have tables after persist');
+        $tables = $tracker->getTableNames();
+        $this->assertContains('cities', $tables, 'Tracker should include cities table');
+    }
+
+    /**
+     * Test that multiple factories track multiple tables
+     *
+     * @return void
+     */
+    public function testTableTrackingRecordsMultipleTables(): void
+    {
+        $tracker = FactoryTableTracker::getInstance();
+        $tracker->clear();
+
+        // Persist cities and countries
+        CityFactory::make()->persist();
+        CountryFactory::make()->persist();
+
+        $tables = $tracker->getTableNames();
+        $this->assertContains('cities', $tables);
+        $this->assertContains('countries', $tables);
+        $this->assertCount(2, $tables, 'Should track 2 distinct tables');
+    }
+
+    /**
+     * Test that tracker can be cleared
+     *
+     * @return void
+     */
+    public function testTableTrackerClear(): void
+    {
+        $tracker = FactoryTableTracker::getInstance();
+
+        CityFactory::make()->persist();
+        $this->assertTrue($tracker->hasTables());
+
+        $tracker->clear();
+        $this->assertFalse($tracker->hasTables());
+        $this->assertEmpty($tracker->getTableNames());
+    }
+
+    /**
+     * Test that FactoryTransactionStrategy integrates properly
+     *
+     * @return void
+     */
+    public function testTransactionStrategySetupAndTeardown(): void
+    {
+        $strategy = new FactoryTransactionStrategy();
+        $connection = ConnectionManager::get('test');
+
+        //Get initial transaction state
+        $initialInTransaction = $connection->inTransaction();
+
+        // Setup should start transactions
+        $strategy->setupTest([]);
+
+        $this->assertTrue($connection->inTransaction(), 'Connection should be in transaction after setup');
+
+        // Persist some data to verify tracking
+        $city = CityFactory::make(['name' => 'Test City'])->persist();
+        $this->assertNotEmpty($city->id);
+
+        // Verify table is tracked
+        $tracker = FactoryTableTracker::getInstance();
+        $this->assertTrue($tracker->hasTables());
+        $this->assertContains('cities', $tracker->getTableNames());
+
+        // Teardown should clear tracked tables
+        $strategy->teardownTest();
+
+        // Tracker should be cleared
+        $this->assertFalse($tracker->hasTables());
+    }
+
+    /**
+     * Test that tracker continues to work across multiple persist calls
+     *
+     * @return void
+     */
+    public function testTrackerWorksAcrossMultiplePersists(): void
+    {
+        $tracker = FactoryTableTracker::getInstance();
+        $tracker->clear();
+
+        // Create some data
+        $city1 = CityFactory::make(['name' => 'City 1'])->persist();
+        $city2 = CityFactory::make(['name' => 'City 2'])->persist();
+
+        $this->assertNotEmpty($city1->id);
+        $this->assertNotEmpty($city2->id);
+
+        // Verify tracking is working
+        $this->assertTrue($tracker->hasTables());
+        $this->assertContains('cities', $tracker->getTableNames());
+    }
+
+    /**
+     * Test that the same table written multiple times is only tracked once
+     *
+     * @return void
+     */
+    public function testSameTableTrackedOnce(): void
+    {
+        $tracker = FactoryTableTracker::getInstance();
+        $tracker->clear();
+
+        // Persist multiple cities
+        CityFactory::make()->persist();
+        CityFactory::make()->persist();
+        CityFactory::make()->persist();
+
+        $tables = $tracker->getTableNames();
+        $this->assertCount(1, $tables, 'Same table should only be tracked once');
+        $this->assertContains('cities', $tables);
+    }
+}


### PR DESCRIPTION
So far there was a lot of db data noise into the next tests, messing up also count

> Failed asserting that 3 is identical to 1. (should only find 1 record)

Update now:

  - Table tracking: Only captures factory->persist() calls
  - Transaction rollback: Handles ALL modifications (factories, controllers, models, etc.)
  - Generator state reset: Works regardless of what modified the data

So overall, it should remove the data properly