### PR TITLE
Raise PHPStan to level 8

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-	level: 7
+	level: 8
 	bootstrapFiles:
 		- tests/bootstrap.php
 	paths:

--- a/src/Command/BakeFixtureFactoryCommand.php
+++ b/src/Command/BakeFixtureFactoryCommand.php
@@ -563,7 +563,7 @@ class BakeFixtureFactoryCommand extends BakeCommand
             }
 
             $columnSchema = $schema->getColumn($column);
-            if ($columnSchema['null'] || $columnSchema['default'] !== null) {
+            if (!$columnSchema || $columnSchema['null'] || $columnSchema['default'] !== null) {
                 continue;
             }
 

--- a/src/Command/PersistCommand.php
+++ b/src/Command/PersistCommand.php
@@ -116,7 +116,7 @@ class PersistCommand extends Command
      */
     public function parseFactory(Arguments $args): BaseFactory
     {
-        $factoryString = $args->getArgument(self::ARG_NAME);
+        $factoryString = (string)$args->getArgument(self::ARG_NAME);
 
         if (is_subclass_of($factoryString, BaseFactory::class)) {
             return $factoryString::make();

--- a/src/Factory/AssociationBuilder.php
+++ b/src/Factory/AssociationBuilder.php
@@ -235,11 +235,11 @@ class AssociationBuilder
      *
      * @param string $string String
      *
-     * @return string|null
+     * @return string
      */
-    public function removeBrackets(string $string): ?string
+    public function removeBrackets(string $string): string
     {
-        return preg_replace("/\[[^]]+\]/", '', $string);
+        return (string)preg_replace("/\[[^]]+\]/", '', $string);
     }
 
     /**

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -715,10 +715,7 @@ abstract class BaseFactory
         }
 
         // Remove the brackets in the association
-        $associationNameAfterBrackets = $this->getAssociationBuilder()->removeBrackets($associationName);
-        if ($associationNameAfterBrackets !== null) {
-            $associationName = $associationNameAfterBrackets;
-        }
+        $associationName = $this->getAssociationBuilder()->removeBrackets($associationName);
 
         $isToOne = $this->getAssociationBuilder()->processToOneAssociation($associationName, $factory);
         $this->getDataCompiler()->collectAssociation($associationName, $factory, $isToOne);

--- a/src/Factory/DataCompiler.php
+++ b/src/Factory/DataCompiler.php
@@ -675,7 +675,7 @@ class DataCompiler
         $res = [];
         foreach ($primaryKeys as $pk) {
             $res[$pk] = $this->generateRandomPrimaryKey(
-                $this->getFactory()->getTable()->getSchema()->getColumnType($pk),
+                (string)$this->getFactory()->getTable()->getSchema()->getColumnType($pk),
             );
         }
 


### PR DESCRIPTION
## Summary
- Raise PHPStan analysis level from 7 to 8 (strict type checks for nullable types)
- Fix all 7 errors that surfaced: null guards, string casts, and a simplified `removeBrackets()` return type