### PR TITLE
Fix BelongsToMany junction-instance mismatch under scoped factory aliases

### DIFF
--- a/src/Factory/EventCollector.php
+++ b/src/Factory/EventCollector.php
@@ -109,16 +109,47 @@ class EventCollector
             $options['connection'] = ConnectionManager::get($this->connectionName);
         }
 
+        $locator = FactoryTableRegistry::getTableLocator();
+
         try {
-            $table = FactoryTableRegistry::getTableLocator()->get($registryAlias, $options);
+            $table = $locator->get($registryAlias, $options);
         } catch (RuntimeException $exception) {
-            if (!FactoryTableRegistry::getTableLocator()->exists($registryAlias)) {
+            if (!$locator->exists($registryAlias)) {
                 throw $exception;
             }
-            FactoryTableRegistry::getTableLocator()->remove($registryAlias);
-            $table = FactoryTableRegistry::getTableLocator()->get($registryAlias, $options);
+            $locator->remove($registryAlias);
+            $table = $locator->get($registryAlias, $options);
         }
         $table->setAlias($this->getRootTableAlias());
+
+        // Mirror the factory's scoped instance under the bare alias and the
+        // plugin-prefixed alias so CakePHP's BTM target lookups and
+        // junction-belongsTo resolutions — which always use those forms,
+        // never the scoped key — return this exact instance instead of
+        // spawning a parallel one under the same logical name.
+        //
+        // Without this consolidation the junction's belongsTo target
+        // (registered by Cake's `_generateJunctionAssociations` source-side
+        // block with `targetTable: $source` = this scoped factory table)
+        // drifts away from the bare-alias instance the inverse direction
+        // creates on its first BTM target lookup. Cake then reaches the
+        // identity check at `BelongsToMany::_generateJunctionAssociations`
+        // and throws the "incompatible association on junction" error
+        // reported in #62.
+        //
+        // The set is unconditional: factories that resolve to the same
+        // scoped key (default-listening factories — the common case) all
+        // map their bare alias here to the same instance, so successive
+        // calls are no-ops. Custom-listening factories overwrite, which
+        // is intentional — the factory that ran most recently owns the
+        // bare alias, matching the behavior CakePHP itself documents for
+        // explicit `set()` calls on the table locator.
+        foreach ([$this->getRootTableAlias(), $this->rootTableRegistryName] as $alias) {
+            if ($alias === $registryAlias) {
+                continue;
+            }
+            $locator->set($alias, $table);
+        }
 
         return $this->table = $table;
     }

