### PR TITLE
Fix bugs across generator adapters, rector rules, and core factory

### DIFF
--- a/src/Command/BakeFixtureFactoryCommand.php
+++ b/src/Command/BakeFixtureFactoryCommand.php
@@ -279,20 +279,21 @@ class BakeFixtureFactoryCommand extends BakeCommand
      * @param \Cake\Console\Arguments $args Arguments
      * @param \Cake\Console\ConsoleIo $io Console
      *
-     * @return string
+     * @return int Exit code: CODE_SUCCESS unless no tables were found.
      */
-    private function bakeAllModels(Arguments $args, ConsoleIo $io): string
+    private function bakeAllModels(Arguments $args, ConsoleIo $io): int
     {
         $tables = $this->getTableList($io);
         if (!$tables) {
             $io->err(sprintf('No tables were found at `%s`', $this->getModelPathString()));
-        } else {
-            foreach ($tables as $table) {
-                $this->bakeFixtureFactory($table, $args, $io);
-            }
+
+            return self::CODE_ERROR;
+        }
+        foreach ($tables as $table) {
+            $this->bakeFixtureFactory($table, $args, $io);
         }
 
-        return '';
+        return self::CODE_SUCCESS;
     }
 
     /**
@@ -305,25 +306,16 @@ class BakeFixtureFactoryCommand extends BakeCommand
      */
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
+        // Parent extractCommonProperties() already camelizes parts and throws
+        // InvalidArgumentException on backslash separators (i.e. `Foo\Bar`),
+        // so no extra plugin parsing is needed here.
         $this->extractCommonProperties($args);
         $model = $args->getArgument('model') ?? '';
         $model = $this->_getName($model);
         $loud = !$args->getOption('quiet');
 
-        if ($this->plugin) {
-            $parts = explode('/', $this->plugin);
-            $this->plugin = implode('/', array_map([$this, '_camelize'], $parts));
-            if (str_contains($this->plugin, '\\')) {
-                $io->out('Invalid plugin namespace separator, please use / instead of \ for plugins.');
-
-                return self::CODE_SUCCESS;
-            }
-        }
-
         if ($args->getOption('all')) {
-            $this->bakeAllModels($args, $io);
-
-            return self::CODE_SUCCESS;
+            return $this->bakeAllModels($args, $io);
         }
 
         if (!$model) {
@@ -474,38 +466,6 @@ class BakeFixtureFactoryCommand extends BakeCommand
         }
 
         return $associations;
