### PR TITLE
Add buildDataCompiler() / buildEventCollector() extension points

### DIFF
--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -128,9 +128,35 @@ abstract class BaseFactory
 
     final protected function __construct()
     {
-        $this->dataCompiler = new DataCompiler($this);
+        $this->dataCompiler = $this->buildDataCompiler();
         $this->associationBuilder = new AssociationBuilder($this);
-        $this->eventCompiler = new EventCollector($this->getRootTableRegistryName());
+        $this->eventCompiler = $this->buildEventCollector();
+    }
+
+    /**
+     * Build the data compiler used by this factory.
+     *
+     * Override in a subclass to swap in a custom DataCompiler implementation
+     * (e.g. a subclass with project-specific compilation behavior).
+     *
+     * @return \CakephpFixtureFactories\Factory\DataCompiler
+     */
+    protected function buildDataCompiler(): DataCompiler
+    {
+        return new DataCompiler($this);
+    }
+
+    /**
+     * Build the event collector used by this factory.
+     *
+     * Override in a subclass to swap in a custom EventCollector implementation
+     * (e.g. a subclass that wires in a project-specific event manager).
+     *
+     * @return \CakephpFixtureFactories\Factory\EventCollector
+     */
+    protected function buildEventCollector(): EventCollector
+    {
+        return new EventCollector($this->getRootTableRegistryName());
     }
 
     /**

--- a/tests/Factory/CustomBuildHooksArticleFactory.php
+++ b/tests/Factory/CustomBuildHooksArticleFactory.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link          https://webrider.de/
+ * @since         3.2.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace CakephpFixtureFactories\Test\Factory;
+
+use CakephpFixtureFactories\Factory\DataCompiler;
+use CakephpFixtureFactories\Factory\EventCollector;
+
+/**
+ * Exercises the buildDataCompiler() / buildEventCollector() extension points
+ * on BaseFactory. Substitutes marker subclasses so tests can assert the hooks
+ * were actually used.
+ */
+class CustomBuildHooksArticleFactory extends ArticleFactory
+{
+    protected function buildDataCompiler(): DataCompiler
+    {
+        return new class ($this) extends DataCompiler {
+        };
+    }
+
+    protected function buildEventCollector(): EventCollector
+    {
+        return new class ($this->getRootTableRegistryName()) extends EventCollector {
+        };
+    }
+
+    public function exposeDataCompiler(): DataCompiler
+    {
+        return $this->getDataCompiler();
+    }
+
+    public function exposeEventCollector(): EventCollector
+    {
+        return $this->getEventCompiler();
+    }
+}

--- a/tests/TestCase/Factory/BuildCollaboratorHooksTest.php
+++ b/tests/TestCase/Factory/BuildCollaboratorHooksTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link https://webrider.de/
+ * @since 3.2.0
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace CakephpFixtureFactories\Test\TestCase\Factory;
+
+use Cake\TestSuite\TestCase;
+use CakephpFixtureFactories\Factory\DataCompiler;
+use CakephpFixtureFactories\Factory\EventCollector;
+use CakephpFixtureFactories\Test\Factory\ArticleFactory;
+use CakephpFixtureFactories\Test\Factory\CustomBuildHooksArticleFactory;
+use ReflectionMethod;
+
+class BuildCollaboratorHooksTest extends TestCase
+{
+    public function testDefaultDataCompilerIsUsedWhenNotOverridden(): void
+    {
+        /** @var \CakephpFixtureFactories\Test\Factory\CustomBuildHooksArticleFactory $factory */
+        $factory = ArticleFactory::make();
+
+        $reflection = new ReflectionMethod($factory, 'getDataCompiler');
+        $compiler = $reflection->invoke($factory);
+
+        $this->assertSame(DataCompiler::class, get_class($compiler));
+    }
+
+    public function testDefaultEventCollectorIsUsedWhenNotOverridden(): void
+    {
+        $factory = ArticleFactory::make();
+
+        $reflection = new ReflectionMethod($factory, 'getEventCompiler');
+        $collector = $reflection->invoke($factory);
+
+        $this->assertSame(EventCollector::class, get_class($collector));
+    }
+
+    public function testBuildDataCompilerHookIsUsedBySubclass(): void
+    {
+        $factory = CustomBuildHooksArticleFactory::make();
+
+        $compiler = $factory->exposeDataCompiler();
+
+        $this->assertInstanceOf(DataCompiler::class, $compiler);
+        $this->assertNotSame(
+            DataCompiler::class,
+            get_class($compiler),
+            'Expected an anonymous subclass of DataCompiler from the build hook',
+        );
+    }
+
+    public function testBuildEventCollectorHookIsUsedBySubclass(): void
+    {
+        $factory = CustomBuildHooksArticleFactory::make();
+
+        $collector = $factory->exposeEventCollector();
+
+        $this->assertInstanceOf(EventCollector::class, $collector);
+        $this->assertNotSame(
+            EventCollector::class,
+            get_class($collector),
+            'Expected an anonymous subclass of EventCollector from the build hook',
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`BaseFactory` constructs `DataCompiler` and `EventCollector` eagerly inside its `final protected __construct()`, so projects that need to substitute customized collaborators have no seam to do it without forking the library.

This PR adds two protected template methods on `BaseFactory`:

- `buildDataCompiler(): DataCompiler`
- `buildEventCollector(): EventCollector`

The constructor calls them instead of `new`-ing the concrete classes directly. The default implementations return the existing concrete classes, so behavior is unchanged.

## Why this shape (and not an interface)

An earlier proposal suggested extracting `DataCompilerInterface` / `EventCollectorInterface`. That would expose ~25 + ~9 public methods as a documented contract — many of which are semi-internal (e.g. `startPersistMode()`, `getEnforcedFields()`, `addEnforcedFields()`) and would lock the maintainer into semver-major churn on every signature change.

Template methods unlock customization at zero contract cost: subclasses can return any subclass of `DataCompiler` / `EventCollector`, and the maintainer keeps full freedom to evolve those concrete classes. If a real second use case shows up later that wants a different implementation entirely, an interface can be extracted then around the methods that actually proved necessary.

This follows the same pattern as PR #25 (custom event manager), which solved a specific extension need with a targeted hook rather than a full abstraction.