### PR TITLE
Fix zero-arg Factory::find() rector rewrite + correct docs path

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -39,7 +39,7 @@ Replace `setDefaultTemplate()` + `setDefaultData()` with `definition()`:
 The bundled Rector ruleset performs this rewrite automatically:
 
 ```bash
-vendor/bin/rector process tests --config rector.php
+vendor/bin/rector process tests --config vendor/dereuromark/cakephp-fixture-factories/rector.php
 ```
 
 See the [v1 → v2 upgrade guide](upgrading.md) for the full ruleset and the call-site renames it covers.

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -26,7 +26,7 @@ If you're still on `1.3.x`, upgrade to `1.4.x` first, then move to v2.
 For the v2 step, the package ships a Rector config to help with the mechanical API rename work:
 
 ```bash
-vendor/bin/rector process tests --config rector.php
+vendor/bin/rector process tests --config vendor/dereuromark/cakephp-fixture-factories/rector.php
 ```
 
 The bundled rules cover the safe, mechanical call-site changes:

--- a/src/Rector/StaticCall/FactoryStaticQueryRector.php
+++ b/src/Rector/StaticCall/FactoryStaticQueryRector.php
@@ -44,6 +44,14 @@ final class FactoryStaticQueryRector extends AbstractRector
             );
         }
 
+        // Factory::find() with no args -> Factory::query(). CakePHP 5's
+        // SelectQuery::find() requires a finder name, so chaining ->find() onto
+        // Factory::query() (which already returns a default 'all' SelectQuery)
+        // would error. Factory::find('all', ...) keeps the chained form.
+        if ($this->isName($node->name, 'find') && $node->args === []) {
+            return new StaticCall($node->class, new Identifier('query'));
+        }
+
         foreach (['find', 'firstOrFail', 'count'] as $queryMethod) {
             if ($this->isName($node->name, $queryMethod)) {
                 return new MethodCall(

--- a/tests/TestCase/Rector/Fixture/factory_static_find_zero_args.php.inc
+++ b/tests/TestCase/Rector/Fixture/factory_static_find_zero_args.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use CakephpFixtureFactories\Test\Factory\ArticleFactory;
+
+final class FactoryFindZeroArgsExample
+{
+    public function migrate(): void
+    {
+        $entry = ArticleFactory::find();
+        $first = ArticleFactory::find()->firstOrFail();
+        $byFinder = ArticleFactory::find('published')->firstOrFail();
+    }
+}
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use CakephpFixtureFactories\Test\Factory\ArticleFactory;
+
+final class FactoryFindZeroArgsExample
+{
+    public function migrate(): void
+    {
+        $entry = ArticleFactory::query();
+        $first = ArticleFactory::query()->firstOrFail();
+        $byFinder = ArticleFactory::query()->find('published')->firstOrFail();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #60.

`FactoryStaticQueryRector` previously rewrote `Factory::find()` (no args) to `Factory::query()->find()`. CakePHP 5's `SelectQuery::find()` requires a finder name, so the chained call errors with `Too few arguments to function Cake\ORM\Query\SelectQuery::find(), 0 passed... exactly 1 expected` at runtime.

- Zero-arg `Factory::find()` now rewrites to `Factory::query()` directly (which already returns a default `'all'` SelectQuery).
- Calls with an explicit finder name (`Factory::find('published')`) keep the chained form `Factory::query()->find('published')`.
- New fixture `factory_static_find_zero_args.php.inc` covers all three cases (bare `find()`, `find()->firstOrFail()`, `find('finder')->firstOrFail()`).
- Upgrading/migration docs corrected to use the vendor-relative rector config path so downstream consumers can copy the command verbatim.