### PR TITLE
Template AssociationBuilder and DataCompiler over the parent factory's TEntity

### DIFF
--- a/src/Factory/AssociationBuilder.php
+++ b/src/Factory/AssociationBuilder.php
@@ -28,7 +28,13 @@ use Throwable;
 /**
  * Class AssociationBuilder
  *
+ * The TEntity template tracks the *parent* factory's entity type. Child
+ * association factories accumulated in `$associations` carry their own
+ * (different) entity types and stay typed as `BaseFactory<EntityInterface>`.
+ *
  * @internal
+ *
+ * @template TEntity of \Cake\Datasource\EntityInterface
  */
 class AssociationBuilder
 {
@@ -47,12 +53,12 @@ class AssociationBuilder
     private array $manualAssociations = [];
 
     /**
-     * @var \CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface>
+     * @var \CakephpFixtureFactories\Factory\BaseFactory<TEntity>
      */
     private BaseFactory $factory;
 
     /**
-     * @param \CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface> $factory Associated factory
+     * @param \CakephpFixtureFactories\Factory\BaseFactory<TEntity> $factory Associated factory
      */
     public function __construct(BaseFactory $factory)
     {
@@ -60,7 +66,7 @@ class AssociationBuilder
     }
 
     /**
-     * @param \CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface> $factory Associated factory
+     * @param \CakephpFixtureFactories\Factory\BaseFactory<TEntity> $factory Associated factory
      *
      * @return void
      */
@@ -270,7 +276,7 @@ class AssociationBuilder
     }
 
     /**
-     * @return \CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface> Factory
+     * @return \CakephpFixtureFactories\Factory\BaseFactory<TEntity> Factory
      */
     public function getFactory(): BaseFactory
     {

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -132,14 +132,14 @@ abstract class BaseFactory
      * and compiles it to produce the data feeding the
      * entities of the Factory
      *
-     * @var \CakephpFixtureFactories\Factory\DataCompiler
+     * @var \CakephpFixtureFactories\Factory\DataCompiler<TEntity>
      */
     private DataCompiler $dataCompiler;
 
     /**
      * Helper to check and build data in associations
      *
-     * @var \CakephpFixtureFactories\Factory\AssociationBuilder
+     * @var \CakephpFixtureFactories\Factory\AssociationBuilder<TEntity>
      */
     private AssociationBuilder $associationBuilder;
 
@@ -164,7 +164,7 @@ abstract class BaseFactory
      * Override in a subclass to swap in a custom DataCompiler implementation
      * (e.g. a subclass with project-specific compilation behavior).
      *
-     * @return \CakephpFixtureFactories\Factory\DataCompiler
+     * @return \CakephpFixtureFactories\Factory\DataCompiler<TEntity>
      */
     protected function buildDataCompiler(): DataCompiler
     {
@@ -1032,7 +1032,7 @@ abstract class BaseFactory
     /**
      * A protected class dedicated to generating / collecting data for this factory
      *
-     * @return \CakephpFixtureFactories\Factory\DataCompiler
+     * @return \CakephpFixtureFactories\Factory\DataCompiler<TEntity>
      */
     protected function getDataCompiler(): DataCompiler
     {
@@ -1042,7 +1042,7 @@ abstract class BaseFactory
     /**
      * A protected class dedicated to building / collecting associations for this factory
      *
-     * @return \CakephpFixtureFactories\Factory\AssociationBuilder
+     * @return \CakephpFixtureFactories\Factory\AssociationBuilder<TEntity>
      */
     protected function getAssociationBuilder(): AssociationBuilder
     {

--- a/src/Factory/DataCompiler.php
+++ b/src/Factory/DataCompiler.php
@@ -30,7 +30,14 @@ use InvalidArgumentException;
 /**
  * Class DataCompiler
  *
+ * The TEntity template tracks the *parent* factory's entity type. Associated
+ * child factories collected in `$dataFromAssociations` and friends carry
+ * their own (different) entity types and stay typed as
+ * `BaseFactory<EntityInterface>`.
+ *
  * @internal
+ *
+ * @template TEntity of \Cake\Datasource\EntityInterface
  */
 class DataCompiler
 {
@@ -108,7 +115,7 @@ class DataCompiler
     private static int $persistDepth = 0;
 
     /**
-     * @var \CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface>
+     * @var \CakephpFixtureFactories\Factory\BaseFactory<TEntity>
      */
     private BaseFactory $factory;
 
@@ -118,7 +125,7 @@ class DataCompiler
     private bool $setPrimaryKey = true;
 
     /**
-     * @param \CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface> $factory Master factory
+     * @param \CakephpFixtureFactories\Factory\BaseFactory<TEntity> $factory Master factory
      */
     public function __construct(BaseFactory $factory)
     {
@@ -126,7 +133,7 @@ class DataCompiler
     }
 
     /**
-     * @param \CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface> $factory Master factory
+     * @param \CakephpFixtureFactories\Factory\BaseFactory<TEntity> $factory Master factory
      *
      * @return void
      */
@@ -909,7 +916,7 @@ class DataCompiler
     }
 
     /**
-     * @return \CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface>
+     * @return \CakephpFixtureFactories\Factory\BaseFactory<TEntity>
      */
     public function getFactory(): BaseFactory
     {


### PR DESCRIPTION
## Summary

`AssociationBuilder` and `DataCompiler` each hold a back-reference to the `BaseFactory` that owns them. That reference was typed `BaseFactory<EntityInterface>`, even though at runtime it is always `BaseFactory<TEntity>` for whatever entity type the owning factory is bound to.

This PR adds `@template TEntity` to both helper classes so the parent-factory seams propagate the concrete entity type. Subclasses that declare a concrete entity now see correct entity inference through `getDataCompiler()->getFactory()` and `getAssociationBuilder()->getFactory()`.

## Changes

- `AssociationBuilder` and `DataCompiler` get `@template TEntity of EntityInterface`
- Their `$factory` property, constructor param, `setFactory()` param, and `getFactory()` return are bound to `TEntity`
- `BaseFactory`'s `$dataCompiler` / `$associationBuilder` properties (and the matching `buildDataCompiler()`, `getDataCompiler()`, `getAssociationBuilder()` methods) are annotated with `<TEntity>` so the binding flows from the owning factory

## Out of scope

The **child** association factories these helpers accumulate (in `$associations`, `$dataFromAssociations`, etc.) carry *different* entity types per association and remain `BaseFactory<EntityInterface>` — a single `TEntity` cannot describe a heterogeneous collection. The class-level docblock on each helper notes this constraint.

`EventCollector` does not hold any `BaseFactory` reference (it operates on a registry-name string), so it stays untemplated.

Pure documentation change — no runtime behavior is affected.