### PR TITLE
add test for broken persist functionality

### DIFF
--- a/tests/TestCase/Factory/BaseFactoryTest.php
+++ b/tests/TestCase/Factory/BaseFactoryTest.php
@@ -876,4 +876,13 @@ class BaseFactoryTest extends TestCase
         $country = CountryFactory::make($n)->getEntities();
         $this->assertSame($n, count($country));
     }
+
+    public function testPersistWithNonCreatedSubEntities(): void
+    {
+        $authors = AuthorFactory::make(5)->getEntities();
+        $article = ArticleFactory::make()
+            ->withAuthors($authors)
+            ->persist();
+        $this->assertCount(5, $article->authors);
+    }
 }


### PR DESCRIPTION
Caused by https://github.com/dereuromark/cakephp-fixture-factories/pull/3

I don't know how to mitigate the issue without breaking the null issue as well, as I have not yet fully understood the factory logic here, but this is at least a test which can be used to see what could work.

The main principle is the fact, that factories don't care if sub entities are persisted or not, usually you just build the main entitiy with all attached sub entities, persist the main entity and it just makes sure that everything works as desired.