### PR TITLE
Fix deep-dive contract bugs on next

### DIFF
--- a/docs/guide/factories.md
+++ b/docs/guide/factories.md
@@ -336,17 +336,17 @@ $article = ArticleFactory::new()
     ->build();
 ```
 
-By default, `setGenerator()` changes the generator globally for all factory instances (preserving the v1 default). The fluent return value reflects this — in global mode the call returns `$this`; in instance mode (below) it returns a clone scoped to the new generator.
+By default, `setGenerator()` only affects the current factory instance. It returns a clone scoped to the requested generator, leaving other factories on the shared default.
 
 #### Instance-Level Generators
 
-If you want `setGenerator()` to only affect the current factory instance, enable the instance-level generator flag:
+This is controlled by the instance-level generator flag, which defaults to `true`:
 
 ```php
 Configure::write('FixtureFactories.instanceLevelGenerator', true);
 ```
 
-With this enabled:
+With the default configuration:
 
 ```php
 $factory1 = ArticleFactory::new()->setGenerator('dummy');
@@ -355,7 +355,15 @@ $factory2 = ArticleFactory::new();
 // $factory1 uses DummyGenerator, $factory2 uses the default (Faker)
 ```
 
-To explicitly set the global default regardless of this flag, use the static method:
+If you explicitly need the legacy global behavior, disable the flag:
+
+```php
+Configure::write('FixtureFactories.instanceLevelGenerator', false);
+```
+
+Then `setGenerator()` updates the shared default for subsequent factories.
+
+To set the global default explicitly regardless of this flag, use the static method:
 
 ```php
 use CakephpFixtureFactories\Factory\BaseFactory;
@@ -363,7 +371,7 @@ use CakephpFixtureFactories\Factory\BaseFactory;
 BaseFactory::setDefaultGenerator('dummy');
 ```
 
-We recommend enabling `instanceLevelGenerator` in new projects to avoid surprising side effects when switching generators in individual factories.
+Keep `instanceLevelGenerator` enabled unless you deliberately want the legacy global `setGenerator()` behavior.
 
 #### Seeding
 

--- a/docs/guide/generators.md
+++ b/docs/guide/generators.md
@@ -117,9 +117,9 @@ $article = ArticleFactory::new()
     ->build();
 ```
 