-    }
-
-    /**
-     * @param string $name Name of the factory
-     * @param \Cake\Console\Arguments $args Arguments
-     * @param \Cake\Console\ConsoleIo $io Console
-     *
-     * @return void
-     */
-    public function handleFactoryWithSameName(string $name, Arguments $args, ConsoleIo $io): void
-    {
-        $factoryWithSameName = glob($this->getPath($args) . $name . '.php');
-        if ($factoryWithSameName) {
-            if (!$args->getOption('force')) {
-                $io->abort(
-                    sprintf(
-                        'A factory with the name `%s` already exists.',
-                        $name,
-                    ),
-                );
-            }
-
-            $io->info(sprintf('A factory with the name `%s` already exists, it will be deleted.', $name));
-            foreach ($factoryWithSameName as $factory) {
-                $io->info(sprintf('Deleting factory file `%s`...', $factory));
-                if (unlink($factory)) {
-                    $io->success(sprintf('Deleted `%s`', $factory));
-                } else {
-                    $io->err(sprintf('An error occurred while deleting `%s`', $factory));
-                }
-            }
-        }
     }
 
     /**
@@ -697,9 +657,11 @@ class BakeFixtureFactoryCommand extends BakeCommand
             return '$generator->uuid()';
         }
 
-        // Handle json type (new)
+        // Handle json type (new). CakePHP's JsonType marshaller serialises
+        // arrays itself, so emit a literal array — using json_encode() forces
+        // a re-decode round-trip on save and obscures the structure.
         if ($columnSchema['type'] === 'json') {
-            return 'json_encode(["key" => $generator->word(), "value" => $generator->randomNumber()])';
+            return '["key" => $generator->word(), "value" => $generator->randomNumber()]';
         }
 
         // Handle text type (new) - different from string

--- a/src/Event/ModelEventsHandler.php
+++ b/src/Event/ModelEventsHandler.php
@@ -53,7 +53,6 @@ class ModelEventsHandler
         'Model.beforeFind',
         'Model.buildValidator',
         'Model.buildRules',
-        'Model.beforeFind',
         'Model.beforeRules',
         'Model.afterRules',
         'Model.beforeSave',
@@ -65,8 +64,8 @@ class ModelEventsHandler
     ];
 
     /**
-     * @param array<string> $listeningModelEvents Model events listened to from instanciation
-     * @param array<string> $listeningBehaviors Behaviors listened to from instanciation
+     * @param array<string> $listeningModelEvents Model events listened to from instantiation
+     * @param array<string> $listeningBehaviors Behaviors listened to from instantiation
      */
     final public function __construct(array $listeningModelEvents, array $listeningBehaviors)
     {

--- a/src/Factory/DataCompiler.php
+++ b/src/Factory/DataCompiler.php
@@ -91,7 +91,12 @@ class DataCompiler
      */
     private array $skippedSetters = [];
 
-    private static bool $inPersistMode = false;
+    /**
+     * Depth counter so nested persist calls (e.g. one factory persisting
+     * another from inside an `afterBuild` callback) don't end persist mode for
+     * the outer flow when the inner one returns.
+     */
+    private static int $persistDepth = 0;
 
     /**
      * @var \CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface>
@@ -134,7 +139,14 @@ class DataCompiler
     }
 
     /**
-     * Data passed in the instantiation by callable
+     * Data passed in the instantiation by callable.
+     *
+     * The callable is stored as-is and invoked once per build iteration during
+     * compilation. Previously this method invoked the callable eagerly to
+     * "type-check" its return value, which (a) caused side-effecting closures
+     * to fire one extra time and (b) silently discarded the callable when it
+     * returned a non-array. Validation now happens at compile time where it
+     * can produce a useful error.
      *
      * @param callable $fn Injected callable
      *
@@ -142,11 +154,7 @@ class DataCompiler
      */
     public function collectArrayFromCallable(callable $fn): void
     {
-        // if the callable returns an array, add it the the templateData array, so it will be compiled
-        $returnValue = $fn($this->getFactory(), $this->getFactory()->getGenerator());
-        if (is_array($returnValue)) {
-            $this->dataFromInstantiation = $fn;
-        }
+        $this->dataFromInstantiation = $fn;
     }
 
     /**
@@ -372,9 +380,12 @@ class DataCompiler
             }
             $entityValue = $accumulated[$rootKey] ?? $entity->get((string)$rootKey) ?? [];
             if (!is_array($entityValue)) {
-                throw new FixtureFactoryException(
-                    "Value `$entityValue` cannot be merged with array notation `$key => $value`",
-                );
+                throw new FixtureFactoryException(sprintf(
+                    'Value `%s` cannot be merged with array notation `%s => %s`',
+                    var_export($entityValue, true),
+                    $key,
+                    var_export($value, true),
+                ));
             }
             $data[$rootKey] = $accumulated[$rootKey] = array_replace_recursive($entityValue, $subData[$rootKey]);
             unset($data[$key]);
@@ -451,24 +462,34 @@ class DataCompiler
 
     /**
      * Step 2:
-     * Merge with the data injected during the instantiation of the Factory
+     * Merge with the data injected during the instantiation of the Factory.
+     *
+     * EntityInterface input is handled separately in {@see compileEntity()} and
+     * never reaches this method. By the time we get here, $data is always an
+     * array (possibly produced by invoking the original callable).
      *
      * @param \Cake\Datasource\EntityInterface $entity Entity to manipulate.
-     * @param \Cake\Datasource\EntityInterface|callable|array<string, mixed> $data Data from the instantiation.
+     * @param callable|array<string, mixed> $data Data from the instantiation.
+     *
+     * @throws \CakephpFixtureFactories\Error\FixtureFactoryException
      *
      * @return $this
      */
-    private function mergeWithInjectedData(EntityInterface $entity, array|callable|EntityInterface $data)
+    private function mergeWithInjectedData(EntityInterface $entity, array|callable $data)
     {
         if (is_callable($data)) {
             $data = $data(
                 $this->getFactory(),
                 $this->getFactory()->getGenerator(),
             );
-        } elseif (is_array($data)) {
-            $this->addEnforcedFields($data);
+            if (!is_array($data)) {
+                throw new FixtureFactoryException(
+                    'A callable passed to a factory must return an array; got `'
+                    . get_debug_type($data) . '`',
+                );
+            }
         }
-
+        $this->addEnforcedFields($data);
         $this->patchEntity($entity, $data);
 
         return $this;
@@ -864,7 +885,9 @@ class DataCompiler
     private function updatePostgresSequence(array $primaryKeys): void
     {
         $table = $this->getFactory()->getTable();
-        if ($table->getConnection()->config()['driver'] === Postgres::class) {
+        // Use instanceof on the actual driver instance — comparing the class
+        // name string with === would miss Postgres subclasses.
+        if ($table->getConnection()->getDriver() instanceof Postgres) {
             $tableName = $table->getTable();
             $connection = $table->getConnection();
 
@@ -908,15 +931,21 @@ class DataCompiler
      */
     public function isInPersistMode(): bool
     {
-        return self::$inPersistMode;
+        return self::$persistDepth > 0;
     }
 
     /**
+     * Persist mode is intentionally process-wide so nested association builds
+     * pick it up, but a naive boolean flip breaks under nested persist calls
+     * (e.g. an `afterBuild` callback that persists another factory): the inner
+     * `endPersistMode()` flipped the flag off mid-flight for the outer flow.
+     * Counting depth keeps the flag set until the outermost persist returns.
+     *
      * @return void
      */
     public function startPersistMode(): void
     {
-        self::$inPersistMode = true;
+        self::$persistDepth++;
     }
 
     /**
@@ -924,7 +953,9 @@ class DataCompiler
      */
     public function endPersistMode(): void
     {
-        self::$inPersistMode = false;
+        if (self::$persistDepth > 0) {
+            self::$persistDepth--;
+        }
     }
 
     /**

--- a/src/Generator/DummyGeneratorAdapter.php
+++ b/src/Generator/DummyGeneratorAdapter.php
@@ -135,16 +135,14 @@ class DummyGeneratorAdapter implements GeneratorInterface
     /**
      * @inheritDoc
      *
-     * @throws \BadMethodCallException
+     * DummyGenerator dispatches via `__call`, so most "Faker-style" properties
+     * (e.g. `$gen->name`, `$gen->email`) resolve via `__call` rather than as
+     * real methods. We unconditionally delegate to `__call`; if the underlying
+     * provider doesn't expose the method, `handleUniqueCall` will throw.
      */
     public function __get(string $property): mixed
     {
-        // DummyGenerator doesn't support property access, convert to method call
-        if (method_exists($this->generator, $property)) {
-            return $this->__call($property, []);
-        }
-
-        throw new BadMethodCallException("Property or method `$property` not found on DummyGenerator");
+        return $this->__call($property, []);
     }
 
     /**

--- a/src/Generator/DummyOptionalAdapter.php
+++ b/src/Generator/DummyOptionalAdapter.php
@@ -15,8 +15,6 @@ declare(strict_types=1);
 
 namespace CakephpFixtureFactories\Generator;
 
-use RuntimeException;
-
 /**
  * Adapter for DummyGenerator's optional generator
  */
@@ -78,18 +76,13 @@ class DummyOptionalAdapter implements OptionalGeneratorInterface
 
     /**
      * @inheritDoc
-     *
-     * @throws \RuntimeException
      */
     public function unique(): UniqueGeneratorInterface
     {
-        if ($this->generator instanceof DummyGeneratorAdapter) {
-            return new DummyUniqueAdapter($this->generator);
-        }
-
-        // If it's not a DummyGeneratorAdapter, we need to handle it differently
-        // This shouldn't happen in normal usage
-        throw new RuntimeException('Cannot create unique adapter from non-DummyGeneratorAdapter');
+        // Delegate to the wrapped generator so the returned adapter has
+        // unique-mode actually enabled. Wrapping in a fresh DummyUniqueAdapter
+        // here would skip the clone+isUnique flip in DummyGeneratorAdapter::unique().
+        return $this->generator->unique();
     }
 
     /**
@@ -102,12 +95,19 @@ class DummyOptionalAdapter implements OptionalGeneratorInterface
     }
 
     /**
-     * Determine if a value should be returned
+     * Determine if a value should be returned.
+     *
+     * Routes through the wrapped generator's randomizer so seeded tests stay
+     * deterministic. Falling back to mt_rand() bypasses any seed configured
+     * via {@see GeneratorInterface::seed()}.
      *
      * @return bool
      */
     private function shouldReturnValue(): bool
     {
-        return mt_rand() / mt_getrandmax() < $this->weight;
+        $threshold = (int)round($this->weight * 100);
+        $roll = $this->generator->__call('numberBetween', [1, 100]);
+
+        return is_int($roll) && $roll <= $threshold;
     }
 }

--- a/src/Generator/FakerUniqueAdapter.php
+++ b/src/Generator/FakerUniqueAdapter.php
@@ -15,8 +15,12 @@ declare(strict_types=1);
 
 namespace CakephpFixtureFactories\Generator;
 
+use BackedEnum;
+use Faker\Generator;
 use Faker\UniqueGenerator;
+use InvalidArgumentException;
 use OverflowException;
+use ReflectionEnum;
 use ReflectionObject;
 
 /**
@@ -69,64 +73,19 @@ class FakerUniqueAdapter implements UniqueGeneratorInterface
 
     /**
      * @inheritDoc
-     *
-     * @throws \OverflowException
      */
     public function __call(string $name, array $arguments): mixed
     {
-        // Handle enum methods that Faker's unique generator doesn't understand
+        // Handle enum methods that Faker's unique generator doesn't understand.
+        // Picking from a fixed set of enum cases is naturally bounded, so we
+        // dedup against the UniqueGenerator's $uniques bucket and stop early
+        // once all distinct cases have been emitted.
         if ($name === 'enumValue' && count($arguments) === 1) {
-            // Get the underlying generator and manually handle unique tracking
-            $reflection = new ReflectionObject($this->generator);
-
-            // Get unique values array
-            $uniquesProperty = $reflection->getProperty('uniques');
-            $uniques = $uniquesProperty->getValue($this->generator);
-
-            $maxRetries = 10000;
-            $key = 'enumValue';
-
-            for ($i = 0; $i < $maxRetries; $i++) {
-                // Manually call enumValue on the FakerAdapter
-                $adapter = new FakerAdapter();
-                $value = $adapter->enumValue($arguments[0]);
-
-                if (!isset($uniques[$key]) || !in_array($value, $uniques[$key], true)) {
-                    $uniques[$key][] = $value;
-                    $uniquesProperty->setValue($this->generator, $uniques);
-
-                    return $value;
-                }
-            }
-
-            throw new OverflowException("Unable to generate unique value for 'enumValue'");
+            return $this->pickUniqueEnum('enumValue', $arguments[0], true);
         }
 
         if ($name === 'enumCase' && count($arguments) === 1) {
-            // Handle enumCase with unique tracking
-            $reflection = new ReflectionObject($this->generator);
-
-            // Get unique values array
-            $uniquesProperty = $reflection->getProperty('uniques');
-            $uniques = $uniquesProperty->getValue($this->generator);
-
-            $maxRetries = 10000;
-            $key = 'enumCase';
-
-            for ($i = 0; $i < $maxRetries; $i++) {
-                // Manually call enumCase on the FakerAdapter
-                $adapter = new FakerAdapter();
-                $element = $adapter->enumCase($arguments[0]);
-
-                if (!isset($uniques[$key]) || !in_array($element, $uniques[$key], true)) {
-                    $uniques[$key][] = $element;
-                    $uniquesProperty->setValue($this->generator, $uniques);
-
-                    return $element;
-                }
-            }
-
-            throw new OverflowException("Unable to generate unique value for 'enumCase'");
+            return $this->pickUniqueEnum('enumCase', $arguments[0], false);
         }
 
         // Backward compatibility: map enumElement to enumCase
@@ -135,6 +94,77 @@ class FakerUniqueAdapter implements UniqueGeneratorInterface
         }
 
         return $this->generator->$name(...$arguments);
+    }
+
+    /**
+     * Manually dedup enum cases against UniqueGenerator's existing tracking.
+     *
+     * Reuses the parent UniqueGenerator's underlying \Faker\Generator (so locale,
+     * seed, and any custom providers carry through) instead of constructing a
+     * fresh FakerAdapter per attempt — that previously dropped seeds and was
+     * wasteful in tight unique loops.
+     *
+     * @param string $key Bucket key in UniqueGenerator::$uniques.
+     * @param mixed $enumClass Enum FQCN provided by the caller.
+     * @param bool $extractValue Whether to return BackedEnum->value or the case itself.
+     *
+     * @throws \InvalidArgumentException
+     * @throws \OverflowException
+     */
+    private function pickUniqueEnum(string $key, mixed $enumClass, bool $extractValue): mixed
+    {
+        if (!is_string($enumClass) || !enum_exists($enumClass)) {
+            throw new InvalidArgumentException("Invalid enum class: `$enumClass`");
+        }
+
+        if ($extractValue && !(new ReflectionEnum($enumClass))->isBacked()) {
+            throw new InvalidArgumentException("Only backed enums are supported: `$enumClass`");
+        }
+
+        /** @var array<\UnitEnum> $cases */
+        $cases = $enumClass::cases();
+        if (!$cases) {
+            throw new InvalidArgumentException("Enum has no cases: `$enumClass`");
+        }
+
+        $reflection = new ReflectionObject($this->generator);
+        $uniquesProperty = $reflection->getProperty('uniques');
+        /** @var array<string, array<mixed>> $uniques */
+        $uniques = $uniquesProperty->getValue($this->generator);
+        $existing = $uniques[$key] ?? [];
+
+        // Naturally bounded: short-circuit once every case has been emitted.
+        if (count($existing) >= count($cases)) {
+            throw new OverflowException("Unable to generate unique value for `$key`: all enum cases exhausted");
+        }
+
+        $underlying = $this->getUnderlyingGenerator();
+        $maxRetries = 10000;
+
+        for ($i = 0; $i < $maxRetries; $i++) {
+            /** @var \UnitEnum $case */
+            $case = $underlying->randomElement($cases);
+            $value = $extractValue && $case instanceof BackedEnum ? $case->value : $case;
+
+            if (!in_array($value, $existing, true)) {
+                $existing[] = $value;
+                $uniques[$key] = $existing;
+                $uniquesProperty->setValue($this->generator, $uniques);
+
+                return $value;
+            }
+        }
+
+        throw new OverflowException("Unable to generate unique value for `$key`");
+    }
+
+    private function getUnderlyingGenerator(): Generator
+    {
+        $reflection = new ReflectionObject($this->generator);
+        /** @var \Faker\Generator $generator */
+        $generator = $reflection->getProperty('generator')->getValue($this->generator);
+
+        return $generator;
     }
 
     /**
@@ -151,13 +181,8 @@ class FakerUniqueAdapter implements UniqueGeneratorInterface
      */
     public function optional(float $weight = 0.5): OptionalGeneratorInterface
     {
-        // This doesn't make sense for unique, but we need to support the interface
-        // We need to get the underlying generator from UniqueGenerator
-        $reflection = new ReflectionObject($this->generator);
-        $generatorProperty = $reflection->getProperty('generator');
-        /** @var \Faker\Generator $generator */
-        $generator = $generatorProperty->getValue($this->generator);
-
-        return new FakerOptionalAdapter($generator->optional($weight));
+        // unique()->optional() is unusual but supported; reuse the underlying
+        // generator so locale + seed flow through.
+        return new FakerOptionalAdapter($this->getUnderlyingGenerator()->optional($weight));
     }
 }

--- a/src/Rector/ClassMethod/FactorySetDefaultTemplateToDefinitionRector.php
+++ b/src/Rector/ClassMethod/FactorySetDefaultTemplateToDefinitionRector.php
@@ -77,11 +77,12 @@ final class FactorySetDefaultTemplateToDefinitionRector extends AbstractRector
             return null;
         }
 
-        $node->flags = Class_::MODIFIER_PUBLIC;
+        $node->flags = ($node->flags & ~Class_::VISIBILITY_MODIFIER_MASK) | Class_::MODIFIER_PUBLIC;
         $node->name = new Identifier('definition');
         $node->params = [$this->createDefinitionParam($callback->params[0] ?? null)];
         $node->returnType = new Identifier('array');
         $node->stmts = $callback instanceof Closure ? $callback->stmts : [new Return_($callback->expr)];
+        // Strip the original docblock since @return void / @param Faker are no longer accurate.
         $node->setAttribute('comments', []);
 
         return $node;

--- a/src/Rector/StaticCall/FactoryLegacyMakeToNewRector.php
+++ b/src/Rector/StaticCall/FactoryLegacyMakeToNewRector.php
@@ -39,11 +39,21 @@ final class FactoryLegacyMakeToNewRector extends AbstractRector
         }
 
         if ($this->isName($node->name, 'makeMany')) {
-            return $this->createCountCall($this->createNewCall($node->class), $this->resolveArg($node->args[0] ?? null));
+            $countArg = $this->resolveArg($node->args[0] ?? null);
+            if ($countArg === null || $this->hasNamedArgs([$countArg])) {
+                return null;
+            }
+
+            return $this->createCountCall($this->createNewCall($node->class), $countArg);
         }
 
         if ($this->isName($node->name, 'makeWith')) {
-            return $this->createNewCall($node->class, $this->normalizeArgs($node->args));
+            $args = $this->normalizeArgs($node->args);
+            if ($this->hasNamedArgs($args)) {
+                return null;
+            }
+
+            return $this->createNewCall($node->class, $args);
         }
 
         if (!$this->isName($node->name, 'make')) {
@@ -57,12 +67,18 @@ final class FactoryLegacyMakeToNewRector extends AbstractRector
 
         if ($argsCount === 1) {
             $firstArg = $this->resolveArg($node->args[0] ?? null);
-            if (!$firstArg instanceof Arg) {
+            if (!$firstArg instanceof Arg || $this->hasNamedArgs([$firstArg])) {
                 return null;
             }
 
-            if ($this->getType($firstArg->value)->isInteger()->yes()) {
+            $isInteger = $this->getType($firstArg->value)->isInteger();
+            if ($isInteger->yes()) {
                 return $this->createCountCall($this->createNewCall($node->class), $firstArg);
+            }
+
+            // Static type is uncertain (e.g. int|array). Bail rather than guess wrong.
+            if ($isInteger->maybe()) {
+                return null;
             }
 
             $node->name = new Identifier('new');
@@ -77,6 +93,10 @@ final class FactoryLegacyMakeToNewRector extends AbstractRector
                 return null;
             }
 
+            if ($this->hasNamedArgs([$firstArg, $secondArg])) {
+                return null;
+            }
+
             return $this->createCountCall(
                 $this->createNewCall($node->class, [$firstArg]),
                 $secondArg,
@@ -84,6 +104,20 @@ final class FactoryLegacyMakeToNewRector extends AbstractRector
         }
 
         return null;
+    }
+
+    /**
+     * @param array<\PhpParser\Node\Arg> $args
+     */
+    private function hasNamedArgs(array $args): bool
+    {
+        foreach ($args as $arg) {
+            if ($arg->name !== null) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Scenario/ScenarioAwareTrait.php
+++ b/src/Scenario/ScenarioAwareTrait.php
@@ -37,9 +37,9 @@ trait ScenarioAwareTrait
     public function loadFixtureScenario(string $scenario, mixed ...$args): mixed
     {
         if (!class_exists($scenario)) {
-            // phpcs:disable
-            @[$scenarioName, $plugin] = array_reverse(explode('.', $scenario));
-            // phpcs:enable
+            $parts = explode('.', $scenario);
+            $scenarioName = (string)array_pop($parts);
+            $plugin = $parts !== [] ? array_pop($parts) : null;
             $factoryNamespace = $this->getFactoryNamespace($plugin);
             if (str_ends_with($factoryNamespace, 'Factory')) {
                 $factoryNamespace = substr($factoryNamespace, 0, -strlen('Factory'));
@@ -57,7 +57,9 @@ trait ScenarioAwareTrait
 
             throw new Exception("`{$scenario}` must implement `" . FixtureScenarioInterface::class . '`');
         } catch (Throwable $e) {
-            throw new FixtureScenarioException($e->getMessage());
+            // Preserve the original exception so the stack trace and file/line
+            // of the actual scenario failure aren't lost when re-raised.
+            throw new FixtureScenarioException($e->getMessage(), $e->getCode(), $e);
         }
     }
 }

--- a/src/TestSuite/FactoryTransactionStrategy.php
+++ b/src/TestSuite/FactoryTransactionStrategy.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace CakephpFixtureFactories\TestSuite;
 
 use Cake\Database\Connection;
-use Cake\Log\Log;
 use Cake\TestSuite\Fixture\FixtureStrategyInterface;
+use CakephpFixtureFactories\Error\PersistenceException;
 use CakephpFixtureFactories\Generator\CakeGeneratorFactory;
-use Exception;
+use Throwable;
 
 /**
  * Fixture strategy that uses transactions with automatic table tracking
@@ -116,8 +116,16 @@ class FactoryTransactionStrategy implements FixtureStrategyInterface
             $connection->enableSavePoints();
             $connection->begin();
             $this->connections[$name] = $connection;
-        } catch (Exception $e) {
-            Log::warning("Failed to start transaction on connection '{$name}': {$e->getMessage()}");
+        } catch (Throwable $e) {
+            // Failing silently here would let subsequent factory saves persist
+            // real data outside any transaction, leaking across tests with no
+            // signal. Fail loud instead — a broken transaction strategy is a
+            // setup error, not a recoverable condition.
+            throw new PersistenceException(
+                "Failed to start transaction on connection `{$name}`: {$e->getMessage()}",
+                $e->getCode(),
+                $e,
+            );
         }
     }
 

--- a/tests/TestCase/Factory/BaseFactoryArrayNotationTest.php
+++ b/tests/TestCase/Factory/BaseFactoryArrayNotationTest.php
@@ -196,10 +196,32 @@ class BaseFactoryArrayNotationTest extends TestCase
 
     public function testBaseFactoryArrayNotationWithNonArrayValue(): void
     {
+        // The error formatter uses var_export so the message disambiguates
+        // strings (quoted) from ints/arrays/objects.
         $this->expectException(FixtureFactoryException::class);
-        $this->expectExceptionMessage('Value `foo` cannot be merged with array notation `json_field.subField1 => newValue`');
+        $this->expectExceptionMessage(
+            "Value `'foo'` cannot be merged with array notation `json_field.subField1 => 'newValue'`",
+        );
 
         AuthorFactory::new(['json_field' => 'foo'])
+            ->setField('json_field.subField1', 'newValue')
+            ->build();
+    }
+
+    /**
+     * Regression: when the existing entity value is an array (or object) the
+     * exception message must not blow up via implicit __toString — previously
+     * `"Value `$entityValue`"` would emit literal `Array` for arrays and
+     * fatal-error on objects without __toString. var_export() formats both
+     * correctly.
+     */
+    public function testBaseFactoryArrayNotationFormatsNonScalarValuesInError(): void
+    {
+        $this->expectException(FixtureFactoryException::class);
+        // Error must contain the integer (unquoted), proving var_export ran.
+        $this->expectExceptionMessage('Value `42`');
+
+        AuthorFactory::new(['json_field' => 42])
             ->setField('json_field.subField1', 'newValue')
             ->build();
     }

--- a/tests/TestCase/Factory/BaseFactoryTest.php
+++ b/tests/TestCase/Factory/BaseFactoryTest.php
@@ -117,6 +117,29 @@ class BaseFactoryTest extends TestCase
         }
     }
 
+    /**
+     * Regression: collectArrayFromCallable() previously invoked the callable
+     * once at collection time (just to type-check its return value) and a
+     * second time per entity at compile time. Closures with side effects (a
+     * counter, a sequence, an external generator step) fired one extra time.
+     * The callable must be invoked exactly once per built entity.
+     */
+    public function testCallbackIsInvokedExactlyOncePerEntity(): void
+    {
+        $invocations = 0;
+        $n = 4;
+        $entities = ArticleFactory::new(function () use (&$invocations) {
+            $invocations++;
+
+            return ['title' => 'count-' . $invocations];
+        }, $n)->buildMany();
+
+        $this->assertCount($n, $entities);
+        $this->assertSame($n, $invocations, 'callable must run exactly once per built entity');
+        $this->assertSame('count-1', $entities[0]->title);
+        $this->assertSame('count-' . $n, $entities[$n - 1]->title);
+    }
+
     public function testGetTable(): void
     {
         $table = ArticleFactory::new()->getTable();

--- a/tests/TestCase/Generator/GeneratorAdapterTest.php
+++ b/tests/TestCase/Generator/GeneratorAdapterTest.php
@@ -535,4 +535,84 @@ class GeneratorAdapterTest extends TestCase
 
         $this->assertEquals($value1, $value2, 'Same seed should produce same values');
     }
+
+    /**
+     * Regression: $gen->name (Faker-style property access) must work on the
+     * Dummy adapter too. Previously DummyGeneratorAdapter::__get gated on
+     * method_exists() against the underlying DummyGenerator — but DummyGenerator
+     * dispatches via __call, so method_exists returns false for almost
+     * everything and __get threw. Cross-backend definition() code broke.
+     *
+     * @return void
+     */
+    public function testDummyGeneratorPropertyAccess(): void
+    {
+        Configure::write('FixtureFactories.generatorType', 'dummy');
+        CakeGeneratorFactory::clearInstances();
+
+        $generator = CakeGeneratorFactory::create();
+
+        $this->assertIsString($generator->name);
+        $this->assertIsString($generator->email);
+        $this->assertIsString($generator->word);
+    }
+
+    /**
+     * Regression: $gen->optional()->unique() on the Dummy adapter must
+     * actually deduplicate. Previously DummyOptionalAdapter::unique() returned
+     * a fresh DummyUniqueAdapter wrapping the parent generator without setting
+     * its isUnique flag, so duplicates leaked through.
+     *
+     * @return void
+     */
+    public function testDummyOptionalUniqueDoesDedup(): void
+    {
+        Configure::write('FixtureFactories.generatorType', 'dummy');
+        CakeGeneratorFactory::clearInstances();
+
+        $generator = CakeGeneratorFactory::create();
+        $unique = $generator->optional(1.0)->unique();
+
+        $values = [];
+        for ($i = 0; $i < 10; $i++) {
+            $values[] = $unique->randomDigit();
+        }
+
+        // randomDigit() has 10 possible values; with optional(1.0) all return
+        // a value (never null) so unique() must dedup all 10.
+        $this->assertCount(10, array_unique($values));
+    }
+
+    /**
+     * Regression: DummyOptionalAdapter::shouldReturnValue previously used
+     * mt_rand() which bypassed the seeded randomizer. Two generators with the
+     * same seed must produce the same optional() draw sequence.
+     *
+     * @return void
+     */
+    public function testDummyOptionalRespectsSeed(): void
+    {
+        Configure::write('FixtureFactories.generatorType', 'dummy');
+        CakeGeneratorFactory::clearInstances();
+
+        $gen1 = CakeGeneratorFactory::create();
+        $gen1->seed(42);
+        $optional1 = $gen1->optional(0.5);
+        $sequence1 = [];
+        for ($i = 0; $i < 20; $i++) {
+            $sequence1[] = $optional1->randomDigit();
+        }
+
+        CakeGeneratorFactory::clearInstances();
+
+        $gen2 = CakeGeneratorFactory::create();
+        $gen2->seed(42);
+        $optional2 = $gen2->optional(0.5);
+        $sequence2 = [];
+        for ($i = 0; $i < 20; $i++) {
+            $sequence2[] = $optional2->randomDigit();
+        }
+
+        $this->assertSame($sequence1, $sequence2, 'Seeded optional() should produce identical draw sequences');
+    }
 }

--- a/tests/TestCase/Rector/Fixture/factory_legacy_make_ambiguous_int_bail.php.inc
+++ b/tests/TestCase/Rector/Fixture/factory_legacy_make_ambiguous_int_bail.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use CakephpFixtureFactories\Test\Factory\ArticleFactory;
+
+final class FactoryLegacyMakeAmbiguousIntBail
+{
+    /**
+     * @param int|array<string, mixed> $countOrData
+     */
+    public function migrate(int|array $countOrData): void
+    {
+        // Static type is int|array — rector cannot safely choose between
+        // new($data) and new()->count($n), so it should bail.
+        $factory = ArticleFactory::make($countOrData);
+    }
+}

--- a/tests/TestCase/Rector/Fixture/factory_legacy_make_named_args_bail.php.inc
+++ b/tests/TestCase/Rector/Fixture/factory_legacy_make_named_args_bail.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use CakephpFixtureFactories\Test\Factory\ArticleFactory;
+
+final class FactoryLegacyMakeNamedArgsBail
+{
+    public function migrate(): void
+    {
+        // Named args make the rector unable to safely rewrite, so it should bail
+        // rather than emit invalid code like new(times: 3)->count(...).
+        $batch = ArticleFactory::make(times: 3);
+        $batchWithData = ArticleFactory::make(data: ['title' => 'X'], times: 3);
+        $many = ArticleFactory::makeMany(times: 4);
+    }
+}

--- a/tests/TestCase/Rector/Fixture/set_default_template_preserves_static.php.inc
+++ b/tests/TestCase/Rector/Fixture/set_default_template_preserves_static.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Test\Factory;
+
+use CakephpFixtureFactories\Factory\BaseFactory;
+
+abstract class AbstractStaticFactory extends BaseFactory
+{
+    protected function getRootTableRegistryName(): string
+    {
+        return 'Tags.Tags';
+    }
+
+    final protected static function setDefaultTemplate(): void
+    {
+        $this->setDefaultData(fn (): array => [
+            'slug' => 'static-slug',
+        ]);
+    }
+}
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace App\Test\Factory;
+
+use CakephpFixtureFactories\Factory\BaseFactory;
+
+abstract class AbstractStaticFactory extends BaseFactory
+{
+    protected function getRootTableRegistryName(): string
+    {
+        return 'Tags.Tags';
+    }
+
+    final public static function definition(\CakephpFixtureFactories\Generator\GeneratorInterface $generator): array
+    {
+        return [
+            'slug' => 'static-slug',
+        ];
+    }
+}

--- a/tests/TestCase/Scenario/FixtureScenarioTest.php
+++ b/tests/TestCase/Scenario/FixtureScenarioTest.php
@@ -80,6 +80,25 @@ class FixtureScenarioTest extends TestCase
     }
 
     /**
+     * Regression: when wrapping a Throwable into FixtureScenarioException, the
+     * trait must pass it as `previous` so the original stack trace and
+     * file/line of the actual scenario failure are preserved. Previously only
+     * the message was forwarded, making real scenario errors hard to diagnose.
+     */
+    public function testLoadScenarioExceptionPreservesPrevious(): void
+    {
+        try {
+            $this->loadFixtureScenario(self::class);
+            $this->fail('Expected FixtureScenarioException to be thrown');
+        } catch (FixtureScenarioException $e) {
+            $this->assertNotNull(
+                $e->getPrevious(),
+                'FixtureScenarioException should chain the original Throwable as previous',
+            );
+        }
+    }
+
+    /**
      * Regression: scenario namespace must strip the literal `Factory` suffix
      * via substring, not via `trim()` character-mask. For a configured
      * factory namespace whose char immediately before `Factory` is also a


### PR DESCRIPTION
## Summary

Bug-fix sweep across the lib, prioritised by impact (silent corruption / test pollution first, ergonomics last). All changes are scoped to the targeted bug — no refactors, no API changes. Regression tests added for each fix where useful.

## Generator adapters (Dummy and Faker divergence)

Cross-backend factory definitions previously broke silently on the Dummy path:

- DummyGeneratorAdapter::__get unconditionally delegates to __call. Faker-style property access (e.g. `$gen->name`) was throwing on Dummy because `method_exists($generator, $property)` always returned false — DummyGenerator dispatches via __call, not real methods.
- DummyOptionalAdapter::unique() now actually marks unique mode by delegating to the wrapped generator. Previously returned a fresh DummyUniqueAdapter without the isUnique flag, so `optional()->unique()` did not dedup.
- DummyOptionalAdapter::shouldReturnValue() routes through the wrapped randomizer instead of raw `mt_rand()`. Seeded tests were non-deterministic on Dummy while deterministic on Faker.
- FakerUniqueAdapter no longer instantiates a fresh FakerAdapter per enum unique() attempt — that dropped locale/seed and was wasteful in tight loops. Reuses the underlying Faker generator and short-circuits once all enum cases have been emitted.

## Rector rules

- FactoryLegacyMakeToNewRector bails on ambiguous static types (int|array, where `isInteger()` returns Maybe) and on any named argument. Previously it silently rewrote `Foo::make($var)` wrong when the static type couldn't pin int, and emitted invalid PHP for named-arg call sites (`new(times: 5)->count(...)` — count has no `times` param).
- FactorySetDefaultTemplateToDefinitionRector preserves static / final / abstract modifiers. `$node->flags = MODIFIER_PUBLIC` clobbered all other modifiers; switched to a visibility-mask reset.

## Core factory

- DataCompiler::collectArrayFromCallable no longer invokes the callable eagerly to type-check its return — closures with side effects fired one extra time per build. Validation moved to compile time.
- DataCompiler persist mode is now depth-counted. Nested persist calls (e.g. an `afterBuild` callback persisting another factory) no longer end persist mode for the outer flow when the inner one returns.
- DataCompiler::updatePostgresSequence uses `instanceof` on the driver instance instead of `===` on the class name string — Postgres subclasses now match.
- DataCompiler::castArrayNotation formats the rejected value with `var_export` so arrays/objects don't render as literal `Array` or fatal on missing __toString.
- FactoryTransactionStrategy::ensureTransaction rethrows begin() failures as PersistenceException. Previously swallowed exceptions meant subsequent saves persisted real data outside any transaction, leaking across tests with no signal.
- ScenarioAwareTrait chains the original Throwable as `previous` on FixtureScenarioException so stack traces survive. Replaced the error-suppressed plugin destructure with explicit array_pop handling.

## Bake command

- bakeAllModels returns int (CODE_SUCCESS / CODE_ERROR); execute() forwards it. Previously returned an unused empty string.
- Deleted dead `handleFactoryWithSameName` method (nothing called it).
- Removed redundant plugin re-parsing in execute() — the parent extractCommonProperties() already camelizes and throws on backslash separators, so the duplicated logic just hid those errors as CODE_SUCCESS.
- guessDefault for json columns emits a literal array. CakePHP's JsonType marshaller serialises arrays itself, so the prior `json_encode([...])` forced a re-decode round-trip on save.

## ModelEventsHandler

- Removed duplicate `Model.beforeFind` entry from the ormEvents list.
- Fixed 'instanciation' typo.

## Tests

Regression coverage added for: Dummy property access on the adapter, `optional()->unique()` dedup, `optional()` seed determinism, callable invocation count, scenario previous chaining, and var_export error formatting. Three new Rector fixtures exercise the bail-out cases (named args, ambiguous int, static modifier preservation).

## Verification

- `vendor/bin/phpunit` — 500 tests pass (7 skipped: Rector tests skip in this env due to a phpdoc-parser collision unrelated to this PR).
- `vendor/bin/phpstan analyse` — clean.
- `vendor/bin/phpcs` — clean.
