### PR TITLE
Add BaseFactory::sequenceField() for per-column cycles

### DIFF
--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -66,6 +66,39 @@ $articles = ArticleFactory::new()
     ->buildMany();
 ```
 
+When you only want to vary one column at a time, `sequenceField()` is the focused alternative. It accepts any value the column supports — scalars, arrays, enum cases, anything Cake's marshaller handles for that field:
+
+```php
+$articles = ArticleFactory::new()
+    ->count(4)
+    ->sequenceField('status', Status::Draft, Status::Published, Status::Archived)
+    ->buildMany();
+
+// or, equivalently, with an enum's ::cases():
+$articles = ArticleFactory::new()
+    ->count(4)
+    ->sequenceField('status', ...Status::cases())
+    ->buildMany();
+```
+
+`sequenceField()` calls **stack across different fields**: each column cycles independently at its own period, so two cycles with different lengths compose without interference.
+
+```php
+$articles = ArticleFactory::new()
+    ->count(6)
+    ->sequenceField('status', 'draft', 'published')   // 2-cycle
+    ->sequenceField('priority', 1, 5, 10)             // 3-cycle
+    ->buildMany();
+// row 0: draft / 1
+// row 1: published / 5
+// row 2: draft / 10
+// row 3: published / 1
+// row 4: draft / 5
+// row 5: published / 10
+```
+
+Calling `sequenceField()` twice for the **same field** replaces that field's cycle (last-write-wins per field, matching normal map semantics). When mixed with `sequence()`, the row-level `sequence()` is applied first and `sequenceField()` overlays its column on top — so for any field appearing in both, the per-field overlay wins.
+
 For reusable business states, prefer named methods on the factory:
 ```php
 $article = ArticleFactory::new()

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -908,6 +908,53 @@ abstract class BaseFactory
     }
 
     /**
+     * Cycle the values of a single column across the entities the factory
+     * produces. A focused alternative to {@see self::sequence()} when you
+     * only want to vary one field — the value can be any scalar, array,
+     * `BackedEnum`/`UnitEnum` case, or anything Cake's marshaller accepts
+     * for the target column.
+     *
+     * Stacking and ordering rules:
+     * - Calls for **different fields** stack: each field cycles independently
+     *   at its own period (`index % count(values)`), so two cycles with
+     *   different cardinalities compose without interference.
+     * - Calls for the **same field** replace that field's cycle (last-write-
+     *   wins per field, matching normal map semantics).
+     * - Plays nicely with `sequence()`: the row-level sequence runs first,
+     *   then `sequenceField()` overlays its column. So if a field appears in
+     *   both, the per-field overlay wins for that column.
+     *
+     * Example:
+     * ```
+     * ArticleFactory::new()
+     *     ->count(6)
+     *     ->sequenceField('status', 'draft', 'published')   // 2-cycle
+     *     ->sequenceField('priority', 1, 5, 10)             // 3-cycle
+     *     ->buildMany();
+     * ```
+     *
+     * @param string $field Column to cycle.
+     * @param mixed ...$values Values cycled in order. At least one is required.
+     *
+     * @throws \InvalidArgumentException When no values are provided.
+     *
+     * @return static
+     */
+    public function sequenceField(string $field, mixed ...$values): static
+    {
+        if ($values === []) {
+            throw new InvalidArgumentException(
+                'sequenceField() expects at least one value to cycle through.',
+            );
+        }
+
+        $factory = clone $this;
+        $factory->getDataCompiler()->collectFieldSequence($field, $values);
+
+        return $factory;
+    }
+
+    /**
      * Register a callback to run on each built entity before `build*()` returns
      * and before `save*()` persists the entity.
      *

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -928,8 +928,8 @@ abstract class BaseFactory
      * ```
      * ArticleFactory::new()
      *     ->count(6)
-     *     ->sequenceField('status', 'draft', 'published')   // 2-cycle
-     *     ->sequenceField('priority', 1, 5, 10)             // 3-cycle
+     *     ->sequenceField('status', 'draft', 'published') // 2-cycle
+     *     ->sequenceField('priority', 1, 5, 10) // 3-cycle
      *     ->buildMany();
      * ```
      *

--- a/src/Factory/DataCompiler.php
+++ b/src/Factory/DataCompiler.php
@@ -64,6 +64,15 @@ class DataCompiler
      */
     private array $sequenceData = [];
 
