### PR TITLE
Bind FactoryBakeHelper TView generic, drop PHPStan ignore

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,5 +9,3 @@ parameters:
 		# Pre-existing issues exposed by CakePHP 5.3.2's stricter type annotations
 		- identifier: return.type
 		  path: src/Factory/BaseFactory.php
-		- identifier: missingType.generics
-		  path: src/View/Helper/FactoryBakeHelper.php

--- a/src/View/Helper/FactoryBakeHelper.php
+++ b/src/View/Helper/FactoryBakeHelper.php
@@ -6,6 +6,9 @@ namespace CakephpFixtureFactories\View\Helper;
 
 use Cake\View\Helper;
 
+/**
+ * @extends \Cake\View\Helper<\Cake\View\View>
+ */
 class FactoryBakeHelper extends Helper
 {
     /**


### PR DESCRIPTION
## Summary

Cake's `View\Helper` is templated as `Helper<TView of View>`. Without binding the generic in subclasses, PHPStan level 8 raises `missingType.generics`. The plugin's `phpstan.neon` carried a path-scoped ignore for `FactoryBakeHelper` to silence it.

This PR adds an `extends` annotation that binds `TView` to `\Cake\View\View` and removes the ignore, so any future `missingType.generics` regression in this file is no longer masked.

Pure documentation change — no runtime impact.