### PR TITLE
Add FactoryAnnotatorTask using PathAwareClassAnnotatorTaskInterface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "fakerphp/faker": "^1.23",
         "cakephp/bake": "^3.0.0",
         "cakephp/twig-view": "^2.0.2",
-        "dereuromark/cakephp-ide-helper": "^2.17",
+        "dereuromark/cakephp-ide-helper": "dev-feature/path-aware-class-annotator-tasks as 2.17",
         "php-collective/code-sniffer": "dev-master",
         "cakephp/migrations": "^4.7.0 || ^5.0.0",
         "josegonzalez/dotenv": "^4.0.0",

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "fakerphp/faker": "^1.23",
         "cakephp/bake": "^3.0.0",
         "cakephp/twig-view": "^2.0.2",
-        "dereuromark/cakephp-ide-helper": "dev-feature/path-aware-class-annotator-tasks as 2.17",
+        "dereuromark/cakephp-ide-helper": "^2.17",
         "php-collective/code-sniffer": "dev-master",
         "cakephp/migrations": "^4.7.0 || ^5.0.0",
         "josegonzalez/dotenv": "^4.0.0",

--- a/composer.json
+++ b/composer.json
@@ -36,11 +36,15 @@
         "fakerphp/faker": "^1.23",
         "cakephp/bake": "^3.0.0",
         "cakephp/twig-view": "^2.0.2",
+        "dereuromark/cakephp-ide-helper": "^2.17",
         "php-collective/code-sniffer": "dev-master",
         "cakephp/migrations": "^4.7.0 || ^5.0.0",
         "josegonzalez/dotenv": "^4.0.0",
         "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^11.5 || ^12.1 || ^13.0"
