### PR TITLE
fix: persist() entity finalization under outer transaction (CakePHP 5.4)

### DIFF
--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -555,9 +555,6 @@ abstract class BaseFactory
         $alias = $table->getRegistryAlias();
         $entities = $result instanceof EntityInterface ? [$result] : $result;
         foreach ($entities as $entity) {
-            if (!$entity instanceof EntityInterface) {
-                continue;
-            }
             $entity->clean();
             $entity->setNew(false);
             $entity->setSource($alias);

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -507,15 +507,60 @@ abstract class BaseFactory
 
         try {
             if (count($entities) === 1) {
-                return $table->saveOrFail($entities[0], $this->getSaveOptions());
+                $result = $table->saveOrFail($entities[0], $this->getSaveOptions());
+            } else {
+                $result = $table->saveManyOrFail($entities, $this->getSaveOptions());
             }
-
-            return $table->saveManyOrFail($entities, $this->getSaveOptions());
         } catch (Throwable $exception) {
             $factory = static::class;
             $message = $exception->getMessage();
 
             throw new PersistenceException("Error in Factory `$factory`.\n Message: $message \n");
+        }
+
+        $this->finalizePersistedEntities($result, $table);
+
+        return $result;
+    }
+
+    /**
+     * Mirror the deferred entity bookkeeping from `Cake\ORM\Table::save()`.
+     *
+     * Since CakePHP 5.4, `$entity->clean()`, `$entity->setNew(false)` and
+     * `$entity->setSource()` are deferred via `Connection::afterCommit()`
+     * whenever the save runs inside an outer transaction. The transaction
+     * strategy used here only ever rolls back at teardown, so those
+     * callbacks are discarded and persisted entities still report
+     * `isNew() === true` to the test — which silently breaks any code
+     * that calls `Table::delete($entity)` (it short-circuits on new
+     * entities) or otherwise inspects post-save entity state.
+     *
+     * Applying the same bookkeeping here restores the synchronous
+     * pre-5.4 behavior that tests have relied on. CakePHP <= 5.3 is
+     * unaffected — it already ran this synchronously inside `save()`,
+     * so this is a harmless second application (the entity is already
+     * clean and not new by the time we get here).
+     *
+     * @param \Cake\Datasource\EntityInterface|\Cake\Datasource\ResultSetInterface<int, \Cake\Datasource\EntityInterface>|iterable<\Cake\Datasource\EntityInterface> $result Saved entity / entities returned by the table.
+     * @param \Cake\ORM\Table $table The table the save was performed on.
+     */
+    private function finalizePersistedEntities(
+        EntityInterface|iterable|ResultSetInterface $result,
+        Table $table,
+    ): void {
+        if (!$table->getConnection()->inTransaction()) {
+            return;
+        }
+
+        $alias = $table->getRegistryAlias();
+        $entities = $result instanceof EntityInterface ? [$result] : $result;
+        foreach ($entities as $entity) {
+            if (!$entity instanceof EntityInterface) {
+                continue;
+            }
+            $entity->clean();
+            $entity->setNew(false);
+            $entity->setSource($alias);
         }
     }
 

--- a/src/ORM/FactoryTableBeforeSave.php
+++ b/src/ORM/FactoryTableBeforeSave.php
@@ -54,7 +54,7 @@ final class FactoryTableBeforeSave
      */
     public static function handle(Table $table, EntityInterface $entity): void
     {
-        $handler = new static($table, $entity);
+        $handler = new self($table, $entity);
 
         $handler->handleUniqueFields();
     }

--- a/tests/TestCase/TestSuite/FactoryTransactionStrategyTest.php
+++ b/tests/TestCase/TestSuite/FactoryTransactionStrategyTest.php
@@ -196,4 +196,53 @@ class FactoryTransactionStrategyTest extends TestCase
         $this->assertCount(1, $tables, 'Same table should only be tracked once');
         $this->assertContains('cities', $tables);
     }
