### PR TITLE
Fix CI PHP version 8.5 to 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.3', '8.5']
+        php-version: ['8.3', '8.4']
         db-type: [sqlite, mysql, pgsql]
         composer-type: [lowest, stable, dev]
 


### PR DESCRIPTION
## Summary
- Fix PHP version in CI matrix from non-existent 8.5 to 8.4

PHP versions go 8.2, 8.3, 8.4, then 9.0 - there is no 8.5.