### PR TITLE
Add PHPStan generic type annotations, remove blanket ignores

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,8 +4,5 @@ parameters:
 		- tests/bootstrap.php
 	paths:
 		- src/
-	reportUnmatchedIgnoredErrors: false
 	ignoreErrors:
-		- identifier: missingType.generics
-		- identifier: missingType.iterableValue
 		- identifier: trait.unused

--- a/src/Command/BakeFixtureFactoryCommand.php
+++ b/src/Command/BakeFixtureFactoryCommand.php
@@ -50,7 +50,7 @@ class BakeFixtureFactoryCommand extends BakeCommand
     private Table $table;
 
     /**
-     * @var array
+     * @var array<string, array<string, string>>
      */
     protected array $map = [
         'string' => [
@@ -222,7 +222,7 @@ class BakeFixtureFactoryCommand extends BakeCommand
      *
      * @param \Cake\Console\ConsoleIo $io Console
      *
-     * @return array
+     * @return array<string>
      */
     public function getTableList(ConsoleIo $io): array
     {
@@ -372,7 +372,9 @@ class BakeFixtureFactoryCommand extends BakeCommand
     }
 
     /**
-     * @inheritDoc
+     * @param \Cake\Console\Arguments $arg Arguments
+     *
+     * @return array<string, mixed>
      */
     public function templateData(Arguments $arg): array
     {
@@ -431,7 +433,7 @@ class BakeFixtureFactoryCommand extends BakeCommand
     /**
      * Returns the one and many association for a given model
      *
-     * @return array
+     * @return array<string, array<string, array<string, string>>>
      */
     public function getAssociations(): array
     {
@@ -589,7 +591,7 @@ class BakeFixtureFactoryCommand extends BakeCommand
     /**
      * @param string $column
      * @param string $modelName
-     * @param array $columnSchema
+     * @param array<string, mixed> $columnSchema
      *
      * @return mixed
      */

--- a/src/Event/ModelEventsHandler.php
+++ b/src/Event/ModelEventsHandler.php
@@ -29,12 +29,12 @@ use ReflectionFunction;
 class ModelEventsHandler
 {
     /**
-     * @var array
+     * @var array<string>
      */
     private array $listeningBehaviors = [];
 
     /**
-     * @var array
+     * @var array<string>
      */
     private array $listeningModelEvents = [];
 
@@ -43,6 +43,9 @@ class ModelEventsHandler
      */
     protected EventCollector $eventCompiler;
 
+    /**
+     * @var array<string>
+     */
     public static array $ormEvents = [
         'Model.initialize',
         'Model.beforeMarshal',
@@ -62,8 +65,8 @@ class ModelEventsHandler
     ];
 
     /**
-     * @param array $listeningModelEvents Model events listened to from instanciation
-     * @param array $listeningBehaviors Behaviors listened to from instanciation
+     * @param array<string> $listeningModelEvents Model events listened to from instanciation
+     * @param array<string> $listeningBehaviors Behaviors listened to from instanciation
      */
     final public function __construct(array $listeningModelEvents, array $listeningBehaviors)
     {
@@ -73,8 +76,8 @@ class ModelEventsHandler
 
     /**
      * @param \Cake\ORM\Table $table Table
-     * @param array $listeningModelEvents Events listened to
-     * @param array $listeningBehaviors Behaviors listened to
+     * @param array<string> $listeningModelEvents Events listened to
+     * @param array<string> $listeningBehaviors Behaviors listened to
      *
      * @return void
      */
@@ -159,7 +162,6 @@ class ModelEventsHandler
                 continue;
             }
 
-            /** @phpstan-ignore-next-line */
             $behaviorInstance = $table->getBehavior($behavior);
 
             $behaviorClassName = get_class($behaviorInstance);
@@ -185,7 +187,7 @@ class ModelEventsHandler
     }
 
     /**
-     * @return array
+     * @return array<string>
      */
     public function getListeningModelEvents(): array
     {
@@ -193,7 +195,7 @@ class ModelEventsHandler
     }
 
     /**
-     * @return array
+     * @return array<string>
      */
     public function getListeningBehaviors(): array
     {

--- a/src/Factory/AssociationBuilder.php
+++ b/src/Factory/AssociationBuilder.php
@@ -43,7 +43,7 @@ class AssociationBuilder
     private array $associations = [];
 
     /**
-     * @var array
+     * @var array<string, mixed>
      */
     private array $manualAssociations = [];
 
@@ -315,7 +315,7 @@ class AssociationBuilder
     }
 
     /**
-     * @return array
+     * @return array<string, mixed>
      */
     public function getAssociated(): array
     {
@@ -357,7 +357,7 @@ class AssociationBuilder
     }
 
     /**
-     * @param array $associations
+     * @param array<string, mixed> $associations
      *
      * @return void
      */

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -47,7 +47,7 @@ abstract class BaseFactory
     private static ?GeneratorInterface $generator = null;
 
     /**
-     * @var array
+     * @var array<string, mixed>
      */
     protected array $marshallerOptions = [
         'validate' => false,
@@ -56,7 +56,7 @@ abstract class BaseFactory
     ];
 
     /**
-     * @var array
+     * @var array<string, mixed>
      */
     protected array $saveOptions = [
         'checkRules' => false,
@@ -65,12 +65,12 @@ abstract class BaseFactory
     ];
 
     /**
-     * @var array Unique fields. Uniqueness applies only to persisted entities.
+     * @var array<string> Unique fields. Uniqueness applies only to persisted entities.
      */
     protected array $uniqueProperties = [];
 
     /**
-     * @var array Fields on which the setters should be skipped.
+     * @var array<string> Fields on which the setters should be skipped.
      */
     protected array $skippedSetters = [];
 
@@ -326,7 +326,7 @@ abstract class BaseFactory
     /**
      * Creates a result set of non-persisted entities
      *
-     * @return \Cake\ORM\ResultSet
+     * @return \Cake\ORM\ResultSet<int, \Cake\Datasource\EntityInterface>
      */
     public function getResultSet(): ResultSet
     {
@@ -336,7 +336,7 @@ abstract class BaseFactory
     /**
      * Creates a result set of persisted entities
      *
-     * @return \Cake\ORM\ResultSet
+     * @return \Cake\ORM\ResultSet<int, \Cake\Datasource\EntityInterface>
      */
     public function getPersistedResultSet(): ResultSet
     {
@@ -344,7 +344,7 @@ abstract class BaseFactory
     }
 
     /**
-     * @return array
+     * @return array<string, mixed>
      */
     public function getMarshallerOptions(): array
     {
@@ -359,7 +359,7 @@ abstract class BaseFactory
     /**
      * @deprecated will be removed in v4
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function getAssociated(): array
     {
@@ -414,7 +414,7 @@ abstract class BaseFactory
      *
      * @throws \CakephpFixtureFactories\Error\PersistenceException if the entity/entities could not be saved.
      *
-     * @return \Cake\Datasource\EntityInterface|\Cake\Datasource\ResultSetInterface|iterable<\Cake\Datasource\EntityInterface>
+     * @return \Cake\Datasource\EntityInterface|\Cake\Datasource\ResultSetInterface<int, \Cake\Datasource\EntityInterface>|iterable<\Cake\Datasource\EntityInterface>
      */
     public function persist(): EntityInterface|iterable|ResultSetInterface
     {
@@ -444,7 +444,7 @@ abstract class BaseFactory
     }
 
     /**
-     * @return array
+     * @return array<string, mixed>
      */
     private function getSaveOptions(): array
     {
@@ -456,7 +456,7 @@ abstract class BaseFactory
     /**
      * Assigns the values of $data to the $keys of the entities generated
      *
-     * @param \Cake\Datasource\EntityInterface|array $data Data to inject
+     * @param \Cake\Datasource\EntityInterface|array<string, mixed> $data Data to inject
      *
      * @return $this
      */
@@ -618,7 +618,7 @@ abstract class BaseFactory
      * ]
      * If not set, the offset is set randomly
      *
-     * @param array|string|int $primaryKeyOffset Offset
+     * @param array<string, int|string>|string|int $primaryKeyOffset Offset
      *
      * @return $this
      */
@@ -645,7 +645,7 @@ abstract class BaseFactory
      * Get the fields that are declared are unique.
      * This should include the uniqueness of the fields in your schema.
      *
-     * @return array
+     * @return array<string>
      */
     public function getUniqueProperties(): array
     {
@@ -660,7 +660,7 @@ abstract class BaseFactory
      * entity will be created, but instead the
      * existing one will be considered.
      *
-     * @param array|string|null $fields Unique fields set on the fly.
+     * @param array<string>|string|null $fields Unique fields set on the fly.
      *
      * @return $this
      */
@@ -691,7 +691,7 @@ abstract class BaseFactory
      * The data can be an array, an integer, an entity interface, a callable or a factory
      *
      * @param string $associationName Association name
-     * @param \CakephpFixtureFactories\Factory\BaseFactory|\Cake\Datasource\EntityInterface|callable|array|string|int $data Injected data
+     * @param \CakephpFixtureFactories\Factory\BaseFactory|\Cake\Datasource\EntityInterface|callable|array<string, mixed>|string|int $data Injected data
      *
      * @return $this
      */
@@ -747,7 +747,7 @@ abstract class BaseFactory
     /**
      * @internal Not for normal use, only used for testing.
      *
-     * @param array $data Data to merge
+     * @param array<string, mixed> $data Data to merge
      *
      * @return $this
      */
@@ -786,7 +786,7 @@ abstract class BaseFactory
      * @param string $type the type of query to perform
      * @param mixed ...$options Options passed to the finder
      *
-     * @return \Cake\ORM\Query\SelectQuery The query builder
+     * @return \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface> The query builder
      */
     public static function find(string $type = 'all', mixed ...$options): SelectQuery
     {
@@ -799,7 +799,7 @@ abstract class BaseFactory
      * @see Table::get()
      *
      * @param mixed $primaryKey primary key value to find
-     * @param array|string $finder The finder to use. Passing an options array is deprecated.
+     * @param array<string, mixed>|string $finder The finder to use. Passing an options array is deprecated.
      * @param \Psr\SimpleCache\CacheInterface|string|null $cache The cache config to use.
      *   Defaults to `null`, i.e. no caching.
      * @param \Closure|string|null $cacheKey The cache key to use. If not provided
@@ -861,9 +861,9 @@ abstract class BaseFactory
     /**
      * Count the factory's related table entries without before find.
      *
-     * @param \Cake\Database\ExpressionInterface|\Closure|array|string|null $conditions The conditions to filter on.
+     * @param \Cake\Database\ExpressionInterface|\Closure|array<string, mixed>|string|null $conditions The conditions to filter on.
      *
-     * @return \Cake\Datasource\EntityInterface|array The first result from the ResultSet.
+     * @return \Cake\Datasource\EntityInterface|array<string, mixed> The first result from the ResultSet.
      */
     public static function firstOrFail(
         ExpressionInterface|Closure|array|string|null $conditions = null,

--- a/src/Factory/DataCompiler.php
+++ b/src/Factory/DataCompiler.php
@@ -44,23 +44,44 @@ class DataCompiler
      */
     public const IS_ASSOCIATED = '___data_compiler__is_associated';
 
+    /**
+     * @var \Closure|array<string, mixed>
+     */
     private array|Closure $dataFromDefaultTemplate = [];
 
     /**
-     * @var \Cake\Datasource\EntityInterface|callable|array|array<\Cake\Datasource\EntityInterface>|string
+     * @var \Cake\Datasource\EntityInterface|callable|array<mixed>|string
      */
     private $dataFromInstantiation = [];
 
+    /**
+     * @var array<string, mixed>
+     */
     private array $dataFromPatch = [];
 
+    /**
+     * @var array<string, array<int, \CakephpFixtureFactories\Factory\BaseFactory>>
+     */
     private array $dataFromAssociations = [];
 
+    /**
+     * @var array<string, array<int, \CakephpFixtureFactories\Factory\BaseFactory>>
+     */
     private array $dataFromDefaultAssociations = [];
 
+    /**
+     * @var array<string, int|string>|null
+     */
     private ?array $primaryKeyOffset = [];
 
+    /**
+     * @var array<string>
+     */
     private array $enforcedFields = [];
 
+    /**
+     * @var array<string>
+     */
     private array $skippedSetters = [];
 
     private static bool $inPersistMode = false;
@@ -112,7 +133,7 @@ class DataCompiler
     }
 
     /**
-     * @param array $data Collected data
+     * @param array<string, mixed> $data Collected data
      *
      * @return void
      */
@@ -205,7 +226,7 @@ class DataCompiler
     }
 
     /**
-     * @param \Cake\Datasource\EntityInterface|callable|array|string $injectedData Data from the injection.
+     * @param \Cake\Datasource\EntityInterface|callable|array<string, mixed>|string $injectedData Data from the injection.
      * @param bool $setPrimaryKey Set the primary key if this entity is alone or the first of an array.
      *
      * @return \Cake\Datasource\EntityInterface
@@ -246,7 +267,7 @@ class DataCompiler
      * Helper method to patch entities with the data compiler data.
      *
      * @param \Cake\Datasource\EntityInterface $entity Entity to patch.
-     * @param array $data Data to patch.
+     * @param array<string, mixed> $data Data to patch.
      *
      * @return \Cake\Datasource\EntityInterface
      */
@@ -271,11 +292,11 @@ class DataCompiler
      * If so, merge recursively with the existing data
      *
      * @param \Cake\Datasource\EntityInterface $entity entity to patch
-     * @param array $data data to patch
+     * @param array<string, mixed> $data data to patch
      *
      * @throws \CakephpFixtureFactories\Error\FixtureFactoryException if an array notation is merged with a string, or a non array
      *
-     * @return array
+     * @return array<string, mixed>
      */
     private function castArrayNotation(EntityInterface $entity, array $data): array
     {
@@ -337,9 +358,9 @@ class DataCompiler
      * and removed from the data patched.
      *
      * @param \Cake\Datasource\EntityInterface $entity entity build
-     * @param array $data data to set
+     * @param array<string, mixed> $data data to set
      *
-     * @return array Data without the fields for which the setters are ignored
+     * @return array<string, mixed> Data without the fields for which the setters are ignored
      */
     private function setDataWithoutSetters(EntityInterface $entity, array $data): array
     {
@@ -375,7 +396,7 @@ class DataCompiler
      * Merge with the data injected during the instantiation of the Factory
      *
      * @param \Cake\Datasource\EntityInterface $entity Entity to manipulate.
-     * @param \Cake\Datasource\EntityInterface|callable|array $data Data from the instantiation.
+     * @param \Cake\Datasource\EntityInterface|callable|array<string, mixed> $data Data from the instantiation.
      *
      * @return $this
      */
@@ -454,7 +475,7 @@ class DataCompiler
      *
      * @param \Cake\Datasource\EntityInterface $entity Entity produced by the factory.
      * @param string $associationName Association
-     * @param array $data Data to inject
+     * @param array<int, \CakephpFixtureFactories\Factory\BaseFactory> $data Data to inject
      *
      * @return void
      */
@@ -476,7 +497,7 @@ class DataCompiler
     /**
      * @param \Cake\Datasource\EntityInterface $entity Entity produced by the factory.
      * @param string $associationName Association
-     * @param array $data Data to inject
+     * @param array<int, \CakephpFixtureFactories\Factory\BaseFactory> $data Data to inject
      *
      * @return void
      */
@@ -515,7 +536,7 @@ class DataCompiler
      * Ensure new associated entities are marked dirty so CakePHP will save them.
      *
      * @param \Cake\Datasource\EntityInterface $entity Entity to mark.
-     * @param array $visited
+     * @param array<int, bool> $visited
      *
      * @return void
      */
@@ -628,7 +649,7 @@ class DataCompiler
     /**
      * @throws \CakephpFixtureFactories\Error\PersistenceException
      *
-     * @return array
+     * @return array<string, int|string>
      */
     public function createPrimaryKeyOffset(): array
     {
@@ -646,7 +667,7 @@ class DataCompiler
     }
 
     /**
-     * @return array
+     * @return array<string, int|string>
      */
     public function generateArrayOfRandomPrimaryKeys(): array
     {
@@ -744,7 +765,7 @@ class DataCompiler
     }
 
     /**
-     * @param array $primaryKeys Set of primary keys
+     * @param array<string, int|string> $primaryKeys Set of primary keys
      *
      * @return void
      */
@@ -775,7 +796,7 @@ class DataCompiler
      * Fetch the fields that were intentionally modified by the developer
      * and that are unique. These should be watched for uniqueness.
      *
-     * @return array
+     * @return array<string>
      */
     public function getModifiedUniqueFields(): array
     {
@@ -815,7 +836,7 @@ class DataCompiler
     }
 
     /**
-     * @return array
+     * @return array<string>
      */
     public function getEnforcedFields(): array
     {
@@ -828,7 +849,7 @@ class DataCompiler
      * have been set by the user. This is useful for the
      * uniqueness of the fields.
      *
-     * @param array $fields Fields to be marked as enforced.
+     * @param array<string, mixed> $fields Fields to be marked as enforced.
      *
      * @return void
      */
@@ -843,7 +864,7 @@ class DataCompiler
     /**
      * Sets the fields which setters should be skipped
      *
-     * @param array $skippedSetters setters to skip
+     * @param array<string> $skippedSetters setters to skip
      *
      * @return void
      */

--- a/src/Factory/EventCollector.php
+++ b/src/Factory/EventCollector.php
@@ -44,17 +44,17 @@ class EventCollector
     private ?Table $table = null;
 
     /**
-     * @var array
+     * @var array<string>
      */
     private array $listeningBehaviors = [];
 
     /**
-     * @var array
+     * @var array<string>
      */
     private array $listeningModelEvents = [];
 
     /**
-     * @var array
+     * @var array<string>
      */
     private array $defaultListeningBehaviors = [];
 
@@ -109,7 +109,7 @@ class EventCollector
     }
 
     /**
-     * @return array
+     * @return array<string>
      */
     public function getListeningBehaviors(): array
     {
@@ -132,9 +132,9 @@ class EventCollector
     }
 
     /**
-     * @param array $activeBehaviors Behaviors the factory will listen to
+     * @param array<string> $activeBehaviors Behaviors the factory will listen to
      *
-     * @return array
+     * @return array<string>
      */
     public function listeningToBehaviors(array $activeBehaviors): array
     {
@@ -144,9 +144,9 @@ class EventCollector
     }
 
     /**
-     * @param array $activeModelEvents Events the factory will listen to
+     * @param array<string> $activeModelEvents Events the factory will listen to
      *
-     * @return array
+     * @return array<string>
      */
     public function listeningToModelEvents(array $activeModelEvents): array
     {
@@ -156,7 +156,7 @@ class EventCollector
     }
 
     /**
-     * @return array
+     * @return array<string>
      */
     public function getListeningModelEvents(): array
     {
@@ -175,7 +175,7 @@ class EventCollector
     }
 
     /**
-     * @return array
+     * @return array<string>
      */
     public function getDefaultListeningBehaviors(): array
     {

--- a/src/Factory/FactoryAwareTrait.php
+++ b/src/Factory/FactoryAwareTrait.php
@@ -31,7 +31,7 @@ trait FactoryAwareTrait
      * @see \CakephpFixtureFactories\Factory\BaseFactory::make
      *
      * @param string $name Factory or model name
-     * @param \Cake\Datasource\EntityInterface|callable|array|string|int|null $makeParameter Injected data
+     * @param \Cake\Datasource\EntityInterface|callable|array<string, mixed>|string|int|null $makeParameter Injected data
      * @param int $times Number of entities created
      *
      * @throws \CakephpFixtureFactories\Error\FactoryNotFoundException if the factory could not be found

--- a/src/Generator/DummyGeneratorAdapter.php
+++ b/src/Generator/DummyGeneratorAdapter.php
@@ -174,7 +174,7 @@ class DummyGeneratorAdapter implements GeneratorInterface
      * Handle method calls with unique value tracking
      *
      * @param string $method The method name to call
-     * @param array $arguments The arguments to pass
+     * @param array<mixed> $arguments The arguments to pass
      *
      * @throws \OverflowException If unable to generate unique value
      * @throws \BadMethodCallException If method not found

--- a/src/Generator/GeneratorInterface.php
+++ b/src/Generator/GeneratorInterface.php
@@ -93,7 +93,7 @@ namespace CakephpFixtureFactories\Generator;
  * @method string creditCardNumber() Generate a random credit card number
  * @method string creditCardType() Generate a random credit card type
  * @method \DateTime creditCardExpirationDate() Generate credit card expiration date
- * @method array creditCardDetails() Generate complete credit card details
+ * @method array<string, mixed> creditCardDetails() Generate complete credit card details
  * @method string iban() Generate a random IBAN
  * @method string swiftBicNumber() Generate a random SWIFT BIC number
  * @method string ean13() Generate EAN-13 barcode

--- a/src/ORM/FactoryTableBeforeSave.php
+++ b/src/ORM/FactoryTableBeforeSave.php
@@ -87,7 +87,7 @@ final class FactoryTableBeforeSave
      *
      * @see DataCompiler::compileEntity()
      *
-     * @return array
+     * @return array<string>
      */
     public function getEntityModifiedUniqueProperties(): array
     {
@@ -112,13 +112,13 @@ final class FactoryTableBeforeSave
     }
 
     /**
-     * @param array $conditions Conditions that a duplicate should meet
+     * @param array<string, mixed> $conditions Conditions that a duplicate should meet
      *
-     * @return array|null
+     * @return array<string, mixed>|null
      */
     public function findDuplicate(array $conditions): ?array
     {
-        /** @var array|null $duplicate */
+        /** @var array<string, mixed>|null $duplicate */
         $duplicate = $this->getTable()
             ->find()
             ->select($this->getPropertiesToPatchFromDuplicate())
@@ -134,7 +134,7 @@ final class FactoryTableBeforeSave
      * extract their values in the entity in an array to prepare a search
      * for a duplicate.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function getEnforcedUniquePropertyValues(): array
     {
@@ -151,7 +151,7 @@ final class FactoryTableBeforeSave
      * the primary keys and the fields modified unique
      * fields shall be overwritten by the already existing entity.
      *
-     * @param array $duplicate Values to patch from the existing entity to the one about to be created.
+     * @param array<string, mixed> $duplicate Values to patch from the existing entity to the one about to be created.
      *
      * @return void
      */
@@ -169,7 +169,7 @@ final class FactoryTableBeforeSave
      * primary keys. Those will define which fields to search
      * in duplicate.
      *
-     * @return array
+     * @return array<string>
      */
     public function getPropertiesToPatchFromDuplicate(): array
     {

--- a/src/ORM/SelectQueryMocker.php
+++ b/src/ORM/SelectQueryMocker.php
@@ -50,7 +50,7 @@ class SelectQueryMocker
         // Use reflection to access the protected getMockBuilder method
         $reflection = new ReflectionMethod($testCase, 'getMockBuilder');
 
-        /** @var \PHPUnit\Framework\MockObject\MockBuilder $selectQueryMockBuilder */
+        /** @var \PHPUnit\Framework\MockObject\MockBuilder<\Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface>> $selectQueryMockBuilder */
         $selectQueryMockBuilder = $reflection->invoke($testCase, SelectQuery::class);
         $selectQueryMocked = $selectQueryMockBuilder
             ->setConstructorArgs([$factory->getTable()])
@@ -63,7 +63,7 @@ class SelectQueryMocker
             ->method('all')
             ->willReturn($resultSet);
 
-        /** @var \PHPUnit\Framework\MockObject\MockBuilder $queryFactoryMockBuilder */
+        /** @var \PHPUnit\Framework\MockObject\MockBuilder<\Cake\ORM\Query\QueryFactory> $queryFactoryMockBuilder */
         $queryFactoryMockBuilder = $reflection->invoke($testCase, QueryFactory::class);
         $queryFactoryMocked = $queryFactoryMockBuilder
             ->onlyMethods(['select'])

--- a/src/View/Helper/FactoryBakeHelper.php
+++ b/src/View/Helper/FactoryBakeHelper.php
@@ -9,7 +9,7 @@ use Cake\View\Helper;
 class FactoryBakeHelper extends Helper
 {
     /**
-     * @param array $defaultData
+     * @param array<string, string> $defaultData
      *
      * @return string
      */


### PR DESCRIPTION
## Summary
- Add proper generic type annotations to all 88 locations across 12 source files that had `missingType.generics` or `missingType.iterableValue` errors at PHPStan level 7
- Remove the blanket `ignoreErrors` for `missingType.generics` and `missingType.iterableValue` from `phpstan.neon` so all generic types are now fully enforced
- Remove an obsolete `@phpstan-ignore-next-line` in `ModelEventsHandler` that was no longer triggering any error

PHPStan now passes clean at level 7 with zero ignored error identifiers.