### PR TITLE
Rector + docs: cover patchData() to state() in v2 migration

### DIFF
--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -29,6 +29,7 @@ The bundled rules cover the safe, mechanical call-site changes:
 - `getEntities()` to `buildMany()`
 - `persistEntity()` to `save()`
 - `persistEntities()` to `saveMany()`
+- `patchData(...)` to `state(...)` (in factory helper methods such as `asAdmin()`)
 - static query helpers like `Factory::find()` to `Factory::query()`
 - `Factory::get($id, $options)` to `Factory::table()->get($id, $options)`
 
@@ -48,6 +49,17 @@ Typical before/after replacements look like this:
 
 - $published = ArticleFactory::find('published')->all();
 + $published = ArticleFactory::query()->find('published')->all();
+```
+
+Custom factory helpers that wrap field overrides also flip from
+`patchData()` to `state()`:
+
+```diff
+ public function asAdmin(): static
+ {
+-    return $this->patchData(['role_id' => self::ROLE_ADMIN]);
++    return $this->state(['role_id' => self::ROLE_ADMIN]);
+ }
 ```
 
 Factory subclass `@extends BaseFactory<TEntity>` annotations are expected to already be in place from the `1.4.x` upgrade step.

--- a/rector.php
+++ b/rector.php
@@ -20,6 +20,7 @@ return static function (RectorConfig $rectorConfig): void {
         new MethodCallRename(BaseFactory::class, 'persistEntity', 'save'),
         new MethodCallRename(BaseFactory::class, 'persistEntities', 'saveMany'),
         new MethodCallRename(BaseFactory::class, 'setTimes', 'count'),
+        new MethodCallRename(BaseFactory::class, 'patchData', 'state'),
     ]);
 
     $rectorConfig->rule(FactoryLegacyMakeToNewRector::class);

--- a/tests/TestCase/Rector/Fixture/patch_data_to_state.php.inc
+++ b/tests/TestCase/Rector/Fixture/patch_data_to_state.php.inc
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Test\Factory;
+
+use CakephpFixtureFactories\Factory\BaseFactory;
+use CakephpFixtureFactories\Generator\GeneratorInterface;
+
+final class UserFactory extends BaseFactory
+{
+    public const int ROLE_ADMIN = 2;
+
+    protected function getRootTableRegistryName(): string
+    {
+        return 'Users';
+    }
+
+    public function definition(GeneratorInterface $generator): array
+    {
+        return [
+            'username' => $generator->userName(),
+            'role_id' => self::ROLE_ADMIN,
+        ];
+    }
+
+    public function asAdmin(): static
+    {
+        return $this->patchData(['role_id' => self::ROLE_ADMIN]);
+    }
+}
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace App\Test\Factory;
+
+use CakephpFixtureFactories\Factory\BaseFactory;
+use CakephpFixtureFactories\Generator\GeneratorInterface;
+
+final class UserFactory extends BaseFactory
+{
+    public const int ROLE_ADMIN = 2;
+
+    protected function getRootTableRegistryName(): string
+    {
+        return 'Users';
+    }
+
+    public function definition(GeneratorInterface $generator): array
+    {
+        return [
+            'username' => $generator->userName(),
+            'role_id' => self::ROLE_ADMIN,
+        ];
+    }
+
+    public function asAdmin(): static
+    {
+        return $this->state(['role_id' => self::ROLE_ADMIN]);
+    }
+}


### PR DESCRIPTION
## Problem

The 1.4 `patchData()` helper was renamed to `state()` in v2, but the mechanical rename was missing from both:

- the bundled Rector ruleset (so `vendor/bin/rector process` left `patchData()` calls untouched);
- the v2 migration helpers checklist in `docs/guide/upgrading.md`.

Custom factory helpers that wrap field overrides — typically `asAdmin()` / `asMod()` style methods — silently fatal at runtime after the v2 upgrade because `patchData()` no longer exists.

## Change

- Add a `RenameMethodRector` entry mapping `BaseFactory::patchData` → `state` next to the other rename rules.
- Mention the rename in the migration-helpers bullet list and add a before/after diff for a typical `asAdmin()` factory helper.
- Add a Rector fixture (`patch_data_to_state.php.inc`) covering a factory helper that wraps `patchData()`, asserting the rewrite preserves the rest of the body.

## Verified

`vendor/bin/phpunit tests/TestCase/Rector/FactoryMigrationRectorTest.php` runs the fixtures via the existing test class. Locally the suite skips on incompatible tokenizer/parser stacks (same as the other Rector fixtures), so CI is the authoritative signal.
