### PR TITLE
Improve generator isolation and primary key randomness

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -38,9 +38,9 @@ return [
          *
          * Use setDefaultGenerator() to explicitly set the global default when this is enabled.
          *
-         * Default: false (setGenerator() affects all factories globally for BC)
+         * Default: true (setGenerator() is scoped to the current factory instance)
          */
-        // 'instanceLevelGenerator' => false,
+        // 'instanceLevelGenerator' => true,
 
         /**
          * Namespace where factory classes are located.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -13,7 +13,7 @@ return [
         'generatorType' => 'faker',
         'defaultLocale' => 'en_US',
         'seed' => 1234,
-        'instanceLevelGenerator' => false,
+        'instanceLevelGenerator' => true,
         'testFixtureNamespace' => 'App\\Test\\Factory',
         'testFixtureOutputDir' => 'Factory/',
         'testFixtureGlobalBehaviors' => [],
@@ -48,9 +48,9 @@ Seed for the generator's RNG. A fixed seed produces reproducible test data acros
 
 When `true`, `setGenerator()` only affects the current factory instance instead of globally changing the generator for all factories. Use `BaseFactory::setDefaultGenerator()` to set the global default explicitly.
 
-Default: `false` (BC — `setGenerator()` affects all factories globally).
+Default: `true` (`setGenerator()` only affects the current factory instance).
 
-> Recommended `true` for new projects to avoid surprising side effects when switching generators per-factory.
+> Set this to `false` only if you explicitly need the legacy global `setGenerator()` behavior.
 
 ### `testFixtureNamespace`
 

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -398,7 +398,7 @@ abstract class BaseFactory
         $generator = clone CakeGeneratorFactory::create($resolvedLocale, $type);
         $generator->seed(static::getGeneratorSeed());
 
-        if (Configure::read('FixtureFactories.instanceLevelGenerator', false)) {
+        if (Configure::read('FixtureFactories.instanceLevelGenerator', true)) {
             $factory = clone $this;
             $factory->instanceGenerator = $generator;
 

--- a/src/Factory/DataCompiler.php
+++ b/src/Factory/DataCompiler.php
@@ -820,13 +820,13 @@ class DataCompiler
     {
         return match ($columnType) {
             'uuid', 'string' => $this->getFactory()->getGenerator()->uuid(),
-            'tinyinteger' => mt_rand(0, 127),
-            'smallinteger' => mt_rand(0, 32767),
-            'mediuminteger' => mt_rand(0, 8388607),
+            'tinyinteger' => random_int(0, 127),
+            'smallinteger' => random_int(0, 32767),
+            'mediuminteger' => random_int(0, 8388607),
             // mt_rand() is capped at mt_getrandmax() (typically 2^31 - 1),
             // which silently truncates biginteger PKs to 32-bit range.
             'biginteger' => random_int(0, PHP_INT_MAX),
-            'integer' => mt_rand(0, 2147483647),
+            'integer' => random_int(0, 2147483647),
             default => throw new FixtureFactoryException(sprintf(
                 'Cannot generate a random primary key for column type `%s`. '
                 . 'Provide an explicit primary key offset via setPrimaryKeyOffset().',

--- a/tests/TestCase/Factory/DataCompilerTest.php
+++ b/tests/TestCase/Factory/DataCompilerTest.php
@@ -83,6 +83,14 @@ class DataCompilerTest extends TestCase
         $this->assertTrue(is_int($this->articleDataCompiler->generateRandomPrimaryKey('integer')));
     }
 
+    public function testGenerateRandomPrimaryKeyIntegerProducesDistinctValues(): void
+    {
+        $value1 = $this->articleDataCompiler->generateRandomPrimaryKey('integer');
+        $value2 = $this->articleDataCompiler->generateRandomPrimaryKey('integer');
+
+        $this->assertNotSame($value1, $value2);
+    }
+
     public function testGenerateRandomPrimaryKeyBigInteger(): void
     {
         $values = [];

--- a/tests/TestCase/Generator/GeneratorAdapterTest.php
+++ b/tests/TestCase/Generator/GeneratorAdapterTest.php
@@ -484,39 +484,35 @@ class GeneratorAdapterTest extends TestCase
     }
 
     /**
-     * Test that setGenerator affects all factories globally by default (BC)
+     * Test that setGenerator only affects the current factory instance by default
      *
      * @return void
      */
-    public function testSetGeneratorGlobalByDefault(): void
+    public function testSetGeneratorInstanceLevelByDefault(): void
     {
         $factory1 = ArticleFactory::new();
-        $factory1->setGenerator('dummy');
+        $factory1 = $factory1->setGenerator('dummy');
 
-        // A different factory instance should also get the dummy generator
         $factory2 = ArticleFactory::new();
 
-        // Both should return the same generator instance (global default)
-        $this->assertSame($factory1->getGenerator(), $factory2->getGenerator());
+        $this->assertNotSame($factory1->getGenerator(), $factory2->getGenerator());
     }
 
     /**
-     * Test that setGenerator only affects current instance when feature flag is enabled
+     * Test that legacy global behavior can still be enabled explicitly
      *
      * @return void
      */
-    public function testSetGeneratorInstanceLevel(): void
+    public function testSetGeneratorGlobalWhenConfigured(): void
     {
-        Configure::write('FixtureFactories.instanceLevelGenerator', true);
+        Configure::write('FixtureFactories.instanceLevelGenerator', false);
 
         $factory1 = ArticleFactory::new();
         $factory1 = $factory1->setGenerator('dummy');
 
         $factory2 = ArticleFactory::new();
 
-        // factory1 should have its own generator
-        // factory2 should fall back to the default (faker)
-        $this->assertNotSame($factory1->getGenerator(), $factory2->getGenerator());
+        $this->assertSame($factory1->getGenerator(), $factory2->getGenerator());
     }
 
     /**


### PR DESCRIPTION
## Summary
- make `setGenerator()` instance-scoped by default on `next`
- switch integer primary key generation to `random_int()`
- update docs/examples and add regression coverage for both behaviors

## Why
In the RentCraft test suite, the `next` branch upgrade exposed two areas that are worth tightening in v2:

1. `setGenerator()` still defaults to mutating the global generator state unless `FixtureFactories.instanceLevelGenerator` is enabled. On a major branch, defaulting to instance-level isolation is safer and better matches the documented recommendation.
2. integer primary keys generated for `disablePrimaryKeyOffset()` still rely on `mt_rand()`. Using `random_int()` consistently across integer PK types avoids depending on process-global RNG state and removes one source of surprising collisions.

## Verification
- `composer test -- --filter 'GeneratorAdapterTest|DataCompilerTest'`
- `composer test`
