### PR TITLE
Narrow BaseFactory's return.type PHPStan ignore

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,6 +6,11 @@ parameters:
 		- src/
 	ignoreErrors:
 		- identifier: trait.unused
-		# Pre-existing issues exposed by CakePHP 5.3.2's stricter type annotations
-		- identifier: return.type
-		  path: src/Factory/BaseFactory.php
+		# PHPStan does not propagate the TEntity template through `new static()`,
+		# so the BaseFactory factory-method helpers are reported as returning
+		# static<EntityInterface> instead of static<TEntity>. Narrow + count-pinned.
+		-
+			message: '#static\(.+BaseFactory<TEntity.+\) but returns static\(.+BaseFactory<.+EntityInterface>\)#'
+			identifier: return.type
+			path: src/Factory/BaseFactory.php
+			count: 2

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -1393,7 +1393,10 @@ abstract class BaseFactory
      */
     public static function query(): SelectQuery
     {
-        return self::configuredFactory()->getTable()->find();
+        /** @var \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface> $query */
+        $query = self::configuredFactory()->getTable()->find();
+
+        return $query;
     }
 
     /**


### PR DESCRIPTION
## Summary

The path-wide `return.type` ignore on `src/Factory/BaseFactory.php` was introduced when CakePHP 5.3.2 tightened its type annotations. After #66 the only legitimate residue is a known PHPStan limitation: `new static()` inside a templated class cannot propagate the outer class's `TEntity` binding into the constructor return type — surfacing twice in `makeFromNonCallable()` / `makeFromCallable()`.

## Changes

- Replace the path-wide `return.type` ignore with a **count-pinned, message-matched** entry that targets exactly those two `new static()` sites. Any *other* `return.type` violation in `BaseFactory` will now surface again instead of being silently swallowed.
- Resolve the third remaining error in `query()` by narrowing `Table::find()`'s wider `SelectQuery<array|EntityInterface>` to the `SelectQuery<EntityInterface>` already promised by the docblock, using an inline `@var` cast at the boundary.

## Why not fix the two `new static()` sites too

Tried `@var static $factory` — PHPStan rejects with `varTag.nativeType` because `static<TEntity>` (what `@var static` means in template context) isn't a subtype of `static<EntityInterface>` (what `new static()` natively returns). This is the documented PHPStan limitation we're now scoping the ignore around, with `count: 2` so a regression elsewhere can't sneak through under the same identifier.