### PR TITLE
Fix persist of clean associated entities

### DIFF
--- a/src/Factory/DataCompiler.php
+++ b/src/Factory/DataCompiler.php
@@ -516,6 +516,7 @@ class DataCompiler
      * Ensure new associated entities are marked dirty so CakePHP will save them.
      *
      * @param \Cake\Datasource\EntityInterface $entity Entity to mark.
+     * @param array $visited
      *
      * @return void
      */
@@ -542,6 +543,7 @@ class DataCompiler
             $value = $entity->get($field);
             if ($value instanceof EntityInterface) {
                 $this->markEntityDirtyIfNew($value, $visited);
+
                 continue;
             }
             if (!is_array($value)) {

--- a/src/TestSuite/FactoryTransactionStrategy.php
+++ b/src/TestSuite/FactoryTransactionStrategy.php
@@ -8,6 +8,7 @@ use Cake\Database\Connection;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\Fixture\FixtureStrategyInterface;
 use CakephpFixtureFactories\Generator\CakeGeneratorFactory;
+use Exception;
 
 /**
  * Fixture strategy that uses transactions with automatic table tracking
@@ -110,7 +111,7 @@ class FactoryTransactionStrategy implements FixtureStrategyInterface
                 $connection->createSavePoint('__fixture_factories__');
 
                 $this->connections[$name] = $connection;
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 // Skip connections that can't be accessed or don't support transactions
                 continue;
             }

--- a/tests/TestCase/Command/BakeFixtureFactoryCommandTest.php
+++ b/tests/TestCase/Command/BakeFixtureFactoryCommandTest.php
@@ -22,6 +22,7 @@ use Cake\Core\Configure;
 use CakephpFixtureFactories\Factory\BaseFactory;
 use CakephpFixtureFactories\Test\Util\TestCaseWithFixtureBaking;
 use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionClass;
 use TestApp\Model\Entity\Address;
 use TestApp\Model\Entity\Article;
@@ -349,7 +350,7 @@ class BakeFixtureFactoryCommandTest extends TestCaseWithFixtureBaking
      * @param mixed $plugin
      * @param bool $expected
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('dataForTestThisTableShouldBeBaked')]
+    #[DataProvider('dataForTestThisTableShouldBeBaked')]
     public function testThisTableShouldBeBaked(string $model, $plugin, bool $expected): void
     {
         $this->FactoryCommand->plugin = $plugin;

--- a/tests/TestCase/Command/PersistCommandTest.php
+++ b/tests/TestCase/Command/PersistCommandTest.php
@@ -29,6 +29,7 @@ use CakephpFixtureFactories\Test\Factory\BillFactory;
 use CakephpFixtureFactories\Test\Factory\CityFactory;
 use CakephpFixtureFactories\Test\Factory\CountryFactory;
 use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class PersistCommandTest extends TestCase
 {
@@ -75,7 +76,7 @@ class PersistCommandTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('dataProviderForStringFactories')]
+    #[DataProvider('dataProviderForStringFactories')]
     public function testPersistOnOneFactory(string $factoryString): void
     {
         $args = new Arguments([$factoryString], [], [PersistCommand::ARG_NAME]);
@@ -95,7 +96,7 @@ class PersistCommandTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('dataProviderForStringPluginFactories')]
+    #[DataProvider('dataProviderForStringPluginFactories')]
     public function testPersistOnOnePluginFactory(string $factoryString): void
     {
         $args = new Arguments([$factoryString], [], [PersistCommand::ARG_NAME]);
@@ -106,7 +107,7 @@ class PersistCommandTest extends TestCase
         $this->assertSame(1, BillFactory::count());
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('dataProviderForStringFactories')]
+    #[DataProvider('dataProviderForStringFactories')]
     public function testPersistOnNFactories(string $factoryString): void
     {
         $number = '3';

--- a/tests/TestCase/Factory/BaseFactoryDisablePrimaryKeyOffsetTest.php
+++ b/tests/TestCase/Factory/BaseFactoryDisablePrimaryKeyOffsetTest.php
@@ -20,6 +20,7 @@ use CakephpFixtureFactories\Test\Factory\BillFactory;
 use CakephpFixtureFactories\Test\Factory\CityFactory;
 use CakephpFixtureFactories\Test\Factory\CountryFactory;
 use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class BaseFactoryDisablePrimaryKeyOffsetTest extends TestCase
 {
@@ -37,7 +38,7 @@ class BaseFactoryDisablePrimaryKeyOffsetTest extends TestCase
     /**
      * @param int $cityOffset
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('dataForTestDisablePrimaryKeyOffset')]
+    #[DataProvider('dataForTestDisablePrimaryKeyOffset')]
     public function testDisablePrimaryKeyOffset(int $cityOffset): void
     {
         $n = 10;
@@ -59,7 +60,7 @@ class BaseFactoryDisablePrimaryKeyOffsetTest extends TestCase
     /**
      * @param int $countryOffset
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('dataForTestDisablePrimaryKeyOffset')]
+    #[DataProvider('dataForTestDisablePrimaryKeyOffset')]
     public function testDisablePrimaryKeyOffsetInAssociation(int $countryOffset): void
     {
         $n = 5;

--- a/tests/TestCase/Factory/BaseFactoryGetResultSetTest.php
+++ b/tests/TestCase/Factory/BaseFactoryGetResultSetTest.php
@@ -20,6 +20,7 @@ use Cake\TestSuite\TestCase;
 use CakephpFixtureFactories\Test\Factory\ArticleFactory;
 use CakephpFixtureFactories\Test\Factory\CountryFactory;
 use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Model\Entity\Address;
 
 class BaseFactoryGetResultSetTest extends TestCase
@@ -41,7 +42,7 @@ class BaseFactoryGetResultSetTest extends TestCase
         return [[false], [true]];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('isPersisted')]
+    #[DataProvider('isPersisted')]
     public function testBaseFactoryGetResultSet(bool $isPersisted): void
     {
         $name1 = 'Name 1';

--- a/tests/TestCase/Factory/BaseFactoryHiddenPropertiesTest.php
+++ b/tests/TestCase/Factory/BaseFactoryHiddenPropertiesTest.php
@@ -20,6 +20,7 @@ use Cake\TestSuite\TestCase;
 use CakephpFixtureFactories\Test\Factory\ArticleFactory;
 use CakephpFixtureFactories\Test\Factory\AuthorFactory;
 use CakephpFixtureFactories\Test\Factory\BillFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Model\Entity\Article;
 
 class BaseFactoryHiddenPropertiesTest extends TestCase
@@ -72,7 +73,7 @@ class BaseFactoryHiddenPropertiesTest extends TestCase
      * @param int $n
      * @param bool $persist
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('iterate')]
+    #[DataProvider('iterate')]
     public function testHiddenPropertyInMainBuild(int $n, bool $persist): void
     {
         $factory = ArticleFactory::make($n)->withHiddenBiography(self::DUMMY_HIDDEN_PARAGRAPH);
@@ -95,7 +96,7 @@ class BaseFactoryHiddenPropertiesTest extends TestCase
      * @param int $n
      * @param bool $persist
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('iterate')]
+    #[DataProvider('iterate')]
     public function testHiddenPropertyInBelongsToManyAssociation(int $n, bool $persist): void
     {
         $factory = AuthorFactory::make()->with(
@@ -117,7 +118,7 @@ class BaseFactoryHiddenPropertiesTest extends TestCase
      * @param int $n
      * @param bool $persist
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('iterate')]
+    #[DataProvider('iterate')]
     public function testHiddenPropertyInBelongsToAssociation(int $n, bool $persist): void
     {
         $factory = BillFactory::make($n)->with(

--- a/tests/TestCase/Factory/BaseFactoryLoadAssociationsInInitializeTest.php
+++ b/tests/TestCase/Factory/BaseFactoryLoadAssociationsInInitializeTest.php
@@ -26,6 +26,7 @@ use CakephpFixtureFactories\Test\Factory\CityFactory;
 use CakephpFixtureFactories\Test\Factory\CountryFactory;
 use CakephpFixtureFactories\Test\Factory\TableWithoutModelFactory;
 use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Model\Entity\Address;
 use TestApp\Model\Entity\Country;
 use function count;
@@ -128,7 +129,7 @@ class BaseFactoryLoadAssociationsInInitializeTest extends TestCase
         return [['TableWithoutModel'], ['table_without_model']];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('dataForClassName')]
+    #[DataProvider('dataForClassName')]
     public function testLoadAssociationOnTheFlyHasManyWithMagicPersist(string $className): void
     {
         CityFactory::make()->getTable()->associations()->remove('Addresses');
@@ -150,7 +151,7 @@ class BaseFactoryLoadAssociationsInInitializeTest extends TestCase
         $this->assertSame($n, TableWithoutModelFactory::count());
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('dataForClassName')]
+    #[DataProvider('dataForClassName')]
     public function testLoadAssociationOnTheFlyBelongsToWithMagicPersist(string $className): void
     {
         // Because of a foreign key constrain at the DB level, a country with id $city->country_id
@@ -174,7 +175,7 @@ class BaseFactoryLoadAssociationsInInitializeTest extends TestCase
         $this->assertSame(1, TableWithoutModelFactory::count());
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('dataForClassName')]
+    #[DataProvider('dataForClassName')]
     public function testLoadAssociationOnTheFlyBelongsToManyWithMagicPersist(string $className): void
     {
         $factory = AuthorFactory::make();

--- a/tests/TestCase/Factory/BaseFactoryPrimaryKeyOffsetTest.php
+++ b/tests/TestCase/Factory/BaseFactoryPrimaryKeyOffsetTest.php
@@ -21,6 +21,7 @@ use CakephpFixtureFactories\Test\Factory\BillFactory;
 use CakephpFixtureFactories\Test\Factory\CityFactory;
 use CakephpFixtureFactories\Test\Factory\CountryFactory;
 use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class BaseFactoryPrimaryKeyOffsetTest extends TestCase
 {
@@ -38,7 +39,7 @@ class BaseFactoryPrimaryKeyOffsetTest extends TestCase
     /**
      * @param int $cityOffset
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('dataForTestSetPrimaryKeyOffset')]
+    #[DataProvider('dataForTestSetPrimaryKeyOffset')]
     public function testSetPrimaryKeyOffset(int $cityOffset): void
     {
         $n = 10;
@@ -57,7 +58,7 @@ class BaseFactoryPrimaryKeyOffsetTest extends TestCase
     /**
      * @param int $countryOffset
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('dataForTestSetPrimaryKeyOffset')]
+    #[DataProvider('dataForTestSetPrimaryKeyOffset')]
     public function testSetPrimaryKeyOffsetInAssociation(int $countryOffset): void
     {
         $n = 5;

--- a/tests/TestCase/Factory/BaseFactoryTest.php
+++ b/tests/TestCase/Factory/BaseFactoryTest.php
@@ -29,6 +29,7 @@ use CakephpFixtureFactories\Test\Factory\CityFactory;
 use CakephpFixtureFactories\Test\Factory\CountryFactory;
 use CakephpFixtureFactories\Test\Factory\CustomerFactory;
 use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Model\Entity\Address;
 use TestApp\Model\Entity\Article;
 use TestApp\Model\Entity\Author;
@@ -59,7 +60,7 @@ class BaseFactoryTest extends TestCase
     /**
      * @param \CakephpFixtureFactories\Factory\BaseFactory $factory
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('dataForTestConnectionInDataProvider')]
+    #[DataProvider('dataForTestConnectionInDataProvider')]
     public function testConnectionInDataProvider(BaseFactory $factory): void
     {
         $connectionName = $factory->getTable()->getConnection()->configName();
@@ -834,7 +835,7 @@ class BaseFactoryTest extends TestCase
     /**
      * @param int $times
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('feedTestSetTimes')]
+    #[DataProvider('feedTestSetTimes')]
     public function testSetTimes(int $times): void
     {
         ArticleFactory::make()->setTimes($times)->persist();

--- a/tests/TestCase/Factory/DataCompilerTest.php
+++ b/tests/TestCase/Factory/DataCompilerTest.php
@@ -23,6 +23,7 @@ use CakephpFixtureFactories\Test\Factory\ArticleFactory;
 use CakephpFixtureFactories\Test\Factory\AuthorFactory;
 use CakephpFixtureFactories\Test\Factory\CountryFactory;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Model\Table\PremiumAuthorsTable;
 
 class DataCompilerTest extends TestCase
@@ -160,7 +161,7 @@ class DataCompilerTest extends TestCase
      * @param array $injectedData
      * @param array $expected
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('dataForGetModifiedUniqueFields')]
+    #[DataProvider('dataForGetModifiedUniqueFields')]
     public function testGetModifiedUniqueFields(array $injectedData, array $expected): void
     {
         $dataCompiler = new DataCompiler(CountryFactory::make($injectedData));

--- a/tests/TestCase/Factory/EventCollectorTest.php
+++ b/tests/TestCase/Factory/EventCollectorTest.php
@@ -31,6 +31,7 @@ use CakephpFixtureFactories\Test\Factory\CityFactory;
 use CakephpFixtureFactories\Test\Factory\CountryFactory;
 use CakephpFixtureFactories\Test\Factory\CustomerFactory;
 use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Model\Entity\Address;
 use TestApp\Model\Entity\Article;
 use TestApp\Model\Entity\City;
@@ -119,7 +120,7 @@ class EventCollectorTest extends TestCase
     /**
      * @param \CakephpFixtureFactories\Factory\BaseFactory $factory
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideFactories')]
+    #[DataProvider('provideFactories')]
     public function testTimestamp(BaseFactory $factory): void
     {
         $entity = $factory->persist();
@@ -136,7 +137,7 @@ class EventCollectorTest extends TestCase
     /**
      * @param bool $applyEvent Bind the event once to the model
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('runSeveralTimesWithOrWithoutEvents')]
+    #[DataProvider('runSeveralTimesWithOrWithoutEvents')]
     public function testApplyOrIgnoreBeforeMarshalSetOnTheFly(bool $applyEvent): void
     {
         $name = 'Foo';
@@ -165,7 +166,7 @@ class EventCollectorTest extends TestCase
         $this->assertNull($country->get('eventApplied'));
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('runSeveralTimesWithOrWithoutEvents')]
+    #[DataProvider('runSeveralTimesWithOrWithoutEvents')]
     public function testApplyOrIgnoreBeforeMarshalSetInTable(bool $applyEvent): void
     {
         $name = 'Foo';
@@ -182,7 +183,7 @@ class EventCollectorTest extends TestCase
         $this->assertTrue($country->get('beforeMarshalTriggered'));
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('runSeveralTimesWithOrWithoutEvents')]
+    #[DataProvider('runSeveralTimesWithOrWithoutEvents')]
     public function testApplyOrIgnoreEventInBehaviors(bool $applyEvent): void
     {
         $title = 'This Article';
@@ -219,7 +220,7 @@ class EventCollectorTest extends TestCase
         $this->assertInstanceOf(Article::class, $article);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('runSeveralTimesWithOrWithoutEvents')]
+    #[DataProvider('runSeveralTimesWithOrWithoutEvents')]
     public function testApplyOrIgnoreEventInBehaviorsOnTheFlyWithCountries(bool $applyEvent): void
     {
         $name = 'Some Country';
@@ -234,7 +235,7 @@ class EventCollectorTest extends TestCase
         $this->assertEquals($slug, $country->get('slug'));
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('runSeveralTimesWithOrWithoutEvents')]
+    #[DataProvider('runSeveralTimesWithOrWithoutEvents')]
     public function testApplyOrIgnoreEventInPluginBehaviorsOnTheFlyWithCountries(bool $applyEvent): void
     {
         $field = SomePluginBehavior::BEFORE_SAVE_FIELD;

--- a/tests/TestCase/Factory/FactoryAwareTraitIntegrationTest.php
+++ b/tests/TestCase/Factory/FactoryAwareTraitIntegrationTest.php
@@ -10,6 +10,7 @@ use CakephpFixtureFactories\Error\FactoryNotFoundException;
 use CakephpFixtureFactories\Factory\FactoryAwareTrait;
 use CakephpFixtureFactories\Test\Factory\CountryFactory;
 use CakephpFixtureFactories\Test\Factory\PremiumAuthorFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class FactoryAwareTraitIntegrationTest extends TestCase
 {
@@ -39,7 +40,7 @@ class FactoryAwareTraitIntegrationTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('factoryFoundData')]
+    #[DataProvider('factoryFoundData')]
     public function testGetFactoryFound(string $name, string $expected): void
     {
         $this->assertInstanceOf($expected, $this->getFactory($name));

--- a/tests/TestCase/Factory/FactoryAwareTraitUnitTest.php
+++ b/tests/TestCase/Factory/FactoryAwareTraitUnitTest.php
@@ -6,6 +6,7 @@ namespace CakephpFixtureFactories\Test\TestCase\Factory;
 
 use Cake\TestSuite\TestCase;
 use CakephpFixtureFactories\Factory\FactoryAwareTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class FactoryAwareTraitUnitTest extends TestCase
 {
@@ -20,7 +21,7 @@ class FactoryAwareTraitUnitTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('getFactoryNamespaceData')]
+    #[DataProvider('getFactoryNamespaceData')]
     public function testGetFactoryNamespace(?string $plugin, string $expected): void
     {
         $this->assertEquals($expected, $this->getFactoryNamespace($plugin));
@@ -34,7 +35,7 @@ class FactoryAwareTraitUnitTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('getFactoryClassNameData')]
+    #[DataProvider('getFactoryClassNameData')]
     public function testGetFactoryClassName(string $name, string $expected): void
     {
         $this->assertEquals($expected, $this->getFactoryClassName($name));
@@ -57,7 +58,7 @@ class FactoryAwareTraitUnitTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('getFactoryNameData')]
+    #[DataProvider('getFactoryNameData')]
     public function testGetFactoryNameFromModelName(string $name, string $factoryName, string $factoryFileName): void
     {
         $this->assertEquals($factoryName, $this->getFactoryNameFromModelName($name));

--- a/tests/TestCase/Factory/FixtureInjectorTest.php
+++ b/tests/TestCase/Factory/FixtureInjectorTest.php
@@ -18,6 +18,7 @@ namespace CakephpFixtureFactories\Test\TestCase\Factory;
 use Cake\TestSuite\TestCase;
 use CakephpFixtureFactories\Test\Factory\ArticleFactory;
 use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class FixtureInjectorTest extends TestCase
 {
@@ -62,7 +63,7 @@ class FixtureInjectorTest extends TestCase
                  *
      * @param \CakephpFixtureFactories\Test\Factory\ArticleFactory $factory
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('createWithOneFactoryInTheDataProvider')]
+    #[DataProvider('createWithOneFactoryInTheDataProvider')]
     public function testCreateFactoryInTheDataProvider(ArticleFactory $factory): void
     {
         $factory->persist();
@@ -76,7 +77,7 @@ class FixtureInjectorTest extends TestCase
      * @param int $n
      * @param \CakephpFixtureFactories\Test\Factory\ArticleFactory $factory
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('createWithDifferentFactoriesInTheDataProvider')]
+    #[DataProvider('createWithDifferentFactoriesInTheDataProvider')]
     public function testCreateFactoryInTheDataProvider2(int $n, ArticleFactory $factory): void
     {
         $factory->persist();

--- a/tests/TestCase/Factory/UniquenessJanitorTest.php
+++ b/tests/TestCase/Factory/UniquenessJanitorTest.php
@@ -20,6 +20,7 @@ use Cake\TestSuite\TestCase;
 use CakephpFixtureFactories\Error\UniquenessException;
 use CakephpFixtureFactories\Factory\BaseFactory;
 use CakephpFixtureFactories\Factory\UniquenessJanitor;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class UniquenessJanitorTest extends TestCase
 {
@@ -47,7 +48,7 @@ class UniquenessJanitorTest extends TestCase
      * @param array $uniqueProperties
      * @param bool $expectException
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('dataForSanitizeEntityArrayOnPrimary')]
+    #[DataProvider('dataForSanitizeEntityArrayOnPrimary')]
     public function testSanitizeEntityArrayOnPrimary(array $uniqueProperties, bool $expectException): void
     {
         $factoryStub = $this->getMockBuilder(BaseFactory::class)->disableOriginalConstructor()->getMock();
@@ -97,7 +98,7 @@ class UniquenessJanitorTest extends TestCase
      * @param array<\Cake\Datasource\EntityInterface> $uniqueProperties
      * @param array $expectOutput
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('dataForSanitizeEntityArrayOnAssociation')]
+    #[DataProvider('dataForSanitizeEntityArrayOnAssociation')]
     public function testSanitizeEntityArrayOnAssociation(array $uniqueProperties, array $expectOutput): void
     {
         $factoryStub = $this->getMockBuilder(BaseFactory::class)->disableOriginalConstructor()->getMock();

--- a/tests/TestCase/ORM/FactoryTableRegistryTest.php
+++ b/tests/TestCase/ORM/FactoryTableRegistryTest.php
@@ -20,6 +20,7 @@ use Cake\TestSuite\TestCase;
 use CakephpFixtureFactories\ORM\FactoryTableRegistry;
 use CakephpFixtureFactories\Test\Factory\CityFactory;
 use CakephpFixtureFactories\Test\Factory\CountryFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Model\Table\AddressesTable;
 use TestApp\Model\Table\ArticlesTable;
 use TestApp\Model\Table\AuthorsTable;
@@ -48,7 +49,7 @@ class FactoryTableRegistryTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('tables')]
+    #[DataProvider('tables')]
     public function testReturnedTableShouldHaveSameAssociations(string $tableName, string $table): void
     {
         $FactoryTable = FactoryTableRegistry::getTableLocator()->get($tableName);

--- a/tests/TestCase/Scenario/FixtureScenarioTest.php
+++ b/tests/TestCase/Scenario/FixtureScenarioTest.php
@@ -25,6 +25,7 @@ use CakephpFixtureFactories\Test\Scenario\NAustralianAuthorsScenario;
 use CakephpFixtureFactories\Test\Scenario\SubFolder\SubFolderScenario;
 use CakephpFixtureFactories\Test\Scenario\TenAustralianAuthorsScenario;
 use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Model\Entity\Author;
 
 class FixtureScenarioTest extends TestCase
@@ -54,7 +55,7 @@ class FixtureScenarioTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('scenarioNames')]
+    #[DataProvider('scenarioNames')]
     public function testLoadScenario(mixed $scenario, int $expectedAuthors): void
     {
         /** @var array<\TestApp\Model\Entity\Author> $authors */


### PR DESCRIPTION
This replaces #12.

The issue: when you prebuild associated entities via `getEntities()` they are cleaned, and `persist()` on the parent does not re-mark them dirty. CakePHP then inserts only timestamps/ids, failing NOT NULL constraints.

Fix: during persist mode, mark injected/associated entities (and their nested associated entities) dirty if they are new, so CakePHP will save them with their factory defaults.

Includes the regression test from #12.

Tests: `vendor/bin/phpunit`.