+
+    /**
+     * Regression: under FactoryTransactionStrategy, persisted entities must
+     * report `isNew() === false` and be clean immediately after `persist()`.
+     *
+     * CakePHP 5.4 defers `$entity->setNew(false)` / `$entity->clean()` /
+     * `$entity->setSource()` to a `Connection::afterCommit()` callback when
+     * the save runs inside an outer transaction. Our strategy never commits
+     * (always rolls back at teardown), so without compensation the returned
+     * entity would still report `isNew() === true` — silently breaking
+     * `Table::delete()` and any other `isNew()`-aware code in tests.
+     *
+     * Pre-5.4 CakePHP ran this synchronously inside `save()`; this test
+     * passes there for that reason.
+     *
+     * @return void
+     */
+    public function testPersistFinalizesEntityStateUnderOuterTransaction(): void
+    {
+        $strategy = new FactoryTransactionStrategy();
+        $strategy->setupTest([]);
+
+        try {
+            $city = CityFactory::make(['name' => 'Berlin'])->persist();
+
+            $this->assertNotEmpty($city->id, 'Entity should have an id after persist');
+            $this->assertFalse(
+                $city->isNew(),
+                'Persisted entity must not report isNew() === true; '
+                . 'a true value here would short-circuit subsequent Table::delete() calls.',
+            );
+            $this->assertFalse($city->isDirty(), 'Persisted entity must be clean.');
+            $this->assertSame(
+                'Cities',
+                $city->getSource(),
+                'Persisted entity must carry its registry alias.',
+            );
+
+            // Connection is in transaction (lazy-started by persist),
+            // mirroring the runtime conditions of the bug.
+            $connection = CityFactory::make()->getTable()->getConnection();
+            $this->assertTrue(
+                $connection->inTransaction(),
+                'Sanity check: the bug only manifests inside an outer transaction.',
+            );
+        } finally {
+            $strategy->teardownTest();
+        }
+    }
 }


### PR DESCRIPTION
## Summary

CakePHP 5.4 defers `\$entity->clean()`, `\$entity->setNew(false)` and `\$entity->setSource()` to a `Connection::afterCommit()` callback when `Table::save()` runs inside an outer transaction (see [\`Cake\ORM\Table::_processSave()\`](https://github.com/cakephp/cakephp/blob/5.4.0-RC1/src/ORM/Table.php#L2005-L2020) on 5.4.0-RC1). \`FactoryTransactionStrategy\` always rolls back at teardown, never commits, and \`Connection::rollback()\` discards queued \`afterCommit\` callbacks — so under 5.4 the deferred bookkeeping never runs.

The user-visible symptom: factory-persisted entities still report \`isNew() === true\`. \`Table::delete(\$entity)\` short-circuits on new entities, and any \`isNew()\`-aware code in the test sees stale state.

This PR mirrors the deferred bookkeeping in \`BaseFactory::persist()\` immediately after a successful save when the connection is still in transaction. That restores the synchronous pre-5.4 behavior tests have relied on for years.

## Reproducer (added as regression test)

\`\`\`php
\$strategy = new FactoryTransactionStrategy();
\$strategy->setupTest([]);

\$city = CityFactory::make(['name' => 'Berlin'])->persist();

\$this->assertFalse(\$city->isNew()); // fails on 5.4 without this PR
\$this->assertFalse(\$city->isDirty());
\$this->assertSame('Cities', \$city->getSource());
\$this->assertTrue(\$city->getTable()->getConnection()->inTransaction());

\$strategy->teardownTest();
\`\`\`

The new \`testPersistFinalizesEntityStateUnderOuterTransaction\` in \`FactoryTransactionStrategyTest\` fails on 5.4 with the message:

> Persisted entity must not report isNew() === true; a true value here would short-circuit subsequent Table::delete() calls.
> Failed asserting that true is false.

…and passes with the fix on both 5.4 and 5.3.

## Impact by CakePHP version

| Version  | Before this PR | After this PR |
|----------|----------------|---------------|
| 5.4+     | Persisted entities silently report \`isNew() === true\`; \`Table::delete()\` no-ops | Fixed — entity state matches production semantics |
| ≤ 5.3.x  | Worked, because \`Table::save()\` runs \`clean()\` + \`setNew(false)\` + \`setSource()\` synchronously after \`_executeTransaction\` regardless of outer-tx state | Unchanged — \`finalizePersistedEntities()\` is a harmless second application on an entity that is already clean and not new |

\`Model.afterSaveCommit\` / \`Model.afterDeleteCommit\` are intentionally **not** dispatched here — those have "after commit" semantics by definition and dispatching them on a transaction that will be rolled back would be wrong.

## Notes

Discovered while upgrading a downstream app to \`cakephp/cakephp:5.4.0-RC1\`. After the upgrade, an \`AttachmentsService\` test that called \`Table::delete(\$entity)\` on a factory-persisted entity started silently leaving the row in place (the delete short-circuited on \`isNew() === true\`). Reloading the entity from the DB before delete worked around it, but the root cause is this missed-deferral interaction. The fix here removes the need for that workaround.