### PR TITLE
Fix PHPStan error: correct rootKey type annotation

### DIFF
--- a/src/Factory/DataCompiler.php
+++ b/src/Factory/DataCompiler.php
@@ -307,7 +307,7 @@ class DataCompiler
                 continue;
             }
             $subData = Hash::expand([$key => $value]);
-            /** @var string|int|null $rootKey */
+            /** @var string|null $rootKey */
             $rootKey = array_key_first($subData);
             if ($rootKey === null) {
                 continue;


### PR DESCRIPTION
The `$rootKey` annotation was overly broad (`string|int|null`). Since it comes from `Hash::expand()` with string keys, it should be `string|null`.