### PR TITLE
Add FactoryAnnotatorTask for cakephp-ide-helper integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,11 +36,15 @@
         "fakerphp/faker": "^1.23",
         "cakephp/bake": "^3.0.0",
         "cakephp/twig-view": "^2.0.2",
+        "dereuromark/cakephp-ide-helper": "^2.16",
         "php-collective/code-sniffer": "dev-master",
         "cakephp/migrations": "^4.7.0 || ^5.0.0",
         "josegonzalez/dotenv": "^4.0.0",
         "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^11.5 || ^12.1 || ^13.0"
+    },
+    "suggest": {
+        "dereuromark/cakephp-ide-helper": "Auto-keeps Factory subclass docblocks in sync via the bundled FactoryAnnotatorTask; runs as part of `bin/cake annotate classes`."
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "phpunit/phpunit": "^11.5 || ^12.1 || ^13.0"
     },
     "suggest": {
-        "dereuromark/cakephp-ide-helper": "Auto-keeps Factory subclass docblocks in sync via the bundled FactoryAnnotatorTask; runs as part of `bin/cake annotate classes`."
+        "dereuromark/cakephp-ide-helper": "Required for the bundled `bin/cake annotate_factories` command, which keeps Factory subclass docblocks in sync with the generic-extends contract."
     },
     "autoload": {
         "psr-4": {

--- a/src/CakephpFixtureFactoriesPlugin.php
+++ b/src/CakephpFixtureFactoriesPlugin.php
@@ -16,10 +16,40 @@ declare(strict_types=1);
 namespace CakephpFixtureFactories;
 
 use Cake\Core\BasePlugin;
+use Cake\Core\Configure;
+use Cake\Core\PluginApplicationInterface;
+use CakephpFixtureFactories\IdeHelper\FactoryAnnotatorTask;
+use IdeHelper\Annotator\ClassAnnotatorTask\ClassAnnotatorTaskInterface;
 
 /**
  * Plugin class for CakephpFixtureFactories
  */
 class CakephpFixtureFactoriesPlugin extends BasePlugin
 {
+    /**
+     * Register a class annotator task with cakephp-ide-helper if it's installed,
+     * so that `bin/cake annotate classes` keeps every Factory subclass docblock
+     * up-to-date with the canonical generic-extends form.
+     *
+     * No-op if cakephp-ide-helper is not present.
+     *
+     * @param \Cake\Core\PluginApplicationInterface<\Cake\Core\BasePlugin> $app
+     *
+     * @return void
+     */
+    public function bootstrap(PluginApplicationInterface $app): void
+    {
+        parent::bootstrap($app);
+
+        if (!interface_exists(ClassAnnotatorTaskInterface::class)) {
+            return;
+        }
+
+        /** @var array<string, string|null> $tasks */
+        $tasks = (array)Configure::read('IdeHelper.classAnnotatorTasks', []);
+        if (!array_key_exists('FactoryAnnotatorTask', $tasks)) {
+            $tasks['FactoryAnnotatorTask'] = FactoryAnnotatorTask::class;
+            Configure::write('IdeHelper.classAnnotatorTasks', $tasks);
+        }
+    }
 }

--- a/src/CakephpFixtureFactoriesPlugin.php
+++ b/src/CakephpFixtureFactoriesPlugin.php
@@ -15,11 +15,14 @@ declare(strict_types=1);
 
 namespace CakephpFixtureFactories;
 
+use Cake\Console\CommandCollection;
 use Cake\Core\BasePlugin;
 use Cake\Core\Configure;
 use Cake\Core\PluginApplicationInterface;
+use CakephpFixtureFactories\Command\AnnotateFactoriesCommand;
 use CakephpFixtureFactories\IdeHelper\FactoryAnnotatorTask;
 use IdeHelper\Annotator\ClassAnnotatorTask\ClassAnnotatorTaskInterface;
+use IdeHelper\Command\AnnotateCommand;
 
 /**
  * Plugin class for CakephpFixtureFactories
@@ -28,7 +31,7 @@ class CakephpFixtureFactoriesPlugin extends BasePlugin
 {
     /**
      * Register a class annotator task with cakephp-ide-helper if it's installed,
-     * so that `bin/cake annotate classes` keeps every Factory subclass docblock
+     * so that `bin/cake annotate_factories` keeps every Factory subclass docblock
      * up-to-date with the canonical generic-extends form.
      *
      * No-op if cakephp-ide-helper is not present.
@@ -51,5 +54,26 @@ class CakephpFixtureFactoriesPlugin extends BasePlugin
             $tasks['FactoryAnnotatorTask'] = FactoryAnnotatorTask::class;
             Configure::write('IdeHelper.classAnnotatorTasks', $tasks);
         }
+    }
+
+    /**
+     * Skip the default plugin command auto-discovery and register
+     * AnnotateFactoriesCommand explicitly only when cakephp-ide-helper is
+     * available. The command extends `IdeHelper\Command\AnnotateCommand`,
+     * so PHP's autoloader would fatal during discovery if ide-helper is
+     * not installed — even though the rest of this plugin works fine
+     * without it.
+     *
+     * @param \Cake\Console\CommandCollection $commands
+     *
+     * @return \Cake\Console\CommandCollection
+     */
+    public function console(CommandCollection $commands): CommandCollection
+    {
+        if (class_exists(AnnotateCommand::class)) {
+            $commands->add('annotate_factories', AnnotateFactoriesCommand::class);
+        }
+
+        return $commands;
     }
 }

--- a/src/Command/AnnotateFactoriesCommand.php
+++ b/src/Command/AnnotateFactoriesCommand.php
@@ -11,6 +11,8 @@ use CakephpFixtureFactories\IdeHelper\FactoryAnnotatorTask;
 use IdeHelper\Annotator\AbstractAnnotator;
 use IdeHelper\Command\AnnotateCommand;
 use IdeHelper\Console\Io;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 
 /**
  * Run the FactoryAnnotatorTask over every Factory subclass under the app's
@@ -93,6 +95,11 @@ class AnnotateFactoriesCommand extends AnnotateCommand
     }
 
     /**
+     * Recursively walk $directory and pass every *Factory.php file at any
+     * depth through the annotator. Recursion matches CakePHP's own
+     * convention where factories may live in subdirectories that mirror
+     * an entity's namespace (e.g. tests/Factory/Admin/UserFactory.php).
+     *
      * @param string $directory
      *
      * @return bool true if any file was modified
@@ -100,10 +107,20 @@ class AnnotateFactoriesCommand extends AnnotateCommand
     protected function annotateDirectory(string $directory): bool
     {
         $changed = false;
-        $files = glob($directory . '*Factory.php') ?: [];
 
-        foreach ($files as $path) {
-            $name = pathinfo($path, PATHINFO_FILENAME);
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($directory, RecursiveDirectoryIterator::SKIP_DOTS),
+        );
+
+        foreach ($iterator as $file) {
+            if (!$file->isFile() || $file->getExtension() !== 'php') {
+                continue;
+            }
+            if (!str_ends_with($file->getFilename(), 'Factory.php')) {
+                continue;
+            }
+            $path = $file->getPathname();
+            $name = $file->getBasename('.php');
             if ($this->_shouldSkip($name, $path)) {
                 continue;
             }

--- a/src/Command/AnnotateFactoriesCommand.php
+++ b/src/Command/AnnotateFactoriesCommand.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CakephpFixtureFactories\Command;
+
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Core\Plugin;
+use CakephpFixtureFactories\IdeHelper\FactoryAnnotatorTask;
+use IdeHelper\Annotator\AbstractAnnotator;
+use IdeHelper\Command\AnnotateCommand;
+use IdeHelper\Console\Io;
+
+/**
+ * Run the FactoryAnnotatorTask over every Factory subclass under the app's
+ * tests/Factory directory and the same path inside each loaded local plugin
+ * (vendor plugins are skipped).
+ *
+ * The default `bin/cake annotate classes` command only scans src/ and
+ * tests/TestCase/, so without this dedicated entry point the
+ * FactoryAnnotatorTask would never run on actual factory files.
+ *
+ * Usage:
+ *
+ *     bin/cake annotate_factories
+ *     bin/cake annotate_factories -d # dry-run
+ *     bin/cake annotate_factories -d --ci # CI gate (exit 2 if changes needed)
+ *
+ * Requires `dereuromark/cakephp-ide-helper` to be installed and loaded.
+ */
+class AnnotateFactoriesCommand extends AnnotateCommand
+{
+    /**
+     * @return string
+     */
+    public static function getDescription(): string
+    {
+        return 'Annotate Factory subclasses with the canonical generic-extends docblock for cakephp-fixture-factories.';
+    }
+
+    /**
+     * @param \Cake\Console\Arguments $args
+     * @param \Cake\Console\ConsoleIo $io
+     *
+     * @return int
+     */
+    public function execute(Arguments $args, ConsoleIo $io): int
+    {
+        parent::execute($args, $io);
+
+        $paths = $this->collectFactoryPaths();
+        $changed = false;
+
+        foreach ($paths as $dir) {
+            $changed = $this->annotateDirectory($dir) || $changed;
+        }
+
+        if ($args->getOption('ci') && $changed) {
+            return static::CODE_CHANGES;
+        }
+
+        return static::CODE_SUCCESS;
+    }
+
+    /**
+     * Collect tests/Factory directories for the app and every loaded local plugin.
+     *
+     * @return array<string>
+     */
+    protected function collectFactoryPaths(): array
+    {
+        $paths = [];
+
+        $appPath = ROOT . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'Factory' . DIRECTORY_SEPARATOR;
+        if (is_dir($appPath)) {
+            $paths[] = $appPath;
+        }
+
+        foreach (Plugin::loaded() as $plugin) {
+            $pluginPath = Plugin::path($plugin);
+            $rootRelative = str_replace(ROOT . DIRECTORY_SEPARATOR, '', $pluginPath);
+            if (str_starts_with($rootRelative, 'vendor' . DIRECTORY_SEPARATOR)) {
+                continue;
+            }
+            $factoryPath = $pluginPath . 'tests' . DIRECTORY_SEPARATOR . 'Factory' . DIRECTORY_SEPARATOR;
+            if (is_dir($factoryPath)) {
+                $paths[] = $factoryPath;
+            }
+        }
+
+        return $paths;
+    }
+
+    /**
+     * @param string $directory
+     *
+     * @return bool true if any file was modified
+     */
+    protected function annotateDirectory(string $directory): bool
+    {
+        $changed = false;
+        $files = glob($directory . '*Factory.php') ?: [];
+
+        foreach ($files as $path) {
+            $name = pathinfo($path, PATHINFO_FILENAME);
+            if ($this->_shouldSkip($name, $path)) {
+                continue;
+            }
+
+            $this->io->out(str_replace(ROOT . DIRECTORY_SEPARATOR, '', $path), 1, ConsoleIo::VERBOSE);
+
+            $content = (string)file_get_contents($path);
+            $task = new FactoryAnnotatorTask(new Io($this->io), $this->getTaskConfig(), $content);
+
+            if (!$task->shouldRun($path, $content)) {
+                continue;
+            }
+            if ($task->annotate($path)) {
+                $changed = true;
+            }
+        }
+
+        return $changed;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getTaskConfig(): array
+    {
+        return [
+            AbstractAnnotator::CONFIG_DRY_RUN => (bool)$this->args->getOption('dry-run'),
+            AbstractAnnotator::CONFIG_VERBOSE => (bool)$this->args->getOption('verbose'),
+        ];
+    }
+}

--- a/src/IdeHelper/FactoryAnnotatorTask.php
+++ b/src/IdeHelper/FactoryAnnotatorTask.php
@@ -20,9 +20,14 @@ use IdeHelper\Annotator\ClassAnnotatorTask\ClassAnnotatorTaskInterface;
  * persistEntity(), persistEntities(), getResultSet() and
  * getPersistedResultSet() all fall back to EntityInterface.
  *
- * Auto-registers via CakephpFixtureFactoriesPlugin::bootstrap() when
- * cakephp-ide-helper is installed. Runs as part of `bin/cake annotate
- * classes`.
+ * Invoked by the dedicated `bin/cake annotate_factories` command shipped
+ * by this plugin. Note that the stock `bin/cake annotate classes` command
+ * from cakephp-ide-helper does not visit `tests/Factory/` or plugin
+ * factory directories, which is why a separate command exists.
+ *
+ * The task is also registered in `IdeHelper.classAnnotatorTasks` during
+ * plugin bootstrap, so it is reused by `annotate_factories` and is
+ * available to any custom command that scans factory paths.
  *
  * Also strips the legacy three-line method block (getEntity / getEntities
  * / persist) emitted by pre-1.4 bake output, so first runs over an

--- a/src/IdeHelper/FactoryAnnotatorTask.php
+++ b/src/IdeHelper/FactoryAnnotatorTask.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CakephpFixtureFactories\IdeHelper;
+
+use IdeHelper\Annotation\AnnotationFactory;
+use IdeHelper\Annotation\ExtendsAnnotation;
+use IdeHelper\Annotator\ClassAnnotatorTask\AbstractClassAnnotatorTask;
+use IdeHelper\Annotator\ClassAnnotatorTask\ClassAnnotatorTaskInterface;
+
+/**
+ * Class annotator task that ensures every Factory subclass declares the
+ * generic-extends docblock contract:
+ *
+ *     extends \CakephpFixtureFactories\Factory\BaseFactory<\App\Model\Entity\X>
+ *
+ * Without this annotation, IDEs and PHPStan/Psalm cannot resolve the
+ * TEntity template on BaseFactory, so getEntity(), getEntities(),
+ * persistEntity(), persistEntities(), getResultSet() and
+ * getPersistedResultSet() all fall back to EntityInterface.
+ *
+ * Auto-registers via CakephpFixtureFactoriesPlugin::bootstrap() when
+ * cakephp-ide-helper is installed. Runs as part of `bin/cake annotate
+ * classes`.
+ *
+ * Also strips the legacy three-line method block (getEntity / getEntities
+ * / persist) emitted by pre-1.4 bake output, so first runs over an
+ * existing codebase migrate the docblock in one pass; subsequent runs are
+ * no-ops.
+ */
+class FactoryAnnotatorTask extends AbstractClassAnnotatorTask implements ClassAnnotatorTaskInterface
+{
+    /**
+     * @var string
+     */
+    public const BASE_FACTORY_FQN = '\\CakephpFixtureFactories\\Factory\\BaseFactory';
+
+    /**
+     * @param string $path
+     * @param string $content
+     *
+     * @return bool
+     */
+    public function shouldRun(string $path, string $content): bool
+    {
+        if (!str_contains($path, DIRECTORY_SEPARATOR . 'Factory' . DIRECTORY_SEPARATOR)) {
+            return false;
+        }
+        if (!preg_match('/^class\s+\w+Factory\b/m', $content)) {
+            return false;
+        }
+
+        return $this->extendsBaseFactory($content);
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return bool
+     */
+    public function annotate(string $path): bool
+    {
+        $entityFqn = $this->deriveEntityFqn($this->content);
+        if ($entityFqn === null) {
+            return false;
+        }
+
+        $type = self::BASE_FACTORY_FQN . '<' . $entityFqn . '>';
+        $annotations = [
+            AnnotationFactory::createOrFail(ExtendsAnnotation::TAG, $type),
+        ];
+
+        $cleaned = $this->stripLegacyMethodBlock($this->content);
+        if ($cleaned !== $this->content) {
+            $this->content = $cleaned;
+        }
+
+        return $this->annotateContent($path, $this->content, $annotations);
+    }
+
+    /**
+     * Detect whether the class extends BaseFactory, allowing for both
+     * fully-qualified `extends \CakephpFixtureFactories\Factory\BaseFactory`
+     * and aliased `use ... as Foo; class X extends Foo`.
+     *
+     * @param string $content
+     *
+     * @return bool
+     */
+    protected function extendsBaseFactory(string $content): bool
+    {
+        if (preg_match('/\bextends\s+\\\\?CakephpFixtureFactories\\\\Factory\\\\BaseFactory\b/', $content)) {
+            return true;
+        }
+        if (
+            !preg_match(
+                '/\buse\s+\\\\?CakephpFixtureFactories\\\\Factory\\\\BaseFactory(?:\s+as\s+(\w+))?\s*;/',
+                $content,
+                $useMatch,
+            )
+        ) {
+            return false;
+        }
+        $alias = $useMatch[1] ?? 'BaseFactory';
+
+        return (bool)preg_match('/\bextends\s+' . preg_quote($alias, '/') . '\b/', $content);
+    }
+
+    /**
+     * Derive the FQN of the entity this factory produces from the file's
+     * namespace + class name.
+     *
+     * Convention:
+     *   App\Test\Factory\InvoiceFactory -> \App\Model\Entity\Invoice
+     *   MyPlugin\Test\Factory\ThingFactory -> \MyPlugin\Model\Entity\Thing
+     *
+     * Returns null if the file does not contain a recognizable namespace
+     * + `<Name>Factory` class declaration.
+     *
+     * @param string $content
+     *
+     * @return string|null
+     */
+    protected function deriveEntityFqn(string $content): ?string
+    {
+        if (!preg_match('/^namespace\s+([\w\\\\]+);/m', $content, $nsMatch)) {
+            return null;
+        }
+        if (!preg_match('/^class\s+(\w+)Factory\b/m', $content, $classMatch)) {
+            return null;
+        }
+        $namespace = $nsMatch[1];
+        $entityName = $classMatch[1];
+        $entityNs = preg_replace('/\\\\Test\\\\Factory$/', '\\Model\\Entity', $namespace);
+        if ($entityNs === $namespace) {
+            $entityNs = $namespace . '\\Model\\Entity';
+        }
+
+        return '\\' . $entityNs . '\\' . $entityName;
+    }
+
+    /**
+     * Strip the legacy three-line "method getEntity / getEntities / persist"
+     * block emitted by pre-1.4 bake output. Any other docblock tags
+     * (method, property, see, etc.) are preserved.
+     *
+     * @param string $content
+     * @return string
+     */
+    protected function stripLegacyMethodBlock(string $content): string
+    {
+        $pattern = '/^\h*\*\h*@method\h+\\\\?[\w\\\\]+\h+getEntity\(\)\R'
+            . '\h*\*\h*@method\h+array<\\\\?[\w\\\\]+>\h+getEntities\(\)\R'
+            . '\h*\*\h*@method\h+\\\\?[\w\\\\]+\|array<\\\\?[\w\\\\]+>\h+persist\(\)\R/m';
+
+        return (string)preg_replace($pattern, '', $content);
+    }
+}

--- a/src/IdeHelper/FactoryAnnotatorTask.php
+++ b/src/IdeHelper/FactoryAnnotatorTask.php
@@ -146,6 +146,7 @@ class FactoryAnnotatorTask extends AbstractClassAnnotatorTask implements ClassAn
      * (method, property, see, etc.) are preserved.
      *
      * @param string $content
+     *
      * @return string
      */
     protected function stripLegacyMethodBlock(string $content): string

--- a/tests/TestCase/Command/AnnotateFactoriesCommandTest.php
+++ b/tests/TestCase/Command/AnnotateFactoriesCommandTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CakephpFixtureFactories\Test\TestCase\Command;
+
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\TestSuite\StubConsoleOutput;
+use Cake\TestSuite\TestCase;
+use CakephpFixtureFactories\Command\AnnotateFactoriesCommand;
+
+class AnnotateFactoriesCommandTest extends TestCase
+{
+    protected string $tmpDir = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Path must contain a "/Factory/" segment so the task's shouldRun() matches.
+        $this->tmpDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'fft_cmd_' . uniqid('', true) . DIRECTORY_SEPARATOR . 'Factory' . DIRECTORY_SEPARATOR;
+        mkdir($this->tmpDir, 0o777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        // Clean up parent of "Factory/" too.
+        $this->rrmdir(dirname(rtrim($this->tmpDir, DIRECTORY_SEPARATOR)));
+        parent::tearDown();
+    }
+
+    /**
+     * Recursive directory cleanup.
+     *
+     * @param string $dir
+     *
+     * @return void
+     */
+    protected function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $entries = scandir($dir) ?: [];
+        foreach ($entries as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $path = $dir . DIRECTORY_SEPARATOR . $entry;
+            if (is_dir($path) && !is_link($path)) {
+                $this->rrmdir($path);
+            } else {
+                @unlink($path);
+            }
+        }
+        @rmdir($dir);
+    }
+
+    /**
+     * Subclass that exposes the protected directory walker for testing.
+     */
+    protected function makeCommand(bool $dryRun = false): AnnotateFactoriesCommand
+    {
+        $command = new class extends AnnotateFactoriesCommand {
+            public function annotateForTest(string $directory): bool
+            {
+                return $this->annotateDirectory($directory);
+            }
+
+            public function setForTest(Arguments $args, ConsoleIo $io): void
+            {
+                $this->args = $args;
+                $this->io = $io;
+            }
+        };
+
+        $args = new Arguments(
+            [],
+            [
+                'dry-run' => $dryRun,
+                'verbose' => false,
+            ],
+            [],
+        );
+        $io = new ConsoleIo(new StubConsoleOutput(), new StubConsoleOutput());
+        $command->setForTest($args, $io);
+
+        return $command;
+    }
+
+    /**
+     * @param string $relativePath
+     * @param string $namespace
+     * @param string $entityName
+     *
+     * @return string Absolute path of the written fixture file.
+     */
+    protected function writeLegacyFactory(string $relativePath, string $namespace, string $entityName): string
+    {
+        $path = $this->tmpDir . $relativePath;
+        $dir = dirname($path);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0o777, true);
+        }
+        $entityFqn = '\\' . $namespace . '\\' . $entityName;
+        $entityFqnEscaped = str_replace('\\', '\\\\', $entityFqn);
+        $namespaceLine = 'namespace ' . $namespace . '\\Test\\Factory;';
+        $content = <<<PHP
+<?php
+declare(strict_types=1);
+
+{$namespaceLine}
+
+use CakephpFixtureFactories\\Factory\\BaseFactory as CakephpBaseFactory;
+
+/**
+ * {$entityName}Factory
+ *
+ * @method {$entityFqnEscaped} getEntity()
+ * @method array<{$entityFqnEscaped}> getEntities()
+ * @method {$entityFqnEscaped}|array<{$entityFqnEscaped}> persist()
+ */
+class {$entityName}Factory extends CakephpBaseFactory
+{
+}
+PHP;
+        file_put_contents($path, $content);
+
+        return $path;
+    }
+
+    /**
+     * @return void
+     */
+    public function testAnnotateDirectoryWalksSubdirectoriesRecursively(): void
+    {
+        $top = $this->writeLegacyFactory('InvoiceFactory.php', 'App', 'Invoice');
+        $nested = $this->writeLegacyFactory('Admin/UserFactory.php', 'App\\Admin', 'User');
+
+        $command = $this->makeCommand();
+        $changed = $command->annotateForTest($this->tmpDir);
+
+        $this->assertTrue($changed);
+        $this->assertStringContainsString(
+            '@extends \CakephpFixtureFactories\Factory\BaseFactory<\App\Model\Entity\Invoice>',
+            (string)file_get_contents($top),
+        );
+        $this->assertStringContainsString(
+            '@extends \CakephpFixtureFactories\Factory\BaseFactory<\App\Admin\Model\Entity\User>',
+            (string)file_get_contents($nested),
+            'Nested factory under a subdirectory must also be reached and annotated.',
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testAnnotateDirectoryIgnoresNonFactoryPhpFiles(): void
+    {
+        $factory = $this->writeLegacyFactory('InvoiceFactory.php', 'App', 'Invoice');
+        $unrelated = $this->tmpDir . 'NotAFactory.php';
+        $unrelatedSrc = "<?php\nclass NotAFactory {}\n";
+        file_put_contents($unrelated, $unrelatedSrc);
+
+        $command = $this->makeCommand();
+        $command->annotateForTest($this->tmpDir);
+
+        $this->assertSame(
+            $unrelatedSrc,
+            (string)file_get_contents($unrelated),
+            'Files that do not end in Factory.php must be left untouched.',
+        );
+        $this->assertStringContainsString(
+            '@extends \CakephpFixtureFactories\Factory\BaseFactory<\App\Model\Entity\Invoice>',
+            (string)file_get_contents($factory),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testAnnotateDirectoryDryRunMakesNoOnDiskChanges(): void
+    {
+        $factory = $this->writeLegacyFactory('InvoiceFactory.php', 'App', 'Invoice');
+        $before = (string)file_get_contents($factory);
+
+        $command = $this->makeCommand(dryRun: true);
+        $command->annotateForTest($this->tmpDir);
+
+        $this->assertSame(
+            $before,
+            (string)file_get_contents($factory),
+            '--dry-run must not write changes to disk.',
+        );
+    }
+}

--- a/tests/TestCase/IdeHelper/FactoryAnnotatorTaskTest.php
+++ b/tests/TestCase/IdeHelper/FactoryAnnotatorTaskTest.php
@@ -1,0 +1,313 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CakephpFixtureFactories\Test\TestCase\IdeHelper;
+
+use Cake\Console\ConsoleIo;
+use Cake\Console\TestSuite\StubConsoleOutput;
+use Cake\TestSuite\TestCase;
+use CakephpFixtureFactories\IdeHelper\FactoryAnnotatorTask;
+use IdeHelper\Annotator\AbstractAnnotator;
+use IdeHelper\Console\Io;
+
+class FactoryAnnotatorTaskTest extends TestCase
+{
+    protected Io $io;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $consoleIo = new ConsoleIo(new StubConsoleOutput(), new StubConsoleOutput());
+        $this->io = new Io($consoleIo);
+    }
+
+    /**
+     * @param string $content
+     *
+     * @return \CakephpFixtureFactories\IdeHelper\FactoryAnnotatorTask
+     */
+    protected function getTask(string $content): FactoryAnnotatorTask
+    {
+        return new FactoryAnnotatorTask(
+            $this->io,
+            [
+                AbstractAnnotator::CONFIG_DRY_RUN => true,
+                AbstractAnnotator::CONFIG_VERBOSE => true,
+            ],
+            $content,
+        );
+    }
+
+    /**
+     * Write $content to a unique temp file and return its path.
+     *
+     * @param string $content
+     *
+     * @return string
+     */
+    protected function writeTempFactory(string $content): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'fft_annotator_');
+        if ($path === false) {
+            $this->fail('Could not create temp file');
+        }
+        // tempnam creates without .php extension; rename so the path looks realistic.
+        $finalPath = $path . '.php';
+        rename($path, $finalPath);
+        file_put_contents($finalPath, $content);
+
+        return $finalPath;
+    }
+
+    /**
+     * @return void
+     */
+    public function testShouldRunMatchesAppFactoryExtendingBaseFactoryViaUse(): void
+    {
+        $content = <<<'PHP'
+<?php
+declare(strict_types=1);
+
+namespace App\Test\Factory;
+
+use CakephpFixtureFactories\Factory\BaseFactory;
+
+class InvoiceFactory extends BaseFactory
+{
+}
+PHP;
+        $result = $this->getTask($content)->shouldRun('/app/tests/Factory/InvoiceFactory.php', $content);
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testShouldRunMatchesAliasedBaseFactoryUseStatement(): void
+    {
+        $content = <<<'PHP'
+<?php
+declare(strict_types=1);
+
+namespace App\Test\Factory;
+
+use CakephpFixtureFactories\Factory\BaseFactory as CakephpBaseFactory;
+
+class InvoiceFactory extends CakephpBaseFactory
+{
+}
+PHP;
+        $result = $this->getTask($content)->shouldRun('/app/tests/Factory/InvoiceFactory.php', $content);
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testShouldRunMatchesPluginFactory(): void
+    {
+        $content = <<<'PHP'
+<?php
+declare(strict_types=1);
+
+namespace MyPlugin\Test\Factory;
+
+use CakephpFixtureFactories\Factory\BaseFactory;
+
+class ThingFactory extends BaseFactory
+{
+}
+PHP;
+        $result = $this->getTask($content)->shouldRun('/plugins/MyPlugin/tests/Factory/ThingFactory.php', $content);
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testShouldRunSkipsFileOutsideFactoryDirectory(): void
+    {
+        $content = <<<'PHP'
+<?php
+namespace App;
+
+use CakephpFixtureFactories\Factory\BaseFactory;
+
+class SomethingFactory extends BaseFactory
+{
+}
+PHP;
+        $result = $this->getTask($content)->shouldRun('/app/src/Something.php', $content);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testShouldRunSkipsFactoryFileNotExtendingBaseFactory(): void
+    {
+        $content = <<<'PHP'
+<?php
+namespace App\Test\Factory;
+
+class InvoiceFactory
+{
+}
+PHP;
+        $result = $this->getTask($content)->shouldRun('/app/tests/Factory/InvoiceFactory.php', $content);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testAnnotateInsertsExtendsForFreshAppFactory(): void
+    {
+        $content = <<<'PHP'
+<?php
+declare(strict_types=1);
+
+namespace App\Test\Factory;
+
+use CakephpFixtureFactories\Factory\BaseFactory;
+
+/**
+ * InvoiceFactory
+ */
+class InvoiceFactory extends BaseFactory
+{
+}
+PHP;
+        $task = $this->getTask($content);
+        $path = $this->writeTempFactory($content);
+        try {
+            $changed = $task->annotate($path);
+            $this->assertTrue($changed);
+            $this->assertStringContainsString(
+                '@extends \CakephpFixtureFactories\Factory\BaseFactory<\App\Model\Entity\Invoice>',
+                $task->getContent(),
+            );
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function testAnnotateInsertsExtendsForPluginFactory(): void
+    {
+        $content = <<<'PHP'
+<?php
+declare(strict_types=1);
+
+namespace MyPlugin\Test\Factory;
+
+use CakephpFixtureFactories\Factory\BaseFactory;
+
+/**
+ * ThingFactory
+ */
+class ThingFactory extends BaseFactory
+{
+}
+PHP;
+        $task = $this->getTask($content);
+        $path = $this->writeTempFactory($content);
+        try {
+            $changed = $task->annotate($path);
+            $this->assertTrue($changed);
+            $this->assertStringContainsString(
+                '@extends \CakephpFixtureFactories\Factory\BaseFactory<\MyPlugin\Model\Entity\Thing>',
+                $task->getContent(),
+            );
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function testAnnotateStripsLegacyMethodBlock(): void
+    {
+        $content = <<<'PHP'
+<?php
+declare(strict_types=1);
+
+namespace App\Test\Factory;
+
+use CakephpFixtureFactories\Factory\BaseFactory as CakephpBaseFactory;
+
+/**
+ * InvoiceFactory
+ *
+ * @method \App\Model\Entity\Invoice getEntity()
+ * @method array<\App\Model\Entity\Invoice> getEntities()
+ * @method \App\Model\Entity\Invoice|array<\App\Model\Entity\Invoice> persist()
+ * @method static \App\Model\Entity\Invoice get(mixed $primaryKey, array $options = [])
+ */
+class InvoiceFactory extends CakephpBaseFactory
+{
+}
+PHP;
+        $task = $this->getTask($content);
+        $path = $this->writeTempFactory($content);
+        try {
+            $changed = $task->annotate($path);
+            $this->assertTrue($changed);
+
+            $newContent = $task->getContent();
+            $this->assertStringNotContainsString('@method \App\Model\Entity\Invoice getEntity()', $newContent);
+            $this->assertStringNotContainsString('@method array<\App\Model\Entity\Invoice> getEntities()', $newContent);
+            $this->assertStringNotContainsString('persist()', $newContent);
+            $this->assertStringContainsString(
+                '@extends \CakephpFixtureFactories\Factory\BaseFactory<\App\Model\Entity\Invoice>',
+                $newContent,
+            );
+            // Static get(...) line is preserved (Table proxy, not generic).
+            $this->assertStringContainsString(
+                '@method static \App\Model\Entity\Invoice get(mixed $primaryKey, array $options = [])',
+                $newContent,
+            );
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function testAnnotateIsIdempotentOnAlreadyMigratedFactory(): void
+    {
+        $content = <<<'PHP'
+<?php
+declare(strict_types=1);
+
+namespace App\Test\Factory;
+
+use CakephpFixtureFactories\Factory\BaseFactory as CakephpBaseFactory;
+
+/**
+ * InvoiceFactory
+ *
+ * @extends \CakephpFixtureFactories\Factory\BaseFactory<\App\Model\Entity\Invoice>
+ * @method static \App\Model\Entity\Invoice get(mixed $primaryKey, array $options = [])
+ */
+class InvoiceFactory extends CakephpBaseFactory
+{
+}
+PHP;
+        $task = $this->getTask($content);
+        $path = $this->writeTempFactory($content);
+        try {
+            $changed = $task->annotate($path);
+            $this->assertFalse($changed, 'Already-migrated factory should produce no changes');
+            $this->assertSame($content, $task->getContent());
+        } finally {
+            @unlink($path);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Ships ongoing-maintenance tooling for the 1.4 generic-extends contract:

- **`FactoryAnnotatorTask`** (a `cakephp-ide-helper` class annotator task) that
  reconciles every Factory subclass docblock with the canonical form
  ```php
  /**
   * extends \CakephpFixtureFactories\Factory\BaseFactory<\App\Model\Entity\Invoice>
   */
  ```
- **`bin/cake annotate_factories`** — a dedicated CLI subcommand that scans
  the app's `tests/Factory/` directory and the same path inside every
  loaded local plugin, applying the task to each.

Together with PR #39's bake template and standalone migration script, this
gives consumers three coordinated paths:

| Tool                                       | When to use                                         |
|--------------------------------------------|-----------------------------------------------------|
| `bin/migrate-factory-annotations.php`      | One-shot 1.3 → 1.4 migration; no extra dependencies |
| `bin/cake annotate_factories`              | Ongoing maintenance after `cakephp-ide-helper` is installed |
| Bake template (PR #39)                     | New factories from `bin/cake bake fixture_factory`  |

## Why a dedicated command?

The default `bin/cake annotate classes` from `cakephp-ide-helper` only walks
`src/` and `tests/TestCase/`. Factory subclasses live in `tests/Factory/`
(and `plugins/MyPlugin/tests/Factory/` for plugin factories), so without a
dedicated entry point the task would be registered but never reach an
actual factory file. The new command fills that gap.

## How it works

**`src/IdeHelper/FactoryAnnotatorTask.php`** — implements
`ClassAnnotatorTaskInterface`:

- `shouldRun(path, content)` matches files under any `/Factory/` directory
  whose class extends `BaseFactory`. Handles fully-qualified `extends
  \CakephpFixtureFactories\Factory\BaseFactory` and aliased `use ... as Foo;
  class X extends Foo`.
- `annotate(path)` derives the entity FQN from the file's namespace plus
  class name (`App\Test\Factory\InvoiceFactory` →
  `\App\Model\Entity\Invoice`; `MyPlugin\Test\Factory\ThingFactory` →
  `\MyPlugin\Model\Entity\Thing`), strips the legacy three-line method
  block emitted by pre-1.4 bake output, then inserts or replaces the
  canonical extends annotation. Idempotent on already-migrated factories.

**`src/Command/AnnotateFactoriesCommand.php`** — extends
`IdeHelper\Command\AnnotateCommand` so the standard `--dry-run`, `--ci`,
`--verbose` flags work out of the box. Iterates the app's `tests/Factory/`
and every non-vendor loaded plugin's `tests/Factory/` directory, passing
each `*Factory.php` file through the task.

**`src/CakephpFixtureFactoriesPlugin.php`** — registers the task in
`IdeHelper.classAnnotatorTasks` during plugin bootstrap, gated behind
`interface_exists()` so this plugin remains usable without
`cakephp-ide-helper` installed. Plugin commands are auto-discovered via
the standard CakePHP plugin convention.

**`composer.json`** — adds `dereuromark/cakephp-ide-helper` to
`require-dev` (needed by tests and PHPStan) and to `suggest`.

## Tests

`tests/TestCase/IdeHelper/FactoryAnnotatorTaskTest.php` — 9 tests, 17
assertions:

- `shouldRun` matches app factories with both fully-qualified and aliased
  use statements
- `shouldRun` matches plugin factories under `MyPlugin\Test\Factory`
- `shouldRun` rejects non-factory files and factory files that don't
  extend `BaseFactory`
- `annotate` inserts `extends` for fresh app factories with derived FQN
- `annotate` inserts `extends` for plugin factories (separate namespace
  shape)
- `annotate` strips the legacy three-line method block while preserving
  the `static get(...)` line (Table proxy, not generic)
- `annotate` is idempotent on already-migrated factories

## Verification

Plugin self-tests:
- `composer test`: 475 tests, 1929 assertions, OK
- `composer stan`: clean
- `composer cs-check` on new files: clean (pre-existing FQCN-attribute
  errors in unrelated test files unaffected)

End-to-end on a downstream codebase (62 factories):
- `bin/cake annotate_factories` correctly migrates legacy three-line
  method blocks to the generic-extends form on every factory
- Idempotent on a second run (no diff)
- Output passes the consumer's `phpstan` (level 7) and `phpcs`
- The standalone migration script and the annotator produce semantically
  equivalent output (different cosmetic ordering of `@extends` vs `@method
  static get(...)` — both forms are valid PHPDoc and resolve identically
  in IDEs and PHPStan)