+    },
+    "suggest": {
+        "dereuromark/cakephp-ide-helper": "Lets `bin/cake annotate classes` (and `annotate all`) keep your Factory subclass docblocks in sync via the bundled FactoryAnnotatorTask. Requires version with PathAwareClassAnnotatorTaskInterface support."
     },
     "autoload": {
         "psr-4": {

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -105,11 +105,14 @@ paths:
    persist` blocks and inserts the canonical `extends` line, keeping
    any other docblock content intact.
 
-2. **`FactoryClassAnnotatorTask`** *(if you also use
-   `dereuromark/cakephp-ide-helper`)* — the task is auto-registered and
-   runs as part of `bin/cake annotate classes`. Unlike the migration
-   script it keeps your factory annotations correct over time, not just
-   on the one-time upgrade.
+2. **`FactoryAnnotatorTask`** *(if you also use
+   `dereuromark/cakephp-ide-helper` 2.17 or newer)* — the task is
+   auto-registered during plugin bootstrap, declares its own scan path
+   (`tests/Factory/`) via `PathAwareClassAnnotatorTaskInterface`, and
+   runs as part of the standard `bin/cake annotate classes` (or
+   `annotate all`) command. Unlike the migration script it keeps your
+   factory annotations correct over time, not just on the one-time
+   upgrade.
 
 After running either, verify with your usual quality gates (phpunit,
 phpstan, phpcs).

--- a/src/CakephpFixtureFactoriesPlugin.php
+++ b/src/CakephpFixtureFactoriesPlugin.php
@@ -16,10 +16,43 @@ declare(strict_types=1);
 namespace CakephpFixtureFactories;
 
 use Cake\Core\BasePlugin;
+use Cake\Core\Configure;
+use Cake\Core\PluginApplicationInterface;
+use CakephpFixtureFactories\IdeHelper\FactoryAnnotatorTask;
+use IdeHelper\Annotator\ClassAnnotatorTask\ClassAnnotatorTaskInterface;
 
 /**
  * Plugin class for CakephpFixtureFactories
  */
 class CakephpFixtureFactoriesPlugin extends BasePlugin
 {
+    /**
+     * Register the FactoryAnnotatorTask with cakephp-ide-helper if it's
+     * installed. The task implements `PathAwareClassAnnotatorTaskInterface`,
+     * so once registered the standard `bin/cake annotate classes` (and
+     * `annotate all`) command walks `tests/Factory/` automatically and
+     * keeps every Factory subclass docblock in sync with the canonical
+     * generic-extends form.
+     *
+     * No-op if cakephp-ide-helper is not present.
+     *
+     * @param \Cake\Core\PluginApplicationInterface<\Cake\Core\BasePlugin> $app
+     *
+     * @return void
+     */
+    public function bootstrap(PluginApplicationInterface $app): void
+    {
+        parent::bootstrap($app);
+
+        if (!interface_exists(ClassAnnotatorTaskInterface::class)) {
+            return;
+        }
+
+        /** @var array<string, string|null> $tasks */
+        $tasks = (array)Configure::read('IdeHelper.classAnnotatorTasks', []);
+        if (!array_key_exists('FactoryAnnotatorTask', $tasks)) {
+            $tasks['FactoryAnnotatorTask'] = FactoryAnnotatorTask::class;
+            Configure::write('IdeHelper.classAnnotatorTasks', $tasks);
+        }
+    }
 }

--- a/src/IdeHelper/FactoryAnnotatorTask.php
+++ b/src/IdeHelper/FactoryAnnotatorTask.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CakephpFixtureFactories\IdeHelper;
+
+use IdeHelper\Annotation\AnnotationFactory;
+use IdeHelper\Annotation\ExtendsAnnotation;
+use IdeHelper\Annotator\ClassAnnotatorTask\AbstractClassAnnotatorTask;
+use IdeHelper\Annotator\ClassAnnotatorTask\PathAwareClassAnnotatorTaskInterface;
+
+/**
+ * Class annotator task that ensures every Factory subclass declares the
+ * generic-extends docblock contract:
+ *
+ *     extends \CakephpFixtureFactories\Factory\BaseFactory<\App\Model\Entity\X>
+ *
+ * Without this annotation, IDEs and PHPStan/Psalm cannot resolve the
+ * TEntity template on BaseFactory, so getEntity(), getEntities(),
+ * persistEntity(), persistEntities(), getResultSet() and
+ * getPersistedResultSet() all fall back to EntityInterface.
+ *
+ * Implements `PathAwareClassAnnotatorTaskInterface` so that the standard
+ * `bin/cake annotate classes` command (and `annotate all`) reach
+ * `tests/Factory/` automatically once this plugin's bootstrap registers
+ * the task. No dedicated subcommand is required.
+ *
+ * Also strips the legacy three-line method block (getEntity / getEntities
+ * / persist) emitted by pre-1.4 bake output, so first runs over an
+ * existing codebase migrate the docblock in one pass; subsequent runs
+ * are no-ops.
+ */
+class FactoryAnnotatorTask extends AbstractClassAnnotatorTask implements PathAwareClassAnnotatorTaskInterface
+{
+    /**
+     * @var string
+     */
+    public const BASE_FACTORY_FQN = '\\CakephpFixtureFactories\\Factory\\BaseFactory';
+
+    /**
+     * @return array<string>
+     */
+    public static function scanPaths(): array
+    {
+        return ['tests/Factory/'];
+    }
+
+    /**
+     * @param string $path
+     * @param string $content
+     *
+     * @return bool
+     */
+    public function shouldRun(string $path, string $content): bool
+    {
+        if (!str_contains($path, DIRECTORY_SEPARATOR . 'Factory' . DIRECTORY_SEPARATOR)) {
+            return false;
+        }
+        if (!preg_match('/^class\s+\w+Factory\b/m', $content)) {
+            return false;
+        }
+
+        return $this->extendsBaseFactory($content);
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return bool
+     */
+    public function annotate(string $path): bool
+    {
+        $entityFqn = $this->deriveEntityFqn($this->content);
+        if ($entityFqn === null) {
+            return false;
+        }
+
+        $type = self::BASE_FACTORY_FQN . '<' . $entityFqn . '>';
+        $annotations = [
+            AnnotationFactory::createOrFail(ExtendsAnnotation::TAG, $type),
+        ];
+
+        $cleaned = $this->stripLegacyMethodBlock($this->content);
+        if ($cleaned !== $this->content) {
+            $this->content = $cleaned;
+        }
+
+        return $this->annotateContent($path, $this->content, $annotations);
+    }
+
+    /**
+     * Detect whether the class extends BaseFactory, allowing for both
+     * fully-qualified `extends \CakephpFixtureFactories\Factory\BaseFactory`
+     * and aliased `use ... as Foo; class X extends Foo`.
+     *
+     * @param string $content
+     *
+     * @return bool
+     */
+    protected function extendsBaseFactory(string $content): bool
+    {
+        if (preg_match('/\bextends\s+\\\\?CakephpFixtureFactories\\\\Factory\\\\BaseFactory\b/', $content)) {
+            return true;
+        }
+        if (
+            !preg_match(
+                '/\buse\s+\\\\?CakephpFixtureFactories\\\\Factory\\\\BaseFactory(?:\s+as\s+(\w+))?\s*;/',
+                $content,
+                $useMatch,
+            )
+        ) {
+            return false;
+        }
+        $alias = $useMatch[1] ?? 'BaseFactory';
+
+        return (bool)preg_match('/\bextends\s+' . preg_quote($alias, '/') . '\b/', $content);
+    }
+
+    /**
+     * Derive the FQN of the entity this factory produces from the file's
+     * namespace + class name.
+     *
+     * Convention:
+     *   App\Test\Factory\InvoiceFactory -> \App\Model\Entity\Invoice
+     *   MyPlugin\Test\Factory\ThingFactory -> \MyPlugin\Model\Entity\Thing
+     *
+     * Returns null if the file does not contain a recognizable namespace
+     * + `<Name>Factory` class declaration.
+     *
+     * @param string $content
+     *
+     * @return string|null
+     */
+    protected function deriveEntityFqn(string $content): ?string
+    {
+        if (!preg_match('/^namespace\s+([\w\\\\]+);/m', $content, $nsMatch)) {
+            return null;
+        }
+        if (!preg_match('/^class\s+(\w+)Factory\b/m', $content, $classMatch)) {
+            return null;
+        }
+        $namespace = $nsMatch[1];
+        $entityName = $classMatch[1];
+        $entityNs = preg_replace('/\\\\Test\\\\Factory$/', '\\Model\\Entity', $namespace);
+        if ($entityNs === $namespace) {
+            $entityNs = $namespace . '\\Model\\Entity';
+        }
+
+        return '\\' . $entityNs . '\\' . $entityName;
+    }
+
+    /**
+     * Strip the legacy three-line "method getEntity / getEntities / persist"
+     * block emitted by pre-1.4 bake output. Any other docblock tags
+     * (method, property, see, etc.) are preserved.
+     *
+     * @param string $content
+     *
+     * @return string
+     */
+    protected function stripLegacyMethodBlock(string $content): string
+    {
+        $pattern = '/^\h*\*\h*@method\h+\\\\?[\w\\\\]+\h+getEntity\(\)\R'
+            . '\h*\*\h*@method\h+array<\\\\?[\w\\\\]+>\h+getEntities\(\)\R'
+            . '\h*\*\h*@method\h+\\\\?[\w\\\\]+\|array<\\\\?[\w\\\\]+>\h+persist\(\)\R/m';
+
+        return (string)preg_replace($pattern, '', $content);
+    }
+}

--- a/tests/TestCase/IdeHelper/FactoryAnnotatorTaskTest.php
+++ b/tests/TestCase/IdeHelper/FactoryAnnotatorTaskTest.php
@@ -1,0 +1,327 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CakephpFixtureFactories\Test\TestCase\IdeHelper;
+
+use Cake\Console\ConsoleIo;
+use Cake\Console\TestSuite\StubConsoleOutput;
+use Cake\TestSuite\TestCase;
+use CakephpFixtureFactories\IdeHelper\FactoryAnnotatorTask;
+use IdeHelper\Annotator\AbstractAnnotator;
+use IdeHelper\Annotator\ClassAnnotatorTask\PathAwareClassAnnotatorTaskInterface;
+use IdeHelper\Console\Io;
+
+class FactoryAnnotatorTaskTest extends TestCase
+{
+    protected Io $io;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $consoleIo = new ConsoleIo(new StubConsoleOutput(), new StubConsoleOutput());
+        $this->io = new Io($consoleIo);
+    }
+
+    /**
+     * @param string $content
+     *
+     * @return \CakephpFixtureFactories\IdeHelper\FactoryAnnotatorTask
+     */
+    protected function getTask(string $content): FactoryAnnotatorTask
+    {
+        return new FactoryAnnotatorTask(
+            $this->io,
+            [
+                AbstractAnnotator::CONFIG_DRY_RUN => true,
+                AbstractAnnotator::CONFIG_VERBOSE => true,
+            ],
+            $content,
+        );
+    }
+
+    /**
+     * @param string $content
+     *
+     * @return string
+     */
+    protected function writeTempFactory(string $content): string
+    {
+        // Path must contain "/Factory/" for shouldRun() to match.
+        $dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'fft_task_' . uniqid('', true) . DIRECTORY_SEPARATOR . 'Factory' . DIRECTORY_SEPARATOR;
+        mkdir($dir, 0o777, true);
+        $path = $dir . 'TempFactory.php';
+        file_put_contents($path, $content);
+
+        return $path;
+    }
+
+    /**
+     * @return void
+     */
+    public function testImplementsPathAwareInterface(): void
+    {
+        $this->assertContains(
+            PathAwareClassAnnotatorTaskInterface::class,
+            class_implements(FactoryAnnotatorTask::class),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testScanPathsAdvertisesTestsFactoryDirectory(): void
+    {
+        $this->assertSame(['tests/Factory/'], FactoryAnnotatorTask::scanPaths());
+    }
+
+    /**
+     * @return void
+     */
+    public function testShouldRunMatchesAppFactoryExtendingBaseFactoryViaUse(): void
+    {
+        $content = <<<'PHP'
+<?php
+declare(strict_types=1);
+
+namespace App\Test\Factory;
+
+use CakephpFixtureFactories\Factory\BaseFactory;
+
+class InvoiceFactory extends BaseFactory
+{
+}
+PHP;
+        $result = $this->getTask($content)->shouldRun('/app/tests/Factory/InvoiceFactory.php', $content);
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testShouldRunMatchesAliasedBaseFactoryUseStatement(): void
+    {
+        $content = <<<'PHP'
+<?php
+declare(strict_types=1);
+
+namespace App\Test\Factory;
+
+use CakephpFixtureFactories\Factory\BaseFactory as CakephpBaseFactory;
+
+class InvoiceFactory extends CakephpBaseFactory
+{
+}
+PHP;
+        $result = $this->getTask($content)->shouldRun('/app/tests/Factory/InvoiceFactory.php', $content);
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testShouldRunMatchesPluginFactory(): void
+    {
+        $content = <<<'PHP'
+<?php
+declare(strict_types=1);
+
+namespace MyPlugin\Test\Factory;
+
+use CakephpFixtureFactories\Factory\BaseFactory;
+
+class ThingFactory extends BaseFactory
+{
+}
+PHP;
+        $result = $this->getTask($content)->shouldRun('/plugins/MyPlugin/tests/Factory/ThingFactory.php', $content);
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testShouldRunSkipsFileOutsideFactoryDirectory(): void
+    {
+        $content = <<<'PHP'
+<?php
+namespace App;
+
+use CakephpFixtureFactories\Factory\BaseFactory;
+
+class SomethingFactory extends BaseFactory
+{
+}
+PHP;
+        $result = $this->getTask($content)->shouldRun('/app/src/Something.php', $content);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testShouldRunSkipsFactoryFileNotExtendingBaseFactory(): void
+    {
+        $content = <<<'PHP'
+<?php
+namespace App\Test\Factory;
+
+class InvoiceFactory
+{
+}
+PHP;
+        $result = $this->getTask($content)->shouldRun('/app/tests/Factory/InvoiceFactory.php', $content);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testAnnotateInsertsExtendsForFreshAppFactory(): void
+    {
+        $content = <<<'PHP'
+<?php
+declare(strict_types=1);
+
+namespace App\Test\Factory;
+
+use CakephpFixtureFactories\Factory\BaseFactory;
+
+/**
+ * InvoiceFactory
+ */
+class InvoiceFactory extends BaseFactory
+{
+}
+PHP;
+        $task = $this->getTask($content);
+        $path = $this->writeTempFactory($content);
+        try {
+            $changed = $task->annotate($path);
+            $this->assertTrue($changed);
+            $this->assertStringContainsString(
+                '@extends \CakephpFixtureFactories\Factory\BaseFactory<\App\Model\Entity\Invoice>',
+                $task->getContent(),
+            );
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function testAnnotateInsertsExtendsForPluginFactory(): void
+    {
+        $content = <<<'PHP'
+<?php
+declare(strict_types=1);
+
+namespace MyPlugin\Test\Factory;
+
+use CakephpFixtureFactories\Factory\BaseFactory;
+
+/**
+ * ThingFactory
+ */
+class ThingFactory extends BaseFactory
+{
+}
+PHP;
+        $task = $this->getTask($content);
+        $path = $this->writeTempFactory($content);
+        try {
+            $changed = $task->annotate($path);
+            $this->assertTrue($changed);
+            $this->assertStringContainsString(
+                '@extends \CakephpFixtureFactories\Factory\BaseFactory<\MyPlugin\Model\Entity\Thing>',
+                $task->getContent(),
+            );
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function testAnnotateStripsLegacyMethodBlock(): void
+    {
+        $content = <<<'PHP'
+<?php
+declare(strict_types=1);
+
+namespace App\Test\Factory;
+
+use CakephpFixtureFactories\Factory\BaseFactory as CakephpBaseFactory;
+
+/**
+ * InvoiceFactory
+ *
+ * @method \App\Model\Entity\Invoice getEntity()
+ * @method array<\App\Model\Entity\Invoice> getEntities()
+ * @method \App\Model\Entity\Invoice|array<\App\Model\Entity\Invoice> persist()
+ * @method static \App\Model\Entity\Invoice get(mixed $primaryKey, array $options = [])
+ */
+class InvoiceFactory extends CakephpBaseFactory
+{
+}
+PHP;
+        $task = $this->getTask($content);
+        $path = $this->writeTempFactory($content);
+        try {
+            $changed = $task->annotate($path);
+            $this->assertTrue($changed);
+
+            $newContent = $task->getContent();
+            $this->assertStringNotContainsString('@method \App\Model\Entity\Invoice getEntity()', $newContent);
+            $this->assertStringNotContainsString('@method array<\App\Model\Entity\Invoice> getEntities()', $newContent);
+            $this->assertStringNotContainsString('persist()', $newContent);
+            $this->assertStringContainsString(
+                '@extends \CakephpFixtureFactories\Factory\BaseFactory<\App\Model\Entity\Invoice>',
+                $newContent,
+            );
+            $this->assertStringContainsString(
+                '@method static \App\Model\Entity\Invoice get(mixed $primaryKey, array $options = [])',
+                $newContent,
+            );
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function testAnnotateIsIdempotentOnAlreadyMigratedFactory(): void
+    {
+        $content = <<<'PHP'
+<?php
+declare(strict_types=1);
+
+namespace App\Test\Factory;
+
+use CakephpFixtureFactories\Factory\BaseFactory as CakephpBaseFactory;
+
+/**
+ * InvoiceFactory
+ *
+ * @extends \CakephpFixtureFactories\Factory\BaseFactory<\App\Model\Entity\Invoice>
+ * @method static \App\Model\Entity\Invoice get(mixed $primaryKey, array $options = [])
+ */
+class InvoiceFactory extends CakephpBaseFactory
+{
+}
+PHP;
+        $task = $this->getTask($content);
+        $path = $this->writeTempFactory($content);
+        try {
+            $changed = $task->annotate($path);
+            $this->assertFalse($changed, 'Already-migrated factory should produce no changes');
+            $this->assertSame($content, $task->getContent());
+        } finally {
+            @unlink($path);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `FactoryAnnotatorTask` for `cakephp-ide-helper` that keeps every
Factory subclass docblock in sync with the canonical generic-extends
contract:

```php
/**
 * extends \CakephpFixtureFactories\Factory\BaseFactory<\App\Model\Entity\Invoice>
 */
class InvoiceFactory extends BaseFactory
```

Without this annotation, IDEs and PHPStan/Psalm cannot resolve the
`TEntity` template on `BaseFactory`, so `getEntity()`, `getEntities()`,
`persistEntity()`, `persistEntities()`, `getResultSet()` and
`getPersistedResultSet()` all fall back to `EntityInterface`.

## How it integrates — no bespoke command needed

The task implements `PathAwareClassAnnotatorTaskInterface` (added in
[`dereuromark/cakephp-ide-helper#435`](https://github.com/dereuromark/cakephp-ide-helper/pull/435)),
declaring `tests/Factory/` as its scan path via a `static` method. The
plugin's `bootstrap()` registers the task in
`IdeHelper.classAnnotatorTasks`, gated behind `interface_exists()` so
this plugin stays usable without ide-helper installed.

From there the standard `bin/cake annotate classes` (or `annotate all`)
command walks `tests/Factory/` for the app and every loaded local plugin
(use `-p all` for plugin factories). No dedicated subcommand on this
side, no plugin-command auto-discovery to gate.

> **Depends on ide-helper PR #435** (`PathAwareClassAnnotatorTaskInterface`).
> Until that release ships, the `composer.json` `require-dev` pin of
> `^2.17` is forward-looking; local development uses a path/dev-branch
> install of ide-helper.

## Files

- **`src/IdeHelper/FactoryAnnotatorTask.php`**: implements
  `PathAwareClassAnnotatorTaskInterface`. `scanPaths()` returns
  `['tests/Factory/']`. `shouldRun()` filters to files under any
  `/Factory/` directory whose class extends `BaseFactory` (handles
  both fully-qualified and aliased use statements). `annotate()`
  derives the entity FQN from the file's namespace + class name,
  strips the legacy three-line `method` block from pre-1.4 bake
  output, and inserts or replaces the canonical `extends` annotation.
  Idempotent on already-migrated files.
- **`src/CakephpFixtureFactoriesPlugin.php`**: registers the task
  during plugin bootstrap, gated behind `interface_exists()`.
- **`composer.json`**: adds `dereuromark/cakephp-ide-helper: ^2.17`
  to `require-dev` and to `suggest`.
- **`docs/guide/upgrading.md`**: updated reference to point at
  `bin/cake annotate classes` rather than a bespoke entry point.

## Tests

`tests/TestCase/IdeHelper/FactoryAnnotatorTaskTest.php` — 11 tests, 19
assertions:

- Task implements `PathAwareClassAnnotatorTaskInterface`
- `scanPaths()` returns `['tests/Factory/']`
- `shouldRun` matches app factories (fully-qualified + aliased uses)
- `shouldRun` matches plugin factories
- `shouldRun` rejects non-factory files and factory files not extending
  `BaseFactory`
- `annotate` inserts `extends` for fresh app factories with derived FQN
- `annotate` inserts `extends` for plugin factories (separate namespace
  shape)
- `annotate` strips the legacy method block while preserving the
  `static get(...)` line (Table proxy, not generic)
- `annotate` is idempotent on already-migrated factories

## Verification

- `composer test`: 477 tests, 1931 assertions, OK
- `composer stan`: clean
- `composer cs-check`: clean

## Relationship to other tooling

| Tool                                       | When to use                                                  |
|--------------------------------------------|--------------------------------------------------------------|
| `bin/migrate-factory-annotations.php` (#39) | One-shot 1.3 to 1.4 migration; no extra dependencies         |
| `FactoryAnnotatorTask` (this PR)           | Ongoing maintenance via the standard annotate command        |
| Bake template (#39)                        | New factories from `bin/cake bake fixture_factory`           |

## Why this PR replaces #41

PR #41 shipped a bespoke `bin/cake annotate_factories` subcommand
because the stock `annotate classes` did not visit `tests/Factory/`.
With ide-helper PR #435 the path-aware interface lifts that limitation
upstream, so this PR drops the subcommand entirely (~140 lines of code
and a corresponding test class) in favour of one `static` method on the
task. Net code goes down; consumers run the same annotate command they
already run.

If #435 lands, this PR can be merged in place of #41.
