### PR TITLE
Reject combining a single injected entity with count > 1

### DIFF
--- a/docs/guide/associations.md
+++ b/docs/guide/associations.md
@@ -101,6 +101,42 @@ $factory = ArticleFactory::from($article);
 
 Unlike `state(EntityInterface)` (which extracts via `toArray()`), `from()` preserves the entity's identity, so `_accessible`/`_virtual`/source-alias stay intact.
 
+### `from()` / `new($entity)` wrap exactly one entity
+
+Combining a single injected entity with a count greater than 1 throws `RuntimeException`:
+
+```php
+// ✗ throws
+ArticleFactory::from($article)->count(3)->buildMany();
+ArticleFactory::new($article)->count(3)->buildMany();
+ArticleFactory::new($article, 3)->buildMany();
+```
+
+A single entity cannot legitimately become N distinct entities — the factory would otherwise return N references to the same instance, mutated repeatedly by each iteration.
+
+To produce N entities seeded from an existing one, extract its data and feed that through `new()` instead:
+
+```php
+// ✓ N distinct entities, all carrying $base's field values
+$articles = ArticleFactory::new($base->toArray())->count(3)->buildMany();
+
+// ✓ Vary attributes per row with sequence() / sequenceField() on top
+$articles = ArticleFactory::new($base->toArray())
+    ->count(3)
+    ->sequenceField('slug', 'a', 'b', 'c')
+    ->buildMany();
+```
+
+You can also pass a list of arrays to `new()` directly when each row needs its own data:
+
+```php
+$articles = ArticleFactory::new([
+    ['title' => 'First'],
+    ['title' => 'Second'],
+    ['title' => 'Third'],
+])->buildMany();
+```
+
 ## Factory injection
 
 When building associations, you may simply provide a factory as parameter. Example:

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -262,6 +262,11 @@ abstract class BaseFactory
     {
         $this->initialize();
         $factory = $this->configure();
+        if ($times > 1 && $factory->getDataCompiler()->isInstantiatedFromEntity()) {
+            throw new RuntimeException(
+                self::entityWithMultipleCountMessage(static::class, $times),
+            );
+        }
         $factory->times = $times;
         $definitionFactory = $factory;
         $factory = $factory->setDefaultData(
@@ -270,6 +275,24 @@ abstract class BaseFactory
         $factory->getDataCompiler()->collectAssociationsFromDefaultTemplate();
 
         return $factory;
+    }
+
+    /**
+     * Compose the message used by the entity-with-count guards in setUp() and
+     * count(). Both error sites point users at the same workaround so the fix
+     * is discoverable from either entry point.
+     */
+    private static function entityWithMultipleCountMessage(string $factory, int $times): string
+    {
+        return sprintf(
+            "%s cannot produce %d entities from a single injected entity — `new(\$entity)` and `from(\$entity)` wrap exactly one existing entity. "
+            . "To produce N entities seeded from an existing one, extract its data and pass it through `new()` instead: "
+            . "%s::new(\$entity->toArray())->count(%d).",
+            $factory,
+            $times,
+            $factory,
+            $times,
+        );
     }
 
     /**
@@ -1054,6 +1077,10 @@ abstract class BaseFactory
      * @param int $times Number of entities to create. Must be at least 1.
      *
      * @throws \InvalidArgumentException When $times is less than 1.
+     * @throws \RuntimeException When called with $times > 1 on a factory that
+     *   was instantiated from an existing entity (via `new($entity)` or
+     *   `from($entity)`). Use `new($entity->toArray())->count($times)`
+     *   instead — wrapping a single entity cannot produce N distinct ones.
      *
      * @return static
      */
@@ -1064,6 +1091,11 @@ abstract class BaseFactory
                 '::count() expects a positive integer, got `%d`.',
                 $times,
             ));
+        }
+        if ($times > 1 && $this->getDataCompiler()->isInstantiatedFromEntity()) {
+            throw new RuntimeException(
+                self::entityWithMultipleCountMessage(static::class, $times),
+            );
         }
         $factory = clone $this;
         $factory->times = $times;

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -256,6 +256,9 @@ abstract class BaseFactory
      *
      * @param int $times Number of entities created
      *
+     * @throws \RuntimeException When $times > 1 is combined with a factory
+     *   instantiated from an existing entity.
+     *
      * @return static
      */
     protected function setUp(int $times): static