+    /**
+     * Per-field cycle map populated by `BaseFactory::sequenceField()`. Each
+     * entry is a list of values cycled at its own period during compilation,
+     * applied AFTER `sequence()` so a per-field overlay wins for that column.
+     *
+     * @var array<string, array<int, mixed>>
+     */
+    private array $fieldSequences = [];
+
     private int $sequenceIndex = 0;
 
     /**
@@ -175,6 +184,22 @@ class DataCompiler
     public function collectSequence(array $states): void
     {
         $this->sequenceData = $states;
+    }
+
+    /**
+     * Register a per-field value cycle. Independent fields cycle at their own
+     * periods during compilation; calling this twice for the same field
+     * replaces that field's cycle (last-write-wins per field, additive across
+     * different fields). Composes with {@see self::collectSequence()}.
+     *
+     * @param string $field Column to cycle.
+     * @param array<array-key, mixed> $values Values cycled by `index % count`.
+     *
+     * @return void
+     */
+    public function collectFieldSequence(string $field, array $values): void
+    {
+        $this->fieldSequences[$field] = array_values($values);
     }
 
     /**
@@ -539,7 +564,13 @@ class DataCompiler
 
     /**
      * Step 3.5:
-     * Merge with the data gathered by sequence.
+     * Merge with the data gathered by sequence().
+     *
+     * Field-level cycles registered via sequenceField() are applied AFTER the
+     * row-level sequence so that for any column appearing in both, the
+     * per-field overlay wins. Each field cycles independently at its own
+     * period (`index % count(values)`), so independent fields with different
+     * cardinalities compose without interfering.
      *
      * @param \Cake\Datasource\EntityInterface $entity Entity to manipulate.
      *
@@ -547,23 +578,30 @@ class DataCompiler
      */
     private function mergeWithSequenceData(EntityInterface $entity)
     {
-        if (!$this->sequenceData) {
-            return $this;
+        if ($this->sequenceData) {
+            $state = $this->sequenceData[$this->sequenceIndex % count($this->sequenceData)];
+            if (is_callable($state)) {
+                $state = $state(
+                    $this->getFactory(),
+                    $this->getFactory()->getGenerator(),
+                    $this->sequenceIndex,
+                );
+            } elseif ($state instanceof EntityInterface) {
+                $state = $state->toArray();
+            }
+
+            $this->patchEntity($entity, $state);
+            $this->addEnforcedFields($state);
         }
 
-        $state = $this->sequenceData[$this->sequenceIndex % count($this->sequenceData)];
-        if (is_callable($state)) {
-            $state = $state(
-                $this->getFactory(),
-                $this->getFactory()->getGenerator(),
-                $this->sequenceIndex,
-            );
-        } elseif ($state instanceof EntityInterface) {
-            $state = $state->toArray();
+        if ($this->fieldSequences) {
+            $fieldState = [];
+            foreach ($this->fieldSequences as $field => $values) {
+                $fieldState[$field] = $values[$this->sequenceIndex % count($values)];
+            }
+            $this->patchEntity($entity, $fieldState);
+            $this->addEnforcedFields($fieldState);
         }
-
-        $this->patchEntity($entity, $state);
-        $this->addEnforcedFields($state);
 
         return $this;
     }

--- a/tests/TestCase/Factory/BaseFactoryTest.php
+++ b/tests/TestCase/Factory/BaseFactoryTest.php
@@ -38,6 +38,7 @@ use TestApp\Model\Entity\Article;
 use TestApp\Model\Entity\Author;
 use TestApp\Model\Entity\City;
 use TestApp\Model\Entity\Country;
+use TestApp\Model\Enum\TestStatus;
 use TestApp\Model\Table\ArticlesTable;
 use TestApp\Model\Table\CountriesTable;
 use TestPlugin\Model\Entity\Bill;
@@ -365,14 +366,14 @@ class BaseFactoryTest extends TestCase
         // sticks on the entity as-is, so we assert against the case itself.
         $articles = ArticleFactory::new()
             ->count(4)
-            ->sequenceField('status', ...\TestApp\Model\Enum\TestStatus::cases())
+            ->sequenceField('status', ...TestStatus::cases())
             ->buildMany();
 
-        $this->assertSame(\TestApp\Model\Enum\TestStatus::Active, $articles[0]->status);
-        $this->assertSame(\TestApp\Model\Enum\TestStatus::Inactive, $articles[1]->status);
-        $this->assertSame(\TestApp\Model\Enum\TestStatus::Pending, $articles[2]->status);
+        $this->assertSame(TestStatus::Active, $articles[0]->status);
+        $this->assertSame(TestStatus::Inactive, $articles[1]->status);
+        $this->assertSame(TestStatus::Pending, $articles[2]->status);
         // count(4) > 3 cases → cycles
-        $this->assertSame(\TestApp\Model\Enum\TestStatus::Active, $articles[3]->status);
+        $this->assertSame(TestStatus::Active, $articles[3]->status);
     }
 
     public function testSequenceFieldRejectsZeroValues(): void

--- a/tests/TestCase/Factory/BaseFactoryTest.php
+++ b/tests/TestCase/Factory/BaseFactoryTest.php
@@ -274,6 +274,128 @@ class BaseFactoryTest extends TestCase
         }
     }
 
