### PR TITLE
Small src/ cleanups: error suppression hack + closure modernization

### DIFF
--- a/src/Command/BakeFixtureFactoryCommand.php
+++ b/src/Command/BakeFixtureFactoryCommand.php
@@ -138,7 +138,7 @@ class BakeFixtureFactoryCommand extends BakeCommand
      */
     public function getModelPath(): string|array
     {
-        if (!empty($this->plugin)) {
+        if ($this->plugin) {
             $path = $this->_pluginPath($this->plugin) . APP_DIR . DS . $this->pathToTableDir;
         } else {
             $path = APP . $this->pathToTableDir;
@@ -171,11 +171,10 @@ class BakeFixtureFactoryCommand extends BakeCommand
         $modelPath = $this->getModelPathString();
         $tables = glob($modelPath . '*Table.php') ?: [];
 
-        $tables = array_map(function ($a) {
-            $result = preg_replace('/Table.php$/', '', $a);
-
-            return $result ?? $a;
-        }, $tables);
+        $tables = array_map(
+            static fn (string $a): string => preg_replace('/Table.php$/', '', $a) ?? $a,
+            $tables,
+        );
 
         $return = [];
         foreach ($tables as $table) {
@@ -345,10 +344,7 @@ class BakeFixtureFactoryCommand extends BakeCommand
                 $methods = array_merge(array_keys($associations['manyToMany']), $methods);
             }
 
-            array_walk($methods, function (&$value): void {
-                $value = "with$value";
-            });
-            $data['methods'] = $methods;
+            $data['methods'] = array_map(static fn (string $value): string => "with$value", $methods);
             $data['useStatements'] = array_unique(array_values(Hash::flatten($useStatements)));
         }
 

--- a/src/Factory/FactoryAwareTrait.php
+++ b/src/Factory/FactoryAwareTrait.php
@@ -66,10 +66,9 @@ trait FactoryAwareTrait
      */
     public function getFactoryClassName(string $name): string
     {
-        // phpcs:disable
-        @[$modelName, $plugin] = array_reverse(explode('.', $name));
-
-        // phpcs:enable
+        $parts = array_reverse(explode('.', $name));
+        $modelName = $parts[0];
+        $plugin = $parts[1] ?? null;
 
         return $this->getFactoryNamespace($plugin) . '\\' . $this->getFactoryNameFromModelName($modelName);
     }


### PR DESCRIPTION
## Summary

Four independent micro-cleanups surfaced during a code-quality audit. None changes behavior.

## Changes

1. **`FactoryAwareTrait::getFactoryClassName`** — replace the unpack via `array_reverse(explode('.', $name))` (which needed an error-suppression operator plus `phpcs:disable` / `phpcs:enable` markers to compile cleanly) with an explicit unpack via `?? null` for the optional plugin component. Drops one anti-pattern (silenced warnings) and two suppression markers.

2. **`BakeFixtureFactoryCommand::getModelPath`** — drop the lone `if (!empty($this->plugin))` branch in favor of `if ($this->plugin)`, matching the convention already used 3x elsewhere in the same class for the same property.

3. **`BakeFixtureFactoryCommand::getTableList`** — collapse the two-line anonymous function in `array_map` to an arrow function with a single `?? $a` fallback expression.

4. **`BakeFixtureFactoryCommand::templateData`** — replace the by-reference `array_walk` that prepended a prefix to each method name with an `array_map` over an arrow function, written directly into `$data['methods']` instead of mutating a temp variable.

## Verification

- `composer stan` — clean
- `composer cs-check` — clean
- `composer test` (sqlite, in-memory) — 599 tests pass, same notice/skip counts as before the change