@@ -285,9 +288,9 @@ abstract class BaseFactory
     private static function entityWithMultipleCountMessage(string $factory, int $times): string
     {
         return sprintf(
-            "%s cannot produce %d entities from a single injected entity — `new(\$entity)` and `from(\$entity)` wrap exactly one existing entity. "
-            . "To produce N entities seeded from an existing one, extract its data and pass it through `new()` instead: "
-            . "%s::new(\$entity->toArray())->count(%d).",
+            '%s cannot produce %d entities from a single injected entity — `new($entity)` and `from($entity)` wrap exactly one existing entity. '
+            . 'To produce N entities seeded from an existing one, extract its data and pass it through `new()` instead: '
+            . '%s::new($entity->toArray())->count(%d).',
             $factory,
             $times,
             $factory,

--- a/src/Factory/DataCompiler.php
+++ b/src/Factory/DataCompiler.php
@@ -148,6 +148,19 @@ class DataCompiler
     }
 
     /**
+     * Whether the factory was instantiated from a single existing entity
+     * (via `BaseFactory::new($entity)` or `BaseFactory::from($entity)`).
+     *
+     * Used by the count guards: combining an entity payload with `times > 1`
+     * would return N references to the same mutated entity, which is never
+     * what callers want.
+     */
+    public function isInstantiatedFromEntity(): bool
+    {
+        return $this->dataFromInstantiation instanceof EntityInterface;
+    }
+
+    /**
      * Data passed in the instantiation by callable.
      *
      * The callable is stored as-is and invoked once per build iteration during

--- a/tests/TestCase/Factory/BaseFactoryMakeWithEntityTest.php
+++ b/tests/TestCase/Factory/BaseFactoryMakeWithEntityTest.php
@@ -22,6 +22,7 @@ use CakephpFixtureFactories\Test\Factory\AddressFactory;
 use CakephpFixtureFactories\Test\Factory\ArticleFactory;
 use CakephpFixtureFactories\Test\Factory\AuthorFactory;
 use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
+use RuntimeException;
 
 class BaseFactoryMakeWithEntityTest extends TestCase
 {
@@ -106,15 +107,21 @@ class BaseFactoryMakeWithEntityTest extends TestCase
         $this->assertSame(2, ArticleFactory::query()->count());
     }
 
-    public function testMakeEntityAndTimes(): void
+    /**
+     * Behavior change in v2: combining a single injected entity with a count
+     * greater than 1 now throws. The previous behavior pushed the same
+     * entity reference N times (each iteration mutated the same instance),
+     * which was never useful in practice. The error message points at the
+     * `new($entity->toArray())->count(N)` workaround.
+     */
+    public function testMakeEntityAndTimesIsRejected(): void
     {
-        $n = 2;
         $author1 = AuthorFactory::new()->save();
-        $authors = AuthorFactory::new($author1, $n)->saveMany();
-        foreach ($authors as $author) {
-            $this->assertSame($author1, $author);
-        }
-        $this->assertSame(1, AuthorFactory::query()->count());
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('cannot produce 2 entities from a single injected entity');
+
+        AuthorFactory::new($author1, 2);
     }
 
     public function testWithEntitiesAndTimes(): void

--- a/tests/TestCase/Factory/BaseFactoryTest.php
+++ b/tests/TestCase/Factory/BaseFactoryTest.php
@@ -384,6 +384,73 @@ class BaseFactoryTest extends TestCase
         ArticleFactory::new()->sequenceField('title');
     }
 
+    /**
+     * Regression: `from($entity)->count(N>1)` used to silently return N
+     * references to the same mutated entity (each iteration of toArray()
+     * pushed the same instance and the merge steps mutated it in place).
+     * Reject the combination with a clear error pointing at the
+     * `new($entity->toArray())->count(N)` workaround.
+     */
+    public function testFromEntityRejectsCountGreaterThanOne(): void
+    {
+        $base = ArticleFactory::new(['title' => 'Original'])->build();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('cannot produce 3 entities from a single injected entity');
+
+        ArticleFactory::from($base)->count(3);
+    }
+
+    public function testNewWithEntityRejectsCountGreaterThanOne(): void
+    {
+        $base = ArticleFactory::new(['title' => 'Original'])->build();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('cannot produce 4 entities from a single injected entity');
+
+        ArticleFactory::new($base)->count(4);
+    }
+
+    public function testNewWithEntityAndExplicitTimesRejected(): void
+    {
+        // Two-arg form (entity + explicit times) must trip the same guard
+        // — the bug exists regardless of how the count gets attached.
+        $base = ArticleFactory::new(['title' => 'Original'])->build();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('cannot produce 2 entities from a single injected entity');
+
+        ArticleFactory::new($base, 2);
+    }
+
+    public function testFromEntityCountOneStillWorks(): void
+    {
+        // The single-row case is the documented use of from()/new(entity)
+        // and must continue to return that exact entity reference.
+        $base = ArticleFactory::new(['title' => 'Wrap me'])->build();
+
+        $wrapped = ArticleFactory::from($base)->build();
+
+        $this->assertSame($base, $wrapped);
+    }
+
+    public function testFromEntityProperWorkaroundUsingToArray(): void
+    {
+        // The documented workaround: extract the entity's data and pass it
+        // through new() so the factory gets a fresh array template per row.
+        // This produces N distinct entities, which is what users actually want.
+        $base = ArticleFactory::new(['title' => 'Seed'])->build();
+
+        $articles = ArticleFactory::new($base->toArray())->count(3)->buildMany();
+
+        $this->assertCount(3, $articles);
+        $ids = array_map(static fn ($e) => spl_object_id($e), $articles);
+        $this->assertCount(3, array_unique($ids), 'each entity must be a distinct instance');
+        foreach ($articles as $article) {
+            $this->assertSame('Seed', $article->title);
+        }
+    }
+
     public function testSequenceFieldDoesNotMutateOriginalFactory(): void
     {
         // Fluent immutability — the original factory must not see the cycle.


### PR DESCRIPTION
## Summary

`new($entity)->count(N)` / `from($entity)->count(N)` / `new($entity, N)` used to silently push the **same entity reference** into the result N times — each iteration of `toArray()` called `compileEntity()` on the same `dataFromInstantiation`, and every merge step mutated the same instance. Callers got an array of identical references with the last iteration's state baked in.

Reproduced by `spl_object_id` check — `from($base)->count(3)->buildMany()` returned 3 entries with only 1 unique id.

## Fix

Reject the combination at both entry points:

- `BaseFactory::setUp()` — covers the two-arg form `new($entity, N)`.
- `BaseFactory::count()` — covers the chained form `new($entity)->count(N)` and `from($entity)->count(N)`.

Both throw `RuntimeException` with the same message, pointing at the proper alternative:

```php
ArticleFactory::new($entity->toArray())->count(N)
```

That extracts the entity's field values once and feeds them through `new()` so the factory builds N distinct entities seeded from the original — which is what callers actually want.

The single-row case (`from($entity)->build()`, `new($entity)->save()`) is **unaffected** and continues to return that exact entity reference, as documented and asserted by the existing `testMakeAliases` regression.

## Test plan

5 new regression tests in `BaseFactoryTest`:

- `testFromEntityRejectsCountGreaterThanOne` — chained `from($entity)->count(3)`.
- `testNewWithEntityRejectsCountGreaterThanOne` — chained `new($entity)->count(4)`.
- `testNewWithEntityAndExplicitTimesRejected` — two-arg form `new($entity, 2)`.
- `testFromEntityCountOneStillWorks` — single-row identity preserved.
- `testFromEntityProperWorkaroundUsingToArray` — the documented `new($entity->toArray())->count(3)` produces 3 distinct entities.

The existing `BaseFactoryMakeWithEntityTest::testMakeEntityAndTimes` was renamed to `testMakeEntityAndTimesIsRejected` and converted from asserting the broken `assertSame` behavior to asserting the new throw — the original test was effectively asserting the bug.

`vendor/bin/phpunit` (578 tests) / `phpstan analyse` / `phpcs` all clean locally.

## Docs

`docs/guide/associations.md` extended next to the existing `from()` section with: the rejected combinations, *why* (single entity can't legitimately become N distinct ones), and the canonical workaround via `new($entity->toArray())->count(N)` — including a `sequence`/`sequenceField` follow-up example for callers who want per-row variation on top.