-> **Note**: By default, `setGenerator()` changes the generator globally. Enable
-> `FixtureFactories.instanceLevelGenerator` to limit it to the current instance.
-> See [Fixture Factories](factories#instance-level-generators).
+> **Note**: By default, `setGenerator()` only affects the current factory
+> instance. Set `FixtureFactories.instanceLevelGenerator` to `false` if you need
+> the legacy global behavior. See [Fixture Factories](factories#instance-level-generators).
 
 ### Migration Guide: Faker → DummyGenerator
 
@@ -237,8 +237,9 @@ ArticleFactory::new()->setGenerator('dummy')->build();
 BaseFactory::setDefaultGenerator('dummy');
 ```
 
-> **Tip**: Enable `FixtureFactories.instanceLevelGenerator` so that `setGenerator()` only
-> affects the current factory instance. See [Fixture Factories](factories#instance-level-generators).
+> **Tip**: Leave `FixtureFactories.instanceLevelGenerator` enabled so that
+> `setGenerator()` stays scoped to the current factory instance. See
+> [Fixture Factories](factories#instance-level-generators).
 
 ### 3. Test with Both Generators (Optional)
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -89,7 +89,7 @@ Then re-run `bin/cake bake fixture_factory <Model> --force`.
 
 ## `setGenerator()` affects unrelated factories
 
-By default, `setGenerator()` changes the global default — any subsequent factory uses the new generator too. To scope it to one factory instance:
+This only happens if you disabled instance-level generators. Re-enable them to keep `setGenerator()` scoped to one factory instance:
 
 ```php
 Configure::write('FixtureFactories.instanceLevelGenerator', true);

--- a/src/Event/ModelEventsHandler.php
+++ b/src/Event/ModelEventsHandler.php
@@ -18,8 +18,10 @@ namespace CakephpFixtureFactories\Event;
 use Cake\ORM\Behavior;
 use Cake\ORM\Table;
 use CakephpFixtureFactories\Factory\EventCollector;
+use Closure;
 use ReflectionException;
 use ReflectionFunction;
+use TypeError;
 
 /**
  * Class ModelEventsHandler
@@ -110,12 +112,7 @@ class ModelEventsHandler
      */
     private function processListener(Table $table, mixed $listener, string $ormEvent): void
     {
-        try {
-            $reflection = new ReflectionFunction($listener);
-            $obj = $reflection->getClosureThis();
-        } catch (ReflectionException) {
-            $obj = null;
-        }
+        $obj = $this->extractListenerObject($listener);
 
         if ($obj !== null) {
             if ($obj instanceof Table) {
@@ -125,6 +122,29 @@ class ModelEventsHandler
             }
         } else {
             $table->getEventManager()->off($ormEvent, $listener);
+        }
+    }
+
+    /**
+     * @param mixed $listener Listener
+     *
+     * @return object|null
+     */
+    private function extractListenerObject(mixed $listener): ?object
+    {
+        if (is_array($listener) && isset($listener[0]) && is_object($listener[0])) {
+            return $listener[0];
+        }
+        if (is_object($listener) && !$listener instanceof Closure) {
+            return $listener;
+        }
+
+        try {
+            $reflection = new ReflectionFunction(Closure::fromCallable($listener));
+
+            return $reflection->getClosureThis();
+        } catch (ReflectionException | TypeError) {
+            return null;
         }
     }
 

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -210,9 +210,13 @@ abstract class BaseFactory
      */
     public static function new(mixed $makeParameter = [], int $times = 1): static
     {
-        if (is_int($makeParameter) || is_float($makeParameter)) {
+        if (is_int($makeParameter)) {
             $factory = self::makeFromNonCallable();
-            $times = (int)$makeParameter;
+            $times = $makeParameter;
+        } elseif (is_float($makeParameter)) {
+            throw new InvalidArgumentException(
+                '::new() only accepts an integer count as first parameter. Floats are not allowed; use ->count() with a positive integer.',
+            );
         } elseif ($makeParameter === null) {
             $factory = self::makeFromNonCallable();
         } elseif (is_array($makeParameter) || $makeParameter instanceof EntityInterface || is_string($makeParameter)) {
@@ -665,7 +669,7 @@ abstract class BaseFactory
         }
 
         $this->finalizePersistedEntities($saved, $table);
-        $this->replayAssociatedAfterSaveEvents($saved, $this);
+        $saved = $this->replayAssociatedAfterSaveEvents($saved, $this);
         $saved = $this->applyCallbacks($saved, $this->afterSaveCallbacks);
 
         return $saved;
@@ -721,43 +725,94 @@ abstract class BaseFactory
      *
      * @param array<\Cake\Datasource\EntityInterface> $entities
      * @param \CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface> $factory
+     * @param array<string, bool> $visited Replay guard
      *
-     * @return void
+     * @return array<\Cake\Datasource\EntityInterface>
      */
-    private function replayAssociatedAfterSaveEvents(array $entities, BaseFactory $factory): void
+    private function replayAssociatedAfterSaveEvents(array $entities, BaseFactory $factory, array &$visited = []): array
     {
         foreach ($factory->getAssociationBuilder()->getAssociations() as $associationName => $associationFactory) {
             $property = $factory->getAssociationBuilder()->getAssociation($associationName)->getProperty();
-            $associatedEntities = [];
-            foreach ($entities as $entity) {
+            foreach ($entities as $index => $entity) {
                 $value = $entity->get($property);
                 if ($value instanceof EntityInterface) {
-                    $associatedEntities[] = $value;
+                    $entity->set($property, $this->replayAssociatedAfterSaveForEntity($value, $associationFactory, $visited));
+                    $entity->setDirty($property, false);
+                    $entities[$index] = $entity;
 
                     continue;
                 }
                 if (!is_array($value)) {
                     continue;
                 }
+
+                $updated = [];
                 foreach ($value as $item) {
                     if ($item instanceof EntityInterface) {
-                        $associatedEntities[] = $item;
+                        $updated[] = $this->replayAssociatedAfterSaveForEntity($item, $associationFactory, $visited);
+                    } else {
+                        $updated[] = $item;
                     }
                 }
+                $entity->set($property, $updated);
+                $entity->setDirty($property, false);
+                $entities[$index] = $entity;
             }
-            if ($associatedEntities === []) {
-                continue;
-            }
-
-            $options = new ArrayObject(['associated' => true, 'atomic' => false]);
-            foreach ($associatedEntities as $entity) {
-                $associationFactory->getTable()->dispatchEvent('Model.afterSave', compact('entity', 'options'));
-            }
-            if ($associationFactory->afterSaveCallbacks !== []) {
-                $associationFactory->applyCallbacks($associatedEntities, $associationFactory->afterSaveCallbacks);
-            }
-            $this->replayAssociatedAfterSaveEvents($associatedEntities, $associationFactory);
         }
+
+        return $entities;
+    }
+
+    /**
+     * @param \Cake\Datasource\EntityInterface $entity Associated entity
+     * @param \CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface> $associationFactory Associated factory
+     * @param array<string, bool> $visited Replay guard
+     *
+     * @return \Cake\Datasource\EntityInterface
+     */
+    private function replayAssociatedAfterSaveForEntity(
+        EntityInterface $entity,
+        BaseFactory $associationFactory,
+        array &$visited,
+    ): EntityInterface {
+        $key = $this->buildAssociatedReplayKey($associationFactory, $entity);
+        if (isset($visited[$key])) {
+            return $entity;
+        }
+        $visited[$key] = true;
+
+        $options = new ArrayObject(['associated' => true, 'atomic' => false]);
+        $associationFactory->getTable()->dispatchEvent('Model.afterSave', compact('entity', 'options'));
+
+        $entities = [$entity];
+        if ($associationFactory->afterSaveCallbacks !== []) {
+            $entities = $associationFactory->applyCallbacks($entities, $associationFactory->afterSaveCallbacks);
+        }
+
+        $entities = $this->replayAssociatedAfterSaveEvents($entities, $associationFactory, $visited);
+
+        return $entities[0];
+    }
+
+    /**
+     * @param \CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface> $associationFactory Associated factory
+     * @param \Cake\Datasource\EntityInterface $entity Associated entity
+     *
+     * @return string
+     */
+    private function buildAssociatedReplayKey(BaseFactory $associationFactory, EntityInterface $entity): string
+    {
+        $primaryKey = (array)$associationFactory->getTable()->getPrimaryKey();
+        $primaryKeyValues = [];
+        foreach ($primaryKey as $field) {
+            $value = $entity->get($field);
+            if ($value === null) {
+                return spl_object_id($associationFactory) . ':object:' . spl_object_id($entity);
+            }
+            $primaryKeyValues[] = $value;
+        }
+
+        return spl_object_id($associationFactory) . ':pk:' . json_encode($primaryKeyValues, JSON_THROW_ON_ERROR);
     }
 
     /**

--- a/tests/TestApp/src/Model/Table/CountriesTable.php
+++ b/tests/TestApp/src/Model/Table/CountriesTable.php
@@ -61,4 +61,9 @@ class CountriesTable extends Table
     {
         $data['beforeMarshalTriggered'] = true;
     }
+
+    public function beforeMarshalArrayCallable(EventInterface $event, ArrayObject $data, ArrayObject $options): void
+    {
+        $data['beforeMarshalArrayCallableTriggered'] = true;
+    }
 }

--- a/tests/TestCase/Event/ModelEventsHandlerTest.php
+++ b/tests/TestCase/Event/ModelEventsHandlerTest.php
@@ -18,6 +18,7 @@ namespace CakephpFixtureFactories\Test\TestCase\Event;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use CakephpFixtureFactories\Event\ModelEventsHandler;
+use ReflectionMethod;
 
 /**
  * Class ModelEventsHandlerTest
@@ -51,6 +52,21 @@ class ModelEventsHandlerTest extends TestCase
         ModelEventsHandler::handle($Countries, ['Model.beforeMarshal']);
         $country = $Countries->newEntity(['name' => 'Foo']);
         $this->assertTrue($country->get('beforeMarshalTriggered'));
+    }
+
+    public function testBeforeMarshalArrayCallableOnTableIsNotRemovedWhenPermitted(): void
+    {
+        $Countries = TableRegistry::getTableLocator()->get('Countries');
+        $listener = [$Countries, 'beforeMarshalArrayCallable'];
+        $Countries->getEventManager()->on('Model.beforeMarshal', $listener);
+
+        $this->assertCount(2, $Countries->getEventManager()->listeners('Model.beforeMarshal'));
+
+        $method = new ReflectionMethod(ModelEventsHandler::class, 'processListener');
+        $method->setAccessible(true);
+        $method->invoke(new ModelEventsHandler(['Model.beforeMarshal'], []), $Countries, $listener, 'Model.beforeMarshal');
+
+        $this->assertCount(2, $Countries->getEventManager()->listeners('Model.beforeMarshal'));
     }
 
     public function testBeforeSaveInBehaviorOnTable(): void

--- a/tests/TestCase/Factory/BaseFactoryTest.php
+++ b/tests/TestCase/Factory/BaseFactoryTest.php
@@ -141,6 +141,14 @@ class BaseFactoryTest extends TestCase
         ArticleFactory::new([], -2);
     }
 
+    public function testNewRejectsFloatCount(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('::new() only accepts an integer count as first parameter');
+
+        ArticleFactory::new(1.9);
+    }
+
     public function testCountRejectsNonPositive(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -314,6 +322,22 @@ class BaseFactoryTest extends TestCase
         $this->assertSame(['child author'], $captured, 'child afterSave must run exactly once');
         $this->assertNotEmpty($article->authors);
         $this->assertSame('mutated by child afterSave', $article->authors[0]->name);
+    }
+
+    public function testAfterSaveOnChildFactoryCanReplaceEntityWhenSavedThroughParent(): void
+    {
+        $article = ArticleFactory::new(['title' => 'parent'])
+            ->with('Authors', AuthorFactory::new(['name' => 'child author'])
+                ->afterSave(static function (Author $author): Author {
+                    $replacement = clone $author;
+                    $replacement->set('name', 'replaced by child afterSave');
+
+                    return $replacement;
+                }))
+            ->save();
+
+        $this->assertNotEmpty($article->authors);
+        $this->assertSame('replaced by child afterSave', $article->authors[0]->name);
     }
 
     public function testMakeFromArrayMultipleWithMakeFromArray(): void


### PR DESCRIPTION
## Summary
- fix nested associated `afterSave()` replay so returned replacement entities are preserved and replay recursion is cycle-safe
- reject float counts in `BaseFactory::new()` and keep persisted parent entities clean during nested replay
- preserve table/behavior listeners that arrive as array-callable or object callables, and align `setGenerator()` docs with the actual instance-scoped default

## Verification
- `vendor/bin/phpunit`
- `composer stan -- --error-format=raw`
- `composer cs-check`