### PR TITLE
Implement lazy transaction strategy

### DIFF
--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -27,6 +27,7 @@ use CakephpFixtureFactories\Error\PersistenceException;
 use CakephpFixtureFactories\Generator\CakeGeneratorFactory;
 use CakephpFixtureFactories\Generator\GeneratorInterface;
 use CakephpFixtureFactories\TestSuite\FactoryTableTracker;
+use CakephpFixtureFactories\TestSuite\FactoryTransactionStrategy;
 use Closure;
 use InvalidArgumentException;
 use Psr\SimpleCache\CacheInterface;
@@ -428,6 +429,12 @@ abstract class BaseFactory
         // Track this table for transaction/cleanup strategies
         $table = $this->getTable();
         FactoryTableTracker::getInstance()->trackTable($table);
+
+        // Ensure a transaction is active on this connection (lazy start)
+        $strategy = FactoryTransactionStrategy::getActiveInstance();
+        if ($strategy !== null) {
+            $strategy->ensureTransaction($table->getConnection());
+        }
 
         try {
             if (count($entities) === 1) {


### PR DESCRIPTION
## Summary

- Transactions are now started lazily — only on connections that are actually used during a test, rather than upfront on all configured connections
- Removes dead savepoint code (`createSavePoint` was called but never rolled back to)
- Logs connection errors via `Cake\Log\Log::warning()` instead of silently swallowing them
- Adds `ensureTransaction()` hook in `BaseFactory::persist()` to start transactions on-demand

Closes #20