--- a/tests/TestCase/Factory/Issue62JunctionInstanceTest.php
+++ b/tests/TestCase/Factory/Issue62JunctionInstanceTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CakephpFixtureFactories\Test\TestCase\Factory;
+
+use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
+use CakephpFixtureFactories\ORM\FactoryTableRegistry;
+use CakephpFixtureFactories\Test\Factory\ArticleFactory;
+use CakephpFixtureFactories\Test\Factory\AuthorFactory;
+use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
+
+/**
+ * Regression coverage for issue #62.
+ *
+ * Failure mode: when a factory's source table is loaded under a hash-scoped
+ * registry alias (e.g. `Authors__ff_<hash>`) and CakePHP's BelongsToMany
+ * machinery later resolves the same logical table by its bare or
+ * plugin-prefixed alias — the two cache entries diverge into separate Table
+ * instances. CakePHP's `_generateJunctionAssociations` then sees a junction
+ * `belongsTo($sAlias)` whose target was registered with one instance but
+ * a different instance arriving from the inverse direction's target lookup,
+ * producing:
+ *
+ *   The existing `<X>` association on `<XY>` is incompatible with the
+ *   `<X>` association on `<Y>`
+ *
+ * The fix pins the bare and plugin-prefixed aliases of every factory-loaded
+ * table to the same instance in `FactoryTableRegistry`, so all subsequent
+ * lookups for the same logical table — by any of its aliases — return the
+ * same Table object.
+ */
+class Issue62JunctionInstanceTest extends TestCase
+{
+    use TruncateDirtyTables;
+
+    public static function setUpBeforeClass(): void
+    {
+        Configure::write('FixtureFactories.testFixtureNamespace', 'CakephpFixtureFactories\Test\Factory');
+    }
+
+    /**
+     * After loading a factory's table, the bare alias must resolve to the
+     * SAME instance as the scoped alias. This is the contract the fix
+     * establishes — without it, downstream BTM lookups silently spawn a
+     * parallel instance.
+     */
+    public function testFactoryAndBareAliasResolveToSameInstance(): void
+    {
+        $factoryTable = AuthorFactory::table();
+        $bareLookup = FactoryTableRegistry::getTableLocator()->get('Authors');
+
+        $this->assertSame(
+            $factoryTable,
+            $bareLookup,
+            'AuthorFactory::table() and a bare-alias lookup must return the same Table instance.',
+        );
+    }
+
+    /**
+     * Trigger the exact junction conflict from #62: register a junction
+     * `belongsTo($source)` whose target is the factory's scoped instance,
+     * then force the inverse direction to look up the same logical source
+     * by its bare alias and verify that lookup returns the same instance —
+     * so the BTM equality check inside CakePHP's
+     * `_generateJunctionAssociations` does not blow up.
+     *
+     * The `remove()` here simulates the state a real test suite ends up in
+     * across PHPUnit test boundaries: cross-test pollution where parts of
+     * the locator have been evicted while association references on
+     * already-loaded tables still point at the original instances.
+     */
+    public function testInverseSaveAfterTargetEvictionDoesNotConflict(): void
+    {
+        $author = AuthorFactory::new()->with('Articles', 1)->save();
+        $this->assertNotNull($author->id);
+
+        $locator = FactoryTableRegistry::getTableLocator();
+        $locator->remove('Authors');
+        $locator->remove('ArticlesAuthors');
+
+        // Without the fix this throws:
+        //   "The existing `Authors` association on `ArticlesAuthors` is
+        //    incompatible with the `Authors` association on `Articles`"
+        $article = ArticleFactory::new()->with('Authors', 1)->save();
+        $this->assertNotNull($article->id);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #62.

In v2, `EventCollector` caches each factory's stripped-down Table under a hash-scoped registry alias (e.g. `Authors__ff_<hash>`) so factories with different listening configs don't share a single mutable Table instance. The side effect: when CakePHP's BelongsToMany machinery later resolves the same logical table by its bare or plugin-prefixed alias — which it always does, the scoped key is private to EventCollector — the factory locator hands back a *parallel* instance under that bare name.

That divergence is exactly the trigger Kevin's follow-up describes. Cake's `_generateJunctionAssociations` source-side block registers `belongsTo($sAlias)` on the junction with `targetTable: $source` = the scoped factory table. The inverse-direction save then re-enters `_generateJunctionAssociations`, looks up the same target by its bare alias, gets a fresh parallel instance, and the identity check at the top of the `else` branch throws:

> The existing `<X>` association on `<XY>` is incompatible with the `<X>` association on `<Y>`

## Fix

After every scoped lookup in `EventCollector::getTable()`, mirror the resolved instance under both the bare alias and (when applicable) the plugin-prefixed alias on the same factory locator. CakePHP's BTM target / junction-belongsTo resolutions now hit the same instance the factory uses, the identity check stays consistent across save directions, and the regression is gone.

The set is unconditional:

- **Default-listening factories (the common case)** all resolve to the same scoped key, so successive mirror-sets are no-ops.
- **Custom-listening factories** overwrite — the factory that ran most recently owns the bare alias, matching CakePHP's documented locator `set()` semantics.

## Regression test

`Issue62JunctionInstanceTest` covers:

1. The core invariant: `AuthorFactory::table()` and `FactoryTableLocator->get('Authors')` must be the same instance.
2. Inverse-save-after-eviction: simulates the cross-test pollution shape (junction reused, target evicted) that fires the runtime error in real test suites and verifies the second save now succeeds.

Verified locally: without the fix the second test errors with the exact issue #62 message; with the fix both pass. Full suite (599 tests, 2203 assertions), phpstan, and phpcs are clean.

## Scope of impact

This is a v2-only regression — v1.4.x cached the factory's table directly under `$rootTableRegistryName` with no scoping, so there was only ever one logical-table cache entry per locator and no bare/scoped divergence. The scoped-alias change landed in v2 (PR #43, commit eb694e7); this PR keeps the scoping benefit (custom-listening factories still get isolation) while restoring v1's "one instance per logical table" guarantee for downstream consumers.