### PR TITLE
Fix getPersistedResultSet() losing the entity in the singular case

### DIFF
--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -91,6 +91,11 @@ $articles = ArticleFactory::make(3)->getResultSet(); // Will not persist in the 
 $articles = ArticleFactory::make(3)->getPersistedResultSet(); // Will persist in the DB
 ```
 
+A single entity is returned wrapped in a result set as well, so the contract is the same regardless of count:
+```php
+$article = ArticleFactory::make()->getPersistedResultSet()->first(); // Cake\Datasource\EntityInterface
+```
+
 Do not forget to check the [plugin's tests](https://github.com/dereuromark/cakephp-fixture-factories/tree/main/tests) for
 more insights!
 

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -436,7 +436,15 @@ abstract class BaseFactory
      */
     public function getPersistedResultSet(): ResultSet
     {
-        return new ResultSet((array)$this->persist());
+        $result = $this->persist();
+        if ($result instanceof EntityInterface) {
+            return new ResultSet([$result]);
+        }
+        if ($result instanceof ResultSet) {
+            return $result;
+        }
+
+        return new ResultSet(is_array($result) ? $result : iterator_to_array($result));
     }
 
     /**

--- a/tests/TestCase/Factory/BaseFactoryGetResultSetTest.php
+++ b/tests/TestCase/Factory/BaseFactoryGetResultSetTest.php
@@ -16,12 +16,14 @@ declare(strict_types=1);
 namespace CakephpFixtureFactories\Test\TestCase\Factory;
 
 use Cake\Core\Configure;
+use Cake\Datasource\EntityInterface;
 use Cake\TestSuite\TestCase;
 use CakephpFixtureFactories\Test\Factory\ArticleFactory;
 use CakephpFixtureFactories\Test\Factory\CountryFactory;
 use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
 use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Model\Entity\Address;
+use TestApp\Model\Entity\Country;
 
 class BaseFactoryGetResultSetTest extends TestCase
 {
@@ -63,6 +65,22 @@ class BaseFactoryGetResultSetTest extends TestCase
         $this->assertSame($street, $articles->last()['authors'][0]['address']['street']);
         $this->assertInstanceOf(Address::class, $articles->first()['authors'][0]['address']);
         $this->assertSame($isPersisted ? 2 : 0, ArticleFactory::count());
+    }
+
+    #[DataProvider('isPersisted')]
+    public function testBaseFactoryGetResultSetWithSingleEntity(bool $isPersisted): void
+    {
+        $name = 'Single';
+        $factory = CountryFactory::make(['name' => $name]);
+
+        $countries = $isPersisted ? $factory->getPersistedResultSet() : $factory->getResultSet();
+
+        $this->assertSame(1, $countries->count());
+        $this->assertInstanceOf(Country::class, $countries->first());
+        $this->assertInstanceOf(EntityInterface::class, $countries->first());
+        $this->assertSame($name, $countries->first()->get('name'));
+        $this->assertSame(!$isPersisted, $countries->first()->get('id') === null);
+        $this->assertSame($isPersisted ? 1 : 0, CountryFactory::count());
     }
 
     public function testBaseFactoryGetResultSetWithIds(): void


### PR DESCRIPTION
## Summary

`BaseFactory::getPersistedResultSet()` was passing `(array)\$this->persist()` straight into a `ResultSet`. When `persist()` returns a single `EntityInterface` (the `count(\$entities) === 1` branch in `persist()`), PHP's object-to-array cast produces an associative array of the entity's mangled private/protected properties (`_fields`, `_original`, ...) instead of `[\$entity]`. The `ResultSet` then iterated those properties, so:

```php
\$factory->getPersistedResultSet()->first()
```

returned the entity's internal `_fields` array (or the first such property), not the entity itself. This contradicts the docblock `@return ResultSet<int, EntityInterface>` and the equivalent in-memory method `getResultSet()`.

The multi-entity case kept working because `saveManyOrFail()` returns an iterable of entities, where the `(array)` cast is roughly a no-op.

## Fix

Branch on the runtime shape returned by `persist()`:

- single `EntityInterface` -> wrap as `[\$entity]`
- existing `ResultSet` -> return as-is
- otherwise -> normalize via `iterator_to_array()` if needed

Behavior for the multi-entity path is unchanged.

## Tests

Added a data-provided regression test `testBaseFactoryGetResultSetWithSingleEntity` covering both `getResultSet()` and `getPersistedResultSet()` for a single-entity factory. It uses `CountryFactory` (no associations) so it runs cleanly across the SQLite/MySQL/Postgres CI matrix.

Verified locally that the new test fails on `main` (`count()` returns 13 instead of 1) and passes with the fix. PHPStan and PHPCS clean.

## Docs

`docs/guide/examples.md` only ever showed `make(N)->getPersistedResultSet()`, so the singular contract was implicit. Added a one-liner showing that the result set shape is the same when only one entity is requested.