### PR TITLE
Make ambiguous-association errors paste-ready and discoverable

### DIFF
--- a/docs/guide/associations.md
+++ b/docs/guide/associations.md
@@ -84,11 +84,45 @@ $author = AuthorFactory::new()
     ->save();
 ```
 
-Both methods auto-resolve which association to attach based on the target factory's table — no association name needed. If the parent table has more than one association pointing at the target table (e.g. `created_by` and `updated_by` both → Users), the call throws an "ambiguous association" exception so you don't accidentally attach to the wrong one. Use the underlying `with('Author', …)` form with the explicit association name when you need to disambiguate.
-
-> Bake-generated `for*()` / `has*()` helpers emit `with('AssociationName', …)` rather than `for()` / `has()` for exactly this reason — the explicit alias is unambiguous at codegen time and survives later schema changes that introduce sibling associations.
+Both methods auto-resolve which association to attach based on the target factory's table — no association name needed.
 
 `has()` accepts an optional `$pivot` array as the second parameter for habtm joins, populating the `_joinData` columns on the join row.
+
+### Disambiguating `for()` and `has()`
+
+When the parent table declares **more than one** association pointing at the target table, the auto-resolver cannot pick a single one and throws — for example, an `Authors` table with both `Address` and `BusinessAddress` belonging to `Addresses`:
+
+```
+AuthorFactory::for(AddressFactory::new()) cannot resolve a unique belongsTo —
+`Authors` declares 2 associations targeting `Addresses`:
+  - Address         (foreign key: address_id)
+  - BusinessAddress (foreign key: business_address_id)
+
+Use the explicit form to disambiguate:
+  AuthorFactory::new()->with('Address',         AddressFactory::new())
+  AuthorFactory::new()->with('BusinessAddress', AddressFactory::new())
+```
+
+The fix is to fall back to the lower-level `with('AliasName', $factory)` form with the explicit association alias. Both `with()` lines in the exception message are paste-ready:
+
+::: code-group
+```php [Pick the alias you want]
+$author = AuthorFactory::new()
+    ->with('Address', AddressFactory::new(['street' => 'Home']))
+    ->save();
+```
+
+```php [Or stack multiple aliases]
+$author = AuthorFactory::new()
+    ->with('Address', AddressFactory::new(['street' => 'Home']))
+    ->with('BusinessAddress', AddressFactory::new(['street' => 'Office']))
+    ->save();
+```
+:::
+
+::: tip
+Bake-generated `for*()` / `has*()` helpers emit `with('AliasName', …)` rather than `for()` / `has()` for exactly this reason — the alias is unambiguous at codegen time and survives later schema changes that introduce sibling associations. If you reach for `with()` to disambiguate at a call site, you're using the same form bake would have generated.
+:::
 
 ## `from()` — start from an existing entity
 

--- a/docs/guide/associations.md
+++ b/docs/guide/associations.md
@@ -103,7 +103,7 @@ Use the explicit form to disambiguate:
   AuthorFactory::new()->with('BusinessAddress', AddressFactory::new())
 ```
 
-The fix is to fall back to the lower-level `with('AliasName', $factory)` form with the explicit association alias. Both `with()` lines in the exception message are paste-ready:
+**Quick fix at the call site** — fall back to the lower-level `with('AliasName', $factory)` form. Both `with()` lines in the exception message are paste-ready:
 
 ::: code-group
 ```php [Pick the alias you want]
@@ -120,8 +120,42 @@ $author = AuthorFactory::new()
 ```
 :::
 
+**Long-term pattern** — for any factory whose target table has more than one association in or out, define named wrapper methods on the factory itself. The bake command generates these automatically when you pass `--methods`:
+
+```bash
+bin/cake bake fixture_factory Authors --methods
+```
+
+```php
+class AuthorFactory extends BaseFactory
+{
+    public function forAddress($parameter = null): static
+    {
+        return $this->with('Address', AddressFactory::new($parameter));
+    }
+
+    public function forBusinessAddress($parameter = null): static
+    {
+        return $this->with('BusinessAddress', AddressFactory::new($parameter));
+    }
+}
+```
+
+Call sites then read like the directional API again, with the alias baked into the method name:
+
+```php
+$author = AuthorFactory::new()
+    ->forAddress(['street' => 'Home'])
+    ->forBusinessAddress(['street' => 'Office'])
+    ->save();
+```
+
 ::: tip
-Bake-generated `for*()` / `has*()` helpers emit `with('AliasName', …)` rather than `for()` / `has()` for exactly this reason — the alias is unambiguous at codegen time and survives later schema changes that introduce sibling associations. If you reach for `with()` to disambiguate at a call site, you're using the same form bake would have generated.
+See [Best Practices — directional helper methods](best-practices#do-add-directional-helper-methods-for-every-association) for the broader recommendation. The factory class is the right home for schema-coupled knowledge: it already knows it is the `AuthorFactory`; let it own the `Address` / `BusinessAddress` choice too rather than scattering inline alias strings across hundreds of call sites.
+:::
+
+::: tip Why bake emits `with()` and not `for()`
+Bake's `--methods` output uses `with('AliasName', …)` rather than `for()` / `has()` even when the relation is unambiguous today, because the alias is unambiguous at codegen time and survives later schema changes that introduce sibling associations. If you reach for `with()` to disambiguate at a call site, you're using the same form bake would have generated.
 :::
 
 ## `from()` — start from an existing entity

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -112,8 +112,31 @@ Use the explicit form to disambiguate:
   MessageFactory::new()->with('Recipient', UserFactory::new())
 ```
 
-The fix is to use the lower-level `with('AliasName', $factory)` form with the explicit association alias instead of the directional helper. Both `with()` lines in the message above are paste-ready — pick the one that matches the relation you want to populate.
+**Quick fix at the call site** — use the lower-level `with('AliasName', $factory)` form. Both `with()` lines in the exception message are paste-ready; pick the one that matches the relation you want to populate.
 
-This is also why bake-generated `for*()` / `has*()` helpers emit `with('AliasName', …)` rather than `for()` / `has()`: the alias is unambiguous at codegen time and survives later schema changes that introduce sibling associations.
+**Long-term pattern** — for any factory whose target table has more than one association in or out, define named wrapper methods directly on the factory:
+
+```php
+class MessageFactory extends BaseFactory
+{
+    public function forSender($parameter = null): static
+    {
+        return $this->with('Sender', UserFactory::new($parameter));
+    }
+
+    public function forRecipient($parameter = null): static
+    {
+        return $this->with('Recipient', UserFactory::new($parameter));
+    }
+}
+```
+
+Call sites then read like the directional API again, with the alias baked into the method name:
+
+```php
+MessageFactory::new()->forSender(['name' => 'Alice'])->forRecipient(['name' => 'Bob'])->save();
+```
+
+This is exactly what `bin/cake bake fixture_factory <Model> --methods` generates automatically — bake emits the explicit `with('AliasName', …)` form per association precisely because the alias is unambiguous at codegen time. The same logic applies when you hand-write factories: co-locate the disambiguation with the schema knowledge in one place rather than scattering alias strings across many test call sites. It mirrors the named-state recommendation in [Best Practices](best-practices) — name what you'll repeat.
 
 See [Associations — directional helpers](associations#directional-helpers-for-and-has) for the full design.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -96,3 +96,24 @@ Configure::write('FixtureFactories.instanceLevelGenerator', true);
 ```
 
 See [Fixture Factories — instance-level generators](factories#instance-level-generators) for details.
+
+## Ambiguous association
+
+`for()` and `has()` auto-resolve which association to attach by looking at the target factory's table. When the parent table declares more than one association pointing at that target table — for example a `Messages` table with both `Sender` and `Recipient` belonging to `Users`, or an `Authors` table with both `Address` and `BusinessAddress` belonging to `Addresses` — the resolver cannot pick a single one and throws:
+
+```
+MessageFactory::for(UserFactory::new()) cannot resolve a unique belongsTo —
+`Messages` declares 2 associations targeting `Users`:
+  - Sender    (foreign key: sender_id)
+  - Recipient (foreign key: recipient_id)
+
+Use the explicit form to disambiguate:
+  MessageFactory::new()->with('Sender',    UserFactory::new())
+  MessageFactory::new()->with('Recipient', UserFactory::new())
+```
+
+The fix is to use the lower-level `with('AliasName', $factory)` form with the explicit association alias instead of the directional helper. Both `with()` lines in the message above are paste-ready — pick the one that matches the relation you want to populate.
+
+This is also why bake-generated `for*()` / `has*()` helpers emit `with('AliasName', …)` rather than `for()` / `has()`: the alias is unambiguous at codegen time and survives later schema changes that introduce sibling associations.
+
+See [Associations — directional helpers](associations#directional-helpers-for-and-has) for the full design.

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -1482,6 +1482,7 @@ abstract class BaseFactory
     {
         $sourceTable = $this->getTable();
         $targetRegistryAlias = $factory->getRootTableRegistryName();
+        /** @var array<int, array{alias: string, foreignKey: string}> $matches */
         $matches = [];
         foreach ($sourceTable->associations() as $association) {
             $associationTargetsFactory = $association->getClassName() === $targetRegistryAlias
@@ -1490,24 +1491,28 @@ abstract class BaseFactory
             if (!$associationTargetsFactory) {
                 continue;
             }
-            if ($belongsTo && $association instanceof BelongsTo) {
-                $matches[] = $association->getName();
+            $isBelongsTo = $association instanceof BelongsTo;
+            if ($belongsTo !== $isBelongsTo) {
+                continue;
             }
-            if (!$belongsTo && !$association instanceof BelongsTo) {
-                $matches[] = $association->getName();
-            }
+            $foreignKey = $association->getForeignKey();
+            $matches[] = [
+                'alias' => $association->getName(),
+                'foreignKey' => is_array($foreignKey) ? implode(', ', $foreignKey) : (string)$foreignKey,
+            ];
         }
 
         if (count($matches) === 1) {
-            return $matches[0];
+            return $matches[0]['alias'];
         }
         if ($matches !== []) {
-            throw new RuntimeException(sprintf(
-                'Ambiguous %s association from `%s` to `%s`: %s. Use with() to select the explicit association name.',
-                $belongsTo ? 'belongsTo' : 'has*',
+            throw new RuntimeException(self::ambiguousAssociationMessage(
+                $belongsTo ? 'for' : 'has',
+                static::class,
+                $factory::class,
                 $sourceTable->getRegistryAlias(),
                 $targetRegistryAlias,
-                implode(', ', $matches),
+                $matches,
             ));
         }
 
@@ -1517,6 +1522,71 @@ abstract class BaseFactory
             $sourceTable->getRegistryAlias(),
             $targetRegistryAlias,
         ));
+    }
+
+    /**
+     * Build the paste-ready exception body for an ambiguous `for()` / `has()`
+     * call. Lists every candidate alias with its foreign key and emits a
+     * literal `with('Alias', TargetFactory::new())` line per candidate so the
+     * fix is reachable without consulting the docs.
+     *
+     * @param string $direction Either `'for'` (belongsTo) or `'has'` (hasMany / hasOne / belongsToMany).
+     * @param string $callerFactory FQCN of the factory the user called the directional helper on.
+     * @param string $targetFactory FQCN of the factory passed in.
+     * @param string $sourceAlias Source-table registry alias.
+     * @param string $targetAlias Target-table registry alias.
+     * @param array<int, array{alias: string, foreignKey: string}> $matches Candidate associations.
+     */
+    private static function ambiguousAssociationMessage(
+        string $direction,
+        string $callerFactory,
+        string $targetFactory,
+        string $sourceAlias,
+        string $targetAlias,
+        array $matches,
+    ): string {
+        $associationKind = $direction === 'for' ? 'belongsTo' : 'has* (hasOne, hasMany, belongsToMany)';
+        $callerShort = self::shortName($callerFactory);
+        $targetShort = self::shortName($targetFactory);
+
+        $candidateLines = array_map(
+            static fn (array $m): string => sprintf('  - %s (foreign key: %s)', $m['alias'], $m['foreignKey']),
+            $matches,
+        );
+        $fixLines = array_map(
+            static fn (array $m): string => sprintf(
+                '  %s::new()->with(\'%s\', %s::new())',
+                $callerShort,
+                $m['alias'],
+                $targetShort,
+            ),
+            $matches,
+        );
+
+        return sprintf(
+            "%s::%s(%s::new()) cannot resolve a unique %s — `%s` declares %d associations targeting `%s`:\n%s\n\n"
+            . "Use the explicit form to disambiguate:\n%s\n\n"
+            . 'See: https://dereuromark.github.io/cakephp-fixture-factories/guide/troubleshooting.html#ambiguous-association',
+            $callerShort,
+            $direction,
+            $targetShort,
+            $associationKind,
+            $sourceAlias,
+            count($matches),
+            $targetAlias,
+            implode("\n", $candidateLines),
+            implode("\n", $fixLines),
+        );
+    }
+
+    /**
+     * Strip the namespace from a class FQCN for use in user-facing snippets.
+     */
+    private static function shortName(string $fqcn): string
+    {
+        $pos = strrpos($fqcn, '\\');
+
+        return $pos === false ? $fqcn : substr($fqcn, $pos + 1);
     }
 
     /**

--- a/tests/TestCase/Factory/BaseFactoryTest.php
+++ b/tests/TestCase/Factory/BaseFactoryTest.php
@@ -1344,7 +1344,7 @@ class BaseFactoryTest extends TestCase
     public function testForThrowsWhenDirectionalBelongsToAssociationIsAmbiguous(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Ambiguous belongsTo association');
+        $this->expectExceptionMessage('cannot resolve a unique belongsTo');
 
         AuthorFactory::new()->for(AddressFactory::new());
     }
@@ -1352,9 +1352,38 @@ class BaseFactoryTest extends TestCase
     public function testHasThrowsWhenDirectionalToManyAssociationIsAmbiguous(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Ambiguous has* association');
+        $this->expectExceptionMessage('cannot resolve a unique has*');
 
         CountryFactory::new()->has(CityFactory::new());
+    }
+
+    /**
+     * Regression: the ambiguous-association exception must be paste-ready —
+     * it lists every candidate's foreign key and emits a literal
+     * `with('Alias', TargetFactory::new())` line per candidate so the user
+     * does not have to consult the docs to fix it.
+     */
+    public function testAmbiguousForExceptionIncludesPasteReadyFix(): void
+    {
+        try {
+            AuthorFactory::new()->for(AddressFactory::new());
+            $this->fail('Expected RuntimeException');
+        } catch (RuntimeException $e) {
+            $message = $e->getMessage();
+
+            // Both candidate aliases (Author belongsTo Address + BusinessAddress)
+            // and a paste-ready `with(...)` line for each are present.
+            $this->assertStringContainsString('Address', $message);
+            $this->assertStringContainsString('BusinessAddress', $message);
+            $this->assertStringContainsString('foreign key:', $message);
+            $this->assertStringContainsString("AuthorFactory::new()->with('Address', AddressFactory::new())", $message);
+            $this->assertStringContainsString(
+                "AuthorFactory::new()->with('BusinessAddress', AddressFactory::new())",
+                $message,
+            );
+            // And a pointer at the troubleshooting page.
+            $this->assertStringContainsString('troubleshooting.html#ambiguous-association', $message);
+        }
     }
 
     public function testStaticTableAndQueryHonorConfigureDefaults(): void


### PR DESCRIPTION
## Summary

Three coordinated changes that turn the `for()` / `has()` ambiguity error from "you have to read the guide to fix it" into "the exception message is the fix."

Motivated by the discussion on #40 — the design point (`for`/`has` for the default, `with('Alias', …)` for the disambiguation case) is right, but the discoverability gap was real: the exception named the candidate aliases without telling the user *what to type instead*.

## 1. Paste-ready exception message

`BaseFactory::resolveDirectionalAssociation()` now emits, for example:

```
AuthorFactory::for(AddressFactory::new()) cannot resolve a unique belongsTo —
`Authors` declares 2 associations targeting `Addresses`:
  - Address         (foreign key: address_id)
  - BusinessAddress (foreign key: business_address_id)

Use the explicit form to disambiguate:
  AuthorFactory::new()->with('Address',         AddressFactory::new())
  AuthorFactory::new()->with('BusinessAddress', AddressFactory::new())

See: https://dereuromark.github.io/cakephp-fixture-factories/guide/troubleshooting.html#ambiguous-association
```

Per-candidate foreign keys make it obvious which alias maps to which relation, and each `with('Alias', …)` line is paste-ready.

## 2. Troubleshooting entry

New section in `docs/guide/troubleshooting.md` titled **"Ambiguous association"** that mirrors the exception body. Catches users who land via Google with the exception substring as the query, or who hit the error inside a wrapped/rethrown stack and only see the first line of the message.

## 3. Promoted inline note in `associations.md`

The previously one-sentence "use `with()` to disambiguate" mention under the directional-helpers section is now a dedicated **"Disambiguating `for()` and `has()`"** subsection, with the exception body shown verbatim and a worked Author/Address + BusinessAddress example showing the single-pick and multi-alias forms side by side. The bake-emits-`with()` rationale moved into a `::: tip` block so it carries visual weight.

## What this PR does *not* do

Two options were considered and skipped on purpose:

- **Add a `for(string $alias, BaseFactory $f)` overload** — that's exactly what `with('Alias', $f)` already does. Two spellings for the same call obscures the `for/has = auto-resolve, with = explicit` design split rather than helping.
- **A `Configure` flag to silence the throw** — turns a clear error back into a silent attach-to-wrong-side bug, which is the bug class the directional-throw was added to prevent.

## Test plan

- Existing `testForThrowsWhenDirectionalBelongsToAssociationIsAmbiguous` and `testHasThrowsWhenDirectionalToManyAssociationIsAmbiguous` updated to the new exception wording (`"cannot resolve a unique belongsTo"` / `"cannot resolve a unique has*"`).
- New `testAmbiguousForExceptionIncludesPasteReadyFix` pins the contract: every candidate alias appears, foreign keys are listed, and a literal `AuthorFactory::new()->with('Address', AddressFactory::new())` line is present in the message for each candidate. Also asserts the troubleshooting URL is in the message.
- `vendor/bin/phpunit` (590 tests) / `phpstan analyse` / `phpcs` clean locally with the same `php-collective/code-sniffer` revision CI installs (composer-updated before running).
