### PR TITLE
Add 1.4 migration tooling: bake fix, migration script, upgrade guide

### DIFF
--- a/bin/migrate-factory-annotations.php
+++ b/bin/migrate-factory-annotations.php
@@ -1,0 +1,195 @@
+#!/usr/bin/env php
+<?php
+/**
+ * One-shot migration script for the 1.3 to 1.4 upgrade.
+ *
+ * Replaces hand-rolled method annotation blocks on Factory subclasses
+ * (the three lines covering getEntity, getEntities, persist) with the
+ * canonical generic-extends form
+ *
+ *   extends \CakephpFixtureFactories\Factory\BaseFactory<\App\Model\Entity\X>
+ *
+ * Idempotent: running it twice is a no-op. Files that already use the
+ * extends form, or do not match the legacy pattern, are left untouched.
+ *
+ * Usage:
+ *
+ *   php bin/migrate-factory-annotations.php tests/Factory [more/paths ...]
+ *   php bin/migrate-factory-annotations.php --dry-run tests/Factory
+ *
+ * Each path can be a directory (scanned recursively for *.php) or a single
+ * file. Multiple paths are processed in order.
+ */
+
+declare(strict_types=1);
+
+$argv = $_SERVER['argv'] ?? [];
+array_shift($argv);
+
+$dryRun = false;
+$paths = [];
+foreach ($argv as $arg) {
+    if ($arg === '--dry-run' || $arg === '-d') {
+        $dryRun = true;
+
+        continue;
+    }
+    if ($arg === '--help' || $arg === '-h') {
+        usage();
+        exit(0);
+    }
+    $paths[] = $arg;
+}
+
+if (!$paths) {
+    usage();
+    exit(64);
+}
+
+$pattern = '/^\h*\*\h*@method\h+\\\\?[\w\\\\]+\h+getEntity\(\)\R'
+    . '\h*\*\h*@method\h+array<\\\\?[\w\\\\]+>\h+getEntities\(\)\R'
+    . '\h*\*\h*@method\h+\\\\?[\w\\\\]+\|array<\\\\?[\w\\\\]+>\h+persist\(\)\R/m';
+
+$replaced = 0;
+$skippedAlreadyMigrated = 0;
+$skippedNoMatch = 0;
+$scanned = 0;
+
+foreach ($paths as $path) {
+    foreach (collectFiles($path) as $file) {
+        $scanned++;
+        $src = (string)file_get_contents($file);
+        if (!preg_match('/extends\h+(?:\\\\?CakephpFixtureFactories\\\\Factory\\\\BaseFactory|\w+BaseFactory)\b/', $src)) {
+            $skippedNoMatch++;
+
+            continue;
+        }
+        if (preg_match('/@extends\h+\\\\?CakephpFixtureFactories\\\\Factory\\\\BaseFactory</', $src)) {
+            $skippedAlreadyMigrated++;
+
+            continue;
+        }
+        $entity = deriveEntityFqn($src, $file);
+        if ($entity === null) {
+            $skippedNoMatch++;
+
+            continue;
+        }
+        $replacementLine = sprintf(" * @extends \\CakephpFixtureFactories\\Factory\\BaseFactory<%s>\n", $entity);
+        $new = preg_replace($pattern, $replacementLine, $src, 1, $count);
+        if ($count === 0 || $new === null) {
+            // Legacy block not found, but extends BaseFactory: try inserting @extends before the closing */ of the class docblock.
+            $new = insertExtendsLine($src, $replacementLine);
+            if ($new === null) {
+                $skippedNoMatch++;
+
+                continue;
+            }
+        }
+        if ($new === $src) {
+            $skippedAlreadyMigrated++;
+
+            continue;
+        }
+        if (!$dryRun) {
+            file_put_contents($file, $new);
+        }
+        $replaced++;
+        printf("%s %s\n", $dryRun ? '[dry-run]' : '[migrated]', $file);
+    }
+}
+
+printf(
+    "\nScanned: %d, migrated: %d, already migrated: %d, skipped (not a factory or no match): %d%s\n",
+    $scanned,
+    $replaced,
+    $skippedAlreadyMigrated,
+    $skippedNoMatch,
+    $dryRun ? ' (dry-run, no files were written)' : '',
+);
+
+exit($replaced > 0 || $scanned > 0 ? 0 : 1);
+
+/**
+ * Collect *.php files under a path. Path may be a single file or a directory.
+ *
+ * @return iterable<string>
+ */
+function collectFiles(string $path): iterable
+{
+    if (is_file($path)) {
+        if (str_ends_with($path, '.php')) {
+            yield $path;
+        }
+
+        return;
+    }
+    if (!is_dir($path)) {
+        fwrite(STDERR, "warning: path not found: {$path}\n");
+
+        return;
+    }
+    $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS));
+    foreach ($iterator as $file) {
+        if ($file instanceof SplFileInfo && $file->isFile() && $file->getExtension() === 'php') {
+            yield $file->getPathname();
+        }
+    }
+}
+
+/**
+ * Derive the entity FQN from the file's namespace + class name.
+ *
+ * App\Test\Factory\InvoiceFactory -> \App\Model\Entity\Invoice
+ * MyPlugin\Test\Factory\ThingFactory -> \MyPlugin\Model\Entity\Thing
+ *
+ * Returns null if the file does not contain a namespace + class declaration
+ * matching the convention.
+ */
+function deriveEntityFqn(string $src, string $file): ?string
+{
+    if (!preg_match('/^namespace\h+([\w\\\\]+);/m', $src, $nsMatch)) {
+        return null;
+    }
+    if (!preg_match('/^class\h+(\w+)Factory\b/m', $src, $classMatch)) {
+        return null;
+    }
+    $namespace = $nsMatch[1];
+    $entityName = $classMatch[1];
+    $entityNs = preg_replace('/\\\\Test\\\\Factory$/', '\\Model\\Entity', $namespace);
+    if ($entityNs === $namespace) {
+        // Namespace did not end with \Test\Factory — fall back to a best-effort guess.
+        $entityNs = $namespace . '\\Model\\Entity';
+    }
+
+    return '\\' . $entityNs . '\\' . $entityName;
+}
+
+/**
+ * Insert an @extends line into the class docblock when no legacy block is present.
+ *
+ * Returns null if the docblock cannot be located.
+ */
+function insertExtendsLine(string $src, string $extendsLine): ?string
+{
+    if (!preg_match('/(\/\*\*[^*]*(?:\*(?!\/)[^*]*)*)\*\/\s*(?:abstract\h+|final\h+)?class\h+\w+Factory\b/m', $src, $m, PREG_OFFSET_CAPTURE)) {
+        return null;
+    }
+    $docblock = $m[1][0];
+    $offset = $m[1][1];
+    $newDocblock = rtrim($docblock) . "\n" . $extendsLine . "\n ";
+
+    return substr_replace($src, $newDocblock, $offset, strlen($docblock));
+}
+
+function usage(): void
+{
+    fwrite(STDERR, <<<TXT
+Usage: php migrate-factory-annotations.php [--dry-run] PATH [PATH ...]
+
+  PATH        File or directory to scan (recursively for directories).
+  --dry-run   Print what would change without modifying files.
+  --help      Show this message.
+
+TXT);
+}

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -12,38 +12,34 @@ from `vierge-noire/cakephp-fixture-factories`, see the [migration guide](migrati
 
 ### Symmetric persist/get API
 
-The persist-side API and the in-memory get-side API are now symmetric. Both
-sides are typed through the `TEntity` template on `BaseFactory`, so an IDE
-can resolve return types to the concrete entity class once your factory
-declares the template parameter (see below).
-
-Renames:
-
-| Before (1.3.x)       | After (1.4.0)         |
-|----------------------|-----------------------|
-| `persistOne()`       | `persistEntity()`     |
-| `persistMany()`      | `persistEntities()`   |
-
-The single-entity `persistEntity()` keeps the throw-if-multiple safety check.
-The plural `persistEntities()` always returns an `array`.
-
-`getEntity()` and `getEntities()` are no longer marked deprecated — they form
-the in-memory counterpart to the persist methods.
-
 `persist()` is now deprecated. Its return type is the union
-`TEntity|iterable<TEntity>`, which means callers always have to narrow before
-they can use the result. Use `persistEntity()` (single) or `persistEntities()`
-(many) for sharp return types instead. `persist()` will be removed in v4.
+`TEntity|iterable<TEntity>`, which means callers always have to narrow
+before they can use the result. 1.4 introduces two typed replacements:
 
-#### `persistOne()` / `persistMany()` users
+| Before (1.3.x)            | After (1.4.0)         | When to use                                  |
+|---------------------------|-----------------------|----------------------------------------------|
+| `persist()` (single row)  | `persistEntity()`     | Factory configured via `make()` or `make([...singleRow])` |
+| `persist()` (multiple)    | `persistEntities()`   | `setTimes(n)`, `make([[...], [...]])`, multi-entity factories |
 
-If you're upgrading from a pre-release that already used `persistOne()` /
-`persistMany()`, just rename the calls — same behavior.
+`persistEntity()` keeps a throw-if-multiple safety check; if the factory
+ends up producing more than one entity, you get a clear runtime error
+instead of a silently-narrowed return value. `persistEntities()` always
+returns an `array<TEntity>`.
 
-#### `persist()` users
+The in-memory side is now symmetric: `getEntity()` and `getEntities()`
+are no longer marked deprecated. They form the non-persisted counterpart
+to the persist pair.
 
-Replace each call site with `persistEntity()` or `persistEntities()` based on
-how the factory was configured:
+All four methods are typed through the `TEntity` template on
+`BaseFactory`, so an IDE resolves return types to the concrete entity
+class once your factory declares the template parameter (see below).
+
+`persist()` will be removed in v4.
+
+#### `persist()` call sites
+
+Replace each call site with `persistEntity()` or `persistEntities()` based
+on how the factory was configured:
 
 ```diff
 - $invoice = InvoiceFactory::make()->persist();

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -1,0 +1,119 @@
+---
+title: Upgrading
+description: Per-version upgrade notes
+---
+
+# Upgrading
+
+This page collects breaking-change notes between minor versions. For migrating
+from `vierge-noire/cakephp-fixture-factories`, see the [migration guide](migration.md).
+
+## 1.3 → 1.4
+
+### Symmetric persist/get API
+
+The persist-side API and the in-memory get-side API are now symmetric. Both
+sides are typed through the `TEntity` template on `BaseFactory`, so an IDE
+can resolve return types to the concrete entity class once your factory
+declares the template parameter (see below).
+
+Renames:
+
+| Before (1.3.x)       | After (1.4.0)         |
+|----------------------|-----------------------|
+| `persistOne()`       | `persistEntity()`     |
+| `persistMany()`      | `persistEntities()`   |
+
+The single-entity `persistEntity()` keeps the throw-if-multiple safety check.
+The plural `persistEntities()` always returns an `array`.
+
+`getEntity()` and `getEntities()` are no longer marked deprecated — they form
+the in-memory counterpart to the persist methods.
+
+`persist()` is now deprecated. Its return type is the union
+`TEntity|iterable<TEntity>`, which means callers always have to narrow before
+they can use the result. Use `persistEntity()` (single) or `persistEntities()`
+(many) for sharp return types instead. `persist()` will be removed in v4.
+
+#### `persistOne()` / `persistMany()` users
+
+If you're upgrading from a pre-release that already used `persistOne()` /
+`persistMany()`, just rename the calls — same behavior.
+
+#### `persist()` users
+
+Replace each call site with `persistEntity()` or `persistEntities()` based on
+how the factory was configured:
+
+```diff
+- $invoice = InvoiceFactory::make()->persist();
++ $invoice = InvoiceFactory::make()->persistEntity();
+
+- $invoices = InvoiceFactory::make()->setTimes(5)->persist();
++ $invoices = InvoiceFactory::make()->setTimes(5)->persistEntities();
+```
+
+### Factory subclass annotations
+
+To get sharp IDE autocomplete and PHPStan/Psalm type resolution on
+`getEntity()`, `getEntities()`, `persistEntity()`, `persistEntities()`,
+`getResultSet()` and `getPersistedResultSet()`, declare the template
+parameter on each Factory subclass:
+
+```php
+/**
+ * extends \CakephpFixtureFactories\Factory\BaseFactory<\App\Model\Entity\Invoice>
+ */
+class InvoiceFactory extends BaseFactory
+```
+
+(The leading-backslash FQN form is the safest because it does not depend on
+a `use` statement being present, and matches what
+SlevomatCodingStandard's `FullyQualifiedClassNameInAnnotation` sniff
+enforces.)
+
+If your project already had hand-rolled `method` annotations like
+
+```
+method getEntity()
+method getEntities()
+method persist()
+```
+
+on each Factory subclass, replace each block with the single `extends`
+line above. The IDE-resolved types are equivalent and the new
+`persistEntity()` / `persistEntities()` methods are picked up
+automatically.
+
+### Bake
+
+The `bake fixture_factory` template now emits the `extends` form by default;
+freshly-baked factories require no manual annotation work.
+
+### Migrating an existing project
+
+The bake template only helps with new factories. For existing ones, two
+paths:
+
+1. **Bundled migration script** — a standalone PHP script that rewrites
+   all factory subclasses under a given path in one pass:
+
+   ```bash
+   php vendor/dereuromark/cakephp-fixture-factories/bin/migrate-factory-annotations.php \
+       tests/Factory
+   ```
+
+   You can pass multiple paths (e.g. for plugin factories under
+   `plugins/MyPlugin/tests/Factory`). The script is idempotent — running
+   it twice is a no-op. It removes legacy `method getEntity/getEntities/
+   persist` blocks and inserts the canonical `extends` line, keeping
+   any other docblock content intact.
+
+2. **`FactoryClassAnnotatorTask`** *(if you also use
+   `dereuromark/cakephp-ide-helper`)* — the task is auto-registered and
+   runs as part of `bin/cake annotate classes`. Unlike the migration
+   script it keeps your factory annotations correct over time, not just
+   on the one-time upgrade.
+
+After running either, verify with your usual quality gates (phpunit,
+phpstan, phpcs).

--- a/templates/bake/fixture_factory.twig
+++ b/templates/bake/fixture_factory.twig
@@ -15,9 +15,7 @@ use {{ useStatement }};
 /**
  * {{ factory }}
  *
- * @method {{ entityClass }} getEntity()
- * @method array<{{ entityClass }}> getEntities()
- * @method {{ entityClass }}|array<{{ entityClass }}> persist()
+ * @extends \CakephpFixtureFactories\Factory\BaseFactory<{{ entityClass }}>
  * @method static {{ entityClass }} get(mixed $primaryKey, array $options = [])
  */
 class {{ factory }} extends CakephpBaseFactory


### PR DESCRIPTION
## Summary

The 1.4 release deprecates `persist()` and replaces it with two typed
methods (`persistEntity()` for single-row factories, `persistEntities()`
for multi-row), and un-deprecates `getEntity()` / `getEntities()` to give
the in-memory side a symmetric pair. All four resolve to the concrete
entity through the `TEntity` template on `BaseFactory`, but only when
the consumer's Factory subclass declares the template parameter:

```php
/**
 * extends \CakephpFixtureFactories\Factory\BaseFactory<\App\Model\Entity\Invoice>
 */
class InvoiceFactory extends BaseFactory
```

This PR ships three pieces of migration tooling so downstream consumers
do not have to hand-edit each subclass.

> **Released-version framing** — `persistOne()` / `persistMany()` lived
> only on `main` and were never tagged. From a 1.3.x user's perspective
> the migration is `persist()` → `persistEntity()` / `persistEntities()`
> at the call sites, plus the docblock change on each Factory subclass.

## Changes

1. **`templates/bake/fixture_factory.twig`** — now emits the `extends`
   form instead of the legacy three-line method block (`getEntity`,
   `getEntities`, `persist`). Freshly-baked factories pick up the new
   `persistEntity()` / `persistEntities()` methods automatically.

2. **`bin/migrate-factory-annotations.php`** — standalone, dependency-free
   PHP CLI script that rewrites existing Factory subclasses under one or
   more paths. Idempotent. Supports `--dry-run`. Derives the entity FQN
   from the class namespace + class name, so it works for both app
   factories (`App\Test\Factory\XFactory`) and plugin factories
   (`MyPlugin\Test\Factory\XFactory`).

   Usage:
   ```bash
   php vendor/dereuromark/cakephp-fixture-factories/bin/migrate-factory-annotations.php tests/Factory
   ```

3. **`docs/guide/upgrading.md`** — new per-version upgrade page (the
   existing `migration.md` is reserved for the vierge-noire fork
   migration). Documents the `persist()` → `persistEntity()` /
   `persistEntities()` migration, the bake change, and the migration
   script. References a follow-up `FactoryClassAnnotatorTask` (separate
   PR) for consumers who also use `cakephp-ide-helper`.

## Why no Rector rule?

A custom Rector rule was considered but skipped: it would require pulling
`rector/rector` into `require-dev` plus rector-testing fixture
infrastructure for a one-time migration. The standalone script delivers
the same value with zero new composer dependencies and is easier to ship.
If a Rector rule becomes desirable later (e.g. as a small composer plugin
or in a separate `-rector` package) it can be added on top of this.

## Smoke test

Verified the script on a temp fixture covering both app and plugin
factory shapes:

```
[migrated] /tmp/factory-test/tests/Factory/InvoiceFactory.php
[migrated] /tmp/factory-test/plugins/MyPlugin/tests/Factory/ThingFactory.php
Scanned: 2, migrated: 2, already migrated: 0, skipped: 0

[second run, same paths]
Scanned: 2, migrated: 0, already migrated: 2, skipped: 0
```

End-to-end run on a real downstream codebase (62 factories) is in flight
under the eventsetting branch and will be reported here once it lands.

## Notes

The pre-existing phpstan errors in `src/Factory/BaseFactory.php` (around
`ResultSet` 2-template-arg annotations) and the FQCN-attribute phpcs
errors in test files are unaffected by this PR — they are present on main
and out of scope here.