### PR TITLE
Fix scenario namespace stripping, biginteger PK range, manual assoc precedence

### DIFF
--- a/src/Factory/AssociationBuilder.php
+++ b/src/Factory/AssociationBuilder.php
@@ -363,6 +363,6 @@ class AssociationBuilder
      */
     public function addManualAssociations(array $associations): void
     {
-        $this->manualAssociations = array_merge_recursive($associations, $this->manualAssociations);
+        $this->manualAssociations = array_merge_recursive($this->manualAssociations, $associations);
     }
 }

--- a/src/Factory/DataCompiler.php
+++ b/src/Factory/DataCompiler.php
@@ -699,20 +699,22 @@ class DataCompiler
 
                 break;
             case 'tinyinteger':
-                $res = mt_rand(0, (int)('127'));
+                $res = mt_rand(0, 127);
 
                 break;
             case 'smallinteger':
-                $res = mt_rand(0, (int)('32767'));
+                $res = mt_rand(0, 32767);
 
                 break;
             case 'biginteger':
-                $res = mt_rand(0, (int)('9223372036854775807'));
+                // mt_rand() is capped at mt_getrandmax() (typically 2^31 - 1),
+                // which silently truncates biginteger PKs to 32-bit range.
+                $res = random_int(0, PHP_INT_MAX);
 
                 break;
             case 'integer':
             default:
-                $res = mt_rand(0, (int)('2147483647'));
+                $res = mt_rand(0, 2147483647);
 
                 break;
         }

--- a/src/Scenario/ScenarioAwareTrait.php
+++ b/src/Scenario/ScenarioAwareTrait.php
@@ -40,7 +40,11 @@ trait ScenarioAwareTrait
             // phpcs:disable
             @[$scenarioName, $plugin] = array_reverse(explode('.', $scenario));
             // phpcs:enable
-            $scenarioNamespace = trim($this->getFactoryNamespace($plugin), 'Factory') . 'Scenario';
+            $factoryNamespace = $this->getFactoryNamespace($plugin);
+            if (str_ends_with($factoryNamespace, 'Factory')) {
+                $factoryNamespace = substr($factoryNamespace, 0, -strlen('Factory'));
+            }
+            $scenarioNamespace = $factoryNamespace . 'Scenario';
             $scenarioName = str_replace('/', '\\', $scenarioName);
             $scenario = $scenarioNamespace . '\\' . $scenarioName . 'Scenario';
         }

--- a/tests/TestCase/Scenario/FixtureScenarioTest.php
+++ b/tests/TestCase/Scenario/FixtureScenarioTest.php
@@ -79,6 +79,41 @@ class FixtureScenarioTest extends TestCase
         $this->loadFixtureScenario(self::class);
     }
 
+    /**
+     * Regression: scenario namespace must strip the literal `Factory` suffix
+     * via substring, not via `trim()` character-mask. For a configured
+     * factory namespace whose char immediately before `Factory` is also a
+     * member of the mask `{F, a, c, t, o, r, y}` (e.g. `Custom\TestFactory`,
+     * where the trailing `t` of `Test` would also be eaten), the buggy
+     * `trim()` produced an invalid scenario class name (`Custom\TesScenario`
+     * instead of `Custom\TestScenario`).
+     */
+    public function testLoadScenarioNamespaceStripsFactorySuffixLiterally(): void
+    {
+        $original = Configure::read('FixtureFactories.testFixtureNamespace');
+        Configure::write('FixtureFactories.testFixtureNamespace', 'Custom\TestFactory');
+
+        try {
+            $this->loadFixtureScenario('NonExistentScenario');
+            $this->fail('Expected FixtureScenarioException to be thrown');
+        } catch (FixtureScenarioException $e) {
+            $this->assertStringContainsString(
+                'Custom\TestScenario\NonExistentScenarioScenario',
+                $e->getMessage(),
+            );
+            $this->assertStringNotContainsString(
+                'Custom\TesScenario',
+                $e->getMessage(),
+            );
+        } finally {
+            if ($original === null) {
+                Configure::delete('FixtureFactories.testFixtureNamespace');
+            } else {
+                Configure::write('FixtureFactories.testFixtureNamespace', $original);
+            }
+        }
+    }
+
     private function countAustralianAuthors(): int
     {
         return AuthorFactory::find()


### PR DESCRIPTION
## Summary

Three independent quality / robustness fixes:

- **`ScenarioAwareTrait::loadFixtureScenario()`**: replace `trim($factoryNamespace, 'Factory')` (PHP character-mask, not literal substring) with `str_ends_with(...) + substr(...)`. With the buggy version, any configured factory namespace whose tail char before `Factory` is also in the mask `{F, a, c, t, o, r, y}` had additional characters silently chewed off — e.g. `Custom\TestFactory` became `Custom\Tes` instead of `Custom\Test`, producing an invalid scenario class name and a confusing "class not found" error.
- **`DataCompiler::generateRandomPrimaryKey()`**: biginteger PKs were generated via `mt_rand(0, 9223372036854775807)`, but `mt_rand()` is capped at `mt_getrandmax()` (typically `2^31 - 1` on 64-bit) — silently truncating biginteger PKs to 32-bit range and defeating the point of using biginteger. Switch to `random_int(0, PHP_INT_MAX)` for the full 64-bit range. Also drop the leftover `(int)('127')`-style casts on string literals in the surrounding integer cases.
- **`AssociationBuilder::addManualAssociations()`**: `array_merge_recursive` arguments were passed in the opposite order from `getAssociated()` (line 327), so an earlier `addManualAssociations()` call won every key collision rather than being overridden by the new associations. Swap to match the precedence convention used elsewhere.

Adds a regression test covering the scenario namespace transformation; verified the test fails against the buggy `trim()` and passes after the fix. Full suite green, phpstan clean, phpcs clean.