+    public function testSequenceFieldCyclesValuesAcrossEntities(): void
+    {
+        $articles = ArticleFactory::new()
+            ->count(5)
+            ->sequenceField('title', 'Alpha', 'Beta')
+            ->buildMany();
+
+        $titles = array_map(static fn (Article $a): string => $a->title, $articles);
+        $this->assertSame(['Alpha', 'Beta', 'Alpha', 'Beta', 'Alpha'], $titles);
+    }
+
+    public function testSequenceFieldStacksAcrossDifferentFields(): void
+    {
+        // Two cycles of different periods (2 and 3) cycle independently:
+        // an LCM-of-6 pattern emerges across the count(6) factory.
+        $articles = ArticleFactory::new()
+            ->count(6)
+            ->sequenceField('title', 'Draft', 'Published')
+            ->sequenceField('body', 'short', 'medium', 'long')
+            ->buildMany();
+
+        $rows = array_map(
+            static fn (Article $a): array => ['title' => $a->title, 'body' => $a->body],
+            $articles,
+        );
+        $this->assertSame([
+            ['title' => 'Draft', 'body' => 'short'],
+            ['title' => 'Published', 'body' => 'medium'],
+            ['title' => 'Draft', 'body' => 'long'],
+            ['title' => 'Published', 'body' => 'short'],
+            ['title' => 'Draft', 'body' => 'medium'],
+            ['title' => 'Published', 'body' => 'long'],
+        ], $rows);
+    }
+
+    public function testSequenceFieldLastWriteWinsForSameField(): void
+    {
+        // Two calls for the same field must REPLACE, not append (matching
+        // the "last-write-wins per field" rule documented on the method).
+        $articles = ArticleFactory::new()
+            ->count(3)
+            ->sequenceField('title', 'OldA', 'OldB')
+            ->sequenceField('title', 'NewA', 'NewB', 'NewC')
+            ->buildMany();
+
+        $titles = array_map(static fn (Article $a): string => $a->title, $articles);
+        $this->assertSame(['NewA', 'NewB', 'NewC'], $titles);
+    }
+
+    public function testSequenceFieldOverlaysSequenceForSameColumn(): void
+    {
+        // sequence() applies first, sequenceField() overlays for that column.
+        $articles = ArticleFactory::new()
+            ->count(3)
+            ->sequence(
+                ['title' => 'FromSequence', 'body' => 'BodyA'],
+                ['title' => 'FromSequence', 'body' => 'BodyB'],
+            )
+            ->sequenceField('title', 'X', 'Y', 'Z')
+            ->buildMany();
+
+        $this->assertSame('X', $articles[0]->title);
+        $this->assertSame('Y', $articles[1]->title);
+        $this->assertSame('Z', $articles[2]->title);
+        // body comes from the row-level sequence and is unaffected
+        $this->assertSame('BodyA', $articles[0]->body);
+        $this->assertSame('BodyB', $articles[1]->body);
+        $this->assertSame('BodyA', $articles[2]->body);
+    }
+
+    public function testSequenceFieldRunsBeforePlainStateOverrides(): void
+    {
+        // state() (collected as patch data) is applied AFTER sequence steps,
+        // so the ad-hoc override still wins like it does for sequence().
+        $articles = ArticleFactory::new()
+            ->count(3)
+            ->sequenceField('title', 'A', 'B', 'C')
+            ->state(['title' => 'Override'])
+            ->buildMany();
+
+        foreach ($articles as $article) {
+            $this->assertSame('Override', $article->title);
+        }
+    }
+
+    public function testSequenceFieldAcceptsBackedEnumCases(): void
+    {
+        // Cake's EnumType marshals enum cases on save; for build() the value
+        // sticks on the entity as-is, so we assert against the case itself.
+        $articles = ArticleFactory::new()
+            ->count(4)
+            ->sequenceField('status', ...\TestApp\Model\Enum\TestStatus::cases())
+            ->buildMany();
+
+        $this->assertSame(\TestApp\Model\Enum\TestStatus::Active, $articles[0]->status);
+        $this->assertSame(\TestApp\Model\Enum\TestStatus::Inactive, $articles[1]->status);
+        $this->assertSame(\TestApp\Model\Enum\TestStatus::Pending, $articles[2]->status);
+        // count(4) > 3 cases → cycles
+        $this->assertSame(\TestApp\Model\Enum\TestStatus::Active, $articles[3]->status);
+    }
+
+    public function testSequenceFieldRejectsZeroValues(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('sequenceField() expects at least one value');
+
+        ArticleFactory::new()->sequenceField('title');
+    }
+
+    public function testSequenceFieldDoesNotMutateOriginalFactory(): void
+    {
+        // Fluent immutability — the original factory must not see the cycle.
+        $base = ArticleFactory::new()->count(2);
+        $cycled = $base->sequenceField('title', 'A', 'B');
+
+        $cycledTitles = array_map(static fn (Article $a): string => $a->title, $cycled->buildMany());
+        $baseTitles = array_map(static fn (Article $a): string => $a->title, $base->buildMany());
+
+        $this->assertSame(['A', 'B'], $cycledTitles);
+        $this->assertNotSame(['A', 'B'], $baseTitles, 'sequenceField must not mutate the originating factory');
+    }
+
     public function testAfterBuildRunsBeforeSave(): void
     {
         $article = ArticleFactory::new()


### PR DESCRIPTION
## Summary

Adds `BaseFactory::sequenceField(string $field, mixed ...$values)` — a focused alternative to `sequence()` when only one column needs to vary across the entities a factory produces. Each call adds the field to a per-column cycle map; at compile time every row pulls each field's value at `index % count(values)`, applied AFTER the row-level `sequence()` so a per-field overlay wins for that column.

Designed around three rules:

- **Different fields stack**: each cycles independently at its own period, so two cycles with different cardinalities compose without interference (e.g. a 2-cycle on `status` + a 3-cycle on `priority` produces an LCM-of-6 pattern across `count(6)`).
- **Same field is last-write-wins**: calling `sequenceField('status', ...)` twice replaces, matching normal map semantics.
- **Composes with `sequence()`**: row-level `sequence()` is applied first; `sequenceField()` overlays its column. For any field appearing in both, the per-field overlay wins.

Naturally accepts `BackedEnum`/`UnitEnum` cases since the variadic signature is `mixed`:

```php
ArticleFactory::new()
    ->count(4)
    ->sequenceField('status', ...Status::cases())
    ->buildMany();
```

Cake's marshaller already handles enum casting on save.

## Implementation

- New `DataCompiler::$fieldSequences` (per-column cycle map) + `collectFieldSequence($field, $values)`.
- Field cycles are applied in `mergeWithSequenceData()` right after the row-level sequence step, so overlay precedence is unambiguous.
- `BaseFactory::sequenceField()` clones the factory (fluent immutability), validates that at least one value is supplied, forwards to the data compiler.

## Docs

`docs/guide/examples.md` extended next to the existing `sequence()` coverage with: the typical single-field cycle, the enum-cases form (`...Status::cases()`), the stacking example showing the LCM pattern in full, and a one-paragraph summary of the precedence rules.
