### PR TITLE
Rename Factory::make() to new() when arg type is mixed/unknown

### DIFF
--- a/src/Rector/StaticCall/FactoryLegacyMakeToNewRector.php
+++ b/src/Rector/StaticCall/FactoryLegacyMakeToNewRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\VariadicPlaceholder;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\UnionType;
 use Rector\Rector\AbstractRector;
 
 final class FactoryLegacyMakeToNewRector extends AbstractRector
@@ -71,13 +72,20 @@ final class FactoryLegacyMakeToNewRector extends AbstractRector
                 return null;
             }
 
-            $isInteger = $this->getType($firstArg->value)->isInteger();
-            if ($isInteger->yes()) {
+            $type = $this->getType($firstArg->value);
+            if ($type->isInteger()->yes()) {
                 return $this->createCountCall($this->createNewCall($node->class), $firstArg);
             }
 
-            // Static type is uncertain (e.g. int|array). Bail rather than guess wrong.
-            if ($isInteger->maybe()) {
+            // Bail only on concretely ambiguous int|array unions where rector
+            // genuinely cannot choose between new($data) and new()->count($n).
+            // For mixed/unknown/untyped variables, fall through to the new()
+            // rename — historically `make($single_arg)` meant data, not count.
+            if (
+                $type instanceof UnionType
+                && $type->isInteger()->maybe()
+                && $type->isArray()->maybe()
+            ) {
                 return null;
             }
 

--- a/tests/TestCase/Rector/Fixture/factory_legacy_make_mixed_arg_renames.php.inc
+++ b/tests/TestCase/Rector/Fixture/factory_legacy_make_mixed_arg_renames.php.inc
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use CakephpFixtureFactories\Test\Factory\ArticleFactory;
+
+final class FactoryLegacyMakeMixedArgRenames
+{
+    /**
+     * Untyped parameter — phpstan resolves it as mixed. Historically
+     * `make($single_arg)` meant data, not count, so the rule should
+     * fall through to the new() rename rather than bailing.
+     */
+    public function migrate($parameter): void
+    {
+        $factory = ArticleFactory::make($parameter);
+    }
+
+    /**
+     * Explicit mixed type behaves the same way.
+     */
+    public function migrateMixed(mixed $parameter): void
+    {
+        $factory = ArticleFactory::make($parameter);
+    }
+}
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use CakephpFixtureFactories\Test\Factory\ArticleFactory;
+
+final class FactoryLegacyMakeMixedArgRenames
+{
+    /**
+     * Untyped parameter — phpstan resolves it as mixed. Historically
+     * `make($single_arg)` meant data, not count, so the rule should
+     * fall through to the new() rename rather than bailing.
+     */
+    public function migrate($parameter): void
+    {
+        $factory = ArticleFactory::new($parameter);
+    }
+
+    /**
+     * Explicit mixed type behaves the same way.
+     */
+    public function migrateMixed(mixed $parameter): void
+    {
+        $factory = ArticleFactory::new($parameter);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #61.

`FactoryLegacyMakeToNewRector` previously bailed on `Factory::make($var)` whenever phpstan reported the arg's int-ness as `maybe`. That fires for `mixed`, untyped variables, and any non-array union that includes `int`. Real-world factory call sites like `RepositoryFactory::make($parameter)` (where `$parameter` is an untyped function parameter) were left un-migrated.

- Bail now only applies to concretely ambiguous `int|array` unions where the rule genuinely cannot choose between `new($data)` and `new()->count($n)`.
- For mixed / unknown / untyped arguments the rule falls through to the `new()` rename — historically `make($single_arg)` meant data, not count.
- New fixture `factory_legacy_make_mixed_arg_renames.php.inc` covers the untyped-parameter and explicit-`mixed` cases.
- Existing `factory_legacy_make_ambiguous_int_bail.php.inc` fixture (concrete `int|array` parameter) continues to bail as before — verified locally.