### PR TITLE
Add BaseFactory::recycle() for shared-parent reuse

### DIFF
--- a/docs/guide/associations.md
+++ b/docs/guide/associations.md
@@ -158,6 +158,97 @@ See [Best Practices — directional helper methods](best-practices#do-add-direct
 Bake's `--methods` output uses `with('AliasName', …)` rather than `for()` / `has()` even when the relation is unambiguous today, because the alias is unambiguous at codegen time and survives later schema changes that introduce sibling associations. If you reach for `with()` to disambiguate at a call site, you're using the same form bake would have generated.
 :::
 
+## Recycling shared parents: `recycle()`
+
+When the same parent should appear on **multiple branches** of an association tree, threading the parent entity through every branch by hand is noisy and easy to forget. `recycle($entity)` registers an already-built entity to be reused wherever any `belongsTo` in the build graph targets the same source table.
+
+```php
+$author = AuthorFactory::new()->save();
+
+// Every Article *and* every Comment under each Article uses $author
+// (assuming Article belongsTo Author and Comment belongsTo Author):
+$articles = ArticleFactory::new()
+    ->count(5)
+    ->with('Comments[3]')
+    ->recycle($author)
+    ->saveMany();
+```
+
+Without `recycle()`, that same build would silently create up to 20 distinct Author rows.
+
+### How it matches
+
+`recycle()` is keyed by **table name**. It substitutes whenever a `belongsTo` association in the build graph targets the same table as the recycled entity AND that branch's child factory has no explicit customization. The recycled entity must already be **persisted** (i.e. you've called `->save()`).
+
+Recycle is intentionally narrow:
+
+- Recycled entities must be saved. An entity from `Factory::new(...)->build()` (built in memory, not in the database) is rejected — recycle's fast path skips the child factory's persistence pipeline, so unsaved entities would never get a primary key. Pass them via `with('Alias', $entity)` instead if you need that.
+- Recycle does not override branches the user customized via `with('Alias', $entity)` (per-alias entity) or `with('Alias', Factory::new()->forX())` (chained child factory). Those calls express explicit per-branch intent and win.
+- `configure()` defaults (the chains baked into `forX()` / `hasX()` helpers and registered before user input) do **not** count as "customized" — recycle still applies to them.
+
+```php
+$country = CountryFactory::new()->save();
+
+CityFactory::new()
+    ->count(5)
+    ->forCountries()       // each city would normally get a fresh Country
+    ->recycle($country)
+    ->saveMany();          // all 5 cities share $country instead
+```
+
+### Propagation through nested factories
+
+Recycles flow down the build graph. The recycled map is inherited by every child factory that runs as part of the same build, so a recycle set on the root applies anywhere in the tree:
+
+```php
+$country = CountryFactory::new()->save();
+
+// Address belongsTo City; City belongsTo Country. Recycle the Country
+// at the root and every nested City reuses it:
+AddressFactory::new()
+    ->count(3)
+    ->with('City', CityFactory::new()->forCountries())
+    ->recycle($country)
+    ->saveMany();
+```
+
+### Multiple recycles
+
+`recycle()` is variadic and chainable. Each call merges into the recycle map (last call wins for the same target table):
+
+```php
+$country = CountryFactory::new()->save();
+$category = CategoryFactory::new()->save();
+
+ArticleFactory::new()
+    ->count(10)
+    ->with('Category')
+    ->with('Author.Country')
+    ->recycle($country, $category)
+    ->saveMany();
+```
+
+### Multiple aliases targeting the same table
+
+If a factory declares two `belongsTo` aliases pointing at the same target table (e.g. `Authors belongsTo Address` and `BusinessAddress`, both targeting `Addresses`), `recycle()` substitutes **both** branches with the recycled entity. If you need per-alias control, use `with('AliasName', $entity)` directly instead:
+
+```php
+$home   = AddressFactory::new()->save();
+$office = AddressFactory::new()->save();
+
+// Per-alias control via explicit with():
+AuthorFactory::new()
+    ->with('Address', $home)
+    ->with('BusinessAddress', $office)
+    ->save();
+```
+
+### When `recycle()` doesn't help
+
+- The build graph has no registered `belongsTo` to the recycled entity's table — recycle is a silent no-op.
+- You need different parents on different branches — use `with('AliasName', $entity)` per branch.
+- You want to reuse a `hasMany` or `belongsToMany` collection — recycle only substitutes single-row `belongsTo` parents. Use `with()` with concrete entities for the many side.
+
 ## `from()` — start from an existing entity
 
 Use `from(EntityInterface)` when you already have an entity and want a factory backed by it:

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -117,6 +117,17 @@ abstract class BaseFactory
     private bool $readBootstrapMode = false;
 
     /**
+     * Already-built entities that should be reused everywhere a belongsTo
+     * association in this factory's build graph targets the same source table.
+     *
+     * Keyed by `EntityInterface::getSource()`. Shared (recursively propagated)
+     * to child factories at compile time.
+     *
+     * @var array<string, \Cake\Datasource\EntityInterface>
+     */
+    private array $recycledEntities = [];
+
+    /**
      * @var array<int, callable(TEntity, int, static): (TEntity|void)>
      */
     private array $afterBuildCallbacks = [];
@@ -1462,6 +1473,134 @@ abstract class BaseFactory
         }
 
         return $this->with($association, $factory);
+    }
+
+    /**
+     * Reuse one or more already-built entities everywhere a belongsTo
+     * association in this factory's build graph targets the same source table.
+     *
+     * Closes the silent N× duplicate-parent gap when the same parent appears
+     * on multiple branches of an association tree.
+     *
+     * ```php
+     * $author = UserFactory::new()->save();
+     *
+     * ArticleFactory::new()
+     *     ->count(5)
+     *     ->with('Comments[3]')
+     *     ->recycle($author) // both Article AND each nested Comment reuse $author
+     *     ->saveMany();
+     * ```
+     *
+     * Recycles only substitute on association branches that already exist in
+     * the build tree (via `with()`, `for()`, `has()`, or `initialize()`/`configure()`
+     * defaults). If a recycle has no matching branch on the current factory,
+     * it is silently ignored on this level but still propagates to children.
+     *
+     * When a factory declares two belongsTo aliases targeting the same table
+     * (e.g. `Authors belongsTo Address` AND `BusinessAddress` — both targeting
+     * Addresses), recycle substitutes both. Use `with('Alias', $entity)`
+     * directly for per-alias control.
+     *
+     * @param \Cake\Datasource\EntityInterface ...$entities One or more
+     *     already-built entities to reuse, keyed internally by source table.
+     *
+     * @throws \InvalidArgumentException If an entity has no source table set.
+     *
+     * @return static
+     */
+    public function recycle(EntityInterface ...$entities): static
+    {
+        if ($this->readBootstrapMode) {
+            return clone $this;
+        }
+
+        $factory = clone $this;
+        foreach ($entities as $entity) {
+            $source = $entity->getSource();
+            if ($source === '') {
+                throw new InvalidArgumentException(
+                    'recycle() requires entities with a known source table. '
+                    . 'Build or save the entity through a factory (or call '
+                    . '`$entity->setSource(\'Tablename\')`) before recycling.',
+                );
+            }
+            if ($entity->isNew()) {
+                throw new InvalidArgumentException(sprintf(
+                    'recycle() requires already-persisted entities (got a `%s` with isNew()=true). '
+                    . 'Save the parent via `$entity = Factory::new(...)->save()` before recycling, '
+                    . 'or use `with(\'Alias\', $entity)` to attach an unsaved entity to a specific branch.',
+                    $entity::class,
+                ));
+            }
+            // Normalize the factory-internal `__ff_<hash>` suffix so the map
+            // keys match association target aliases on the lookup side.
+            $key = DataCompiler::normalizeTableAlias($source);
+            $factory->recycledEntities[$key] = $entity;
+        }
+
+        return $factory;
+    }
+
+    /**
+     * @internal Used by DataCompiler to propagate recycles down the build tree.
+     *
+     * @return array<string, \Cake\Datasource\EntityInterface>
+     */
+    public function getRecycledEntities(): array
+    {
+        return $this->recycledEntities;
+    }
+
+    /**
+     * Whether this factory was instantiated from an explicit entity
+     * (`Factory::new($entity)` or `Factory::from($entity)`).
+     *
+     * Used by `DataCompiler` to keep an explicit `with('Alias', $entity)`
+     * from being silently overridden by `recycle()` on the parent factory.
+     *
+     * @internal
+     */
+    public function isInstantiatedFromEntity(): bool
+    {
+        return $this->dataCompiler->isInstantiatedFromEntity();
+    }
+
+    /**
+     * Whether the user added explicit `with()` / `for()` / `has()` calls on
+     * this factory after `configure()` registered its defaults.
+     *
+     * @internal
+     */
+    public function hasUserSetAssociations(): bool
+    {
+        return $this->dataCompiler->hasUserSetAssociations();
+    }
+
+    /**
+     * Merge inherited recycles from a parent factory into a child without
+     * overriding locally-set recycles. Returns the same instance if nothing
+     * changes, or a clone with the merged map.
+     *
+     * @internal Called by DataCompiler when a child factory is about to build.
+     *
+     * @param array<string, \Cake\Datasource\EntityInterface> $recycles
+     *
+     * @return static
+     */
+    public function inheritRecycledEntities(array $recycles): static
+    {
+        if ($recycles === []) {
+            return $this;
+        }
+        $merged = $this->recycledEntities + $recycles;
+        if ($merged === $this->recycledEntities) {
+            return $this;
+        }
+        $factory = clone $this;
+        $factory->recycledEntities = $merged;
+
+        return $factory;
     }
 
     /**

--- a/src/Factory/DataCompiler.php
+++ b/src/Factory/DataCompiler.php
@@ -649,7 +649,7 @@ class DataCompiler
             $propertyName = $this->getMarshallerAssociationName($propertyName);
             if ($association instanceof HasOne || $association instanceof BelongsTo) {
                 // toOne associated data must be singular when saved
-                $this->mergeWithToOne($entity, $propertyName, $data);
+                $this->mergeWithToOne($entity, $propertyName, $data, $association);
             } else {
                 $this->mergeWithToMany($entity, $propertyName, $data);
             }
@@ -671,22 +671,62 @@ class DataCompiler
      *
      * @return void
      */
-    private function mergeWithToOne(EntityInterface $entity, string $associationName, array $data): void
-    {
+
+    /**
+     * @param \Cake\Datasource\EntityInterface $entity Entity produced by the factory.
+     * @param string $associationName Association property name.
+     * @param array<int, \CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface>> $data Data to inject
+     * @param \Cake\ORM\Association|null $association Resolved association (used for recycle target-table lookup).
+     *
+     * @throws \CakephpFixtureFactories\Error\FixtureFactoryException
+     */
+    private function mergeWithToOne(
+        EntityInterface $entity,
+        string $associationName,
+        array $data,
+        ?Association $association = null,
+    ): void {
         $count = count($data);
         /** @var \CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface> $factory */
         $factory = $data[$count - 1];
 
-        $associatedEntities = $factory->buildMany();
-        if (count($associatedEntities) !== 1) {
-            throw new FixtureFactoryException(sprintf(
-                'Association `%s` expects exactly 1 entity, but `%s` produced %d. Use a singular factory for to-one associations.',
-                $associationName,
-                $factory::class,
-                count($associatedEntities),
-            ));
+        $recycles = $this->factory->getRecycledEntities();
+        $associatedEntity = null;
+        // Recycle substitutes only when this branch's active (last-written)
+        // factory has no explicit customization. A user who wrote
+        // `with('Alias', $entity)` or `with('Alias', Factory::new()->forX())`
+        // has expressed per-branch intent that should win over recycle.
+        //
+        // The post-buildMany cardinality check below is intentionally skipped on
+        // the recycle fast path: the user supplied a specific entity to reuse, so
+        // the original factory's build (and its afterBuild callbacks) are no longer
+        // expected to fire. AssociationBuilder already rejects `->count(N)` on
+        // to-one branches at registration time, which is the common-case guard.
+        if (
+            $recycles !== []
+            && $association instanceof BelongsTo
+            && !$factory->isInstantiatedFromEntity()
+            && !$factory->hasUserSetAssociations()
+        ) {
+            $associatedEntity = self::matchRecycledEntity($association, $recycles);
         }
-        $associatedEntity = $associatedEntities[0];
+
+        if ($associatedEntity === null) {
+            if ($recycles !== []) {
+                $factory = $factory->inheritRecycledEntities($recycles);
+            }
+            $associatedEntities = $factory->buildMany();
+            if (count($associatedEntities) !== 1) {
+                throw new FixtureFactoryException(sprintf(
+                    'Association `%s` expects exactly 1 entity, but `%s` produced %d. Use a singular factory for to-one associations.',
+                    $associationName,
+                    $factory::class,
+                    count($associatedEntities),
+                ));
+            }
+            $associatedEntity = $associatedEntities[0];
+        }
+
         if ($this->isInPersistMode()) {
             $associatedEntity->set(self::IS_ASSOCIATED, true);
             $this->markEntityDirtyIfNew($associatedEntity);
@@ -705,7 +745,11 @@ class DataCompiler
     private function mergeWithToMany(EntityInterface $entity, string $associationName, array $data): void
     {
         $associationData = $entity->get($associationName);
+        $recycles = $this->factory->getRecycledEntities();
         foreach ($data as $factory) {
+            if ($recycles !== []) {
+                $factory = $factory->inheritRecycledEntities($recycles);
+            }
             if (!$associationData) {
                 $associationData = $this->getManyEntities($factory);
             } else {
@@ -713,6 +757,81 @@ class DataCompiler
             }
         }
         $entity->set($associationName, $associationData);
+    }
+
+    /**
+     * Normalize a registry alias / class name to a canonical recycle key.
+     *
+     * Stripped:
+     *  - FQCN namespace (`App\Model\Table\AddressesTable` → `AddressesTable`)
+     *  - The `Table` suffix on bare table class names (`AddressesTable` → `Addresses`)
+     *  - The factory-internal `__ff_<hash>` suffix added by FactoryTableLocator
+     *  - The `Plugin.` prefix on plugin-namespaced table identifiers — mirrors
+     *    `FactoryTableLocator`, which already strips that prefix from the
+     *    registry aliases it generates for plugin tables; both sides of the
+     *    recycle map must agree to match.
+     *
+     * Examples — all normalize to `Addresses`:
+     *  - `Addresses`
+     *  - `Addresses__ff_e0b429e1`
+     *  - `TestPlugin.Addresses`
+     *  - `App\Model\Table\AddressesTable`
+     *
+     * @internal
+     */
+    public static function normalizeTableAlias(string $alias): string
+    {
+        // Strip FQCN namespace.
+        $pos = strrpos($alias, '\\');
+        if ($pos !== false) {
+            $alias = substr($alias, $pos + 1);
+        }
+        // Strip the `Table` suffix on bare class names (but not the literal `Table`).
+        if ($alias !== 'Table' && str_ends_with($alias, 'Table')) {
+            $alias = substr($alias, 0, -5);
+        }
+        // Strip the plugin prefix (`Plugin.Addresses` → `Addresses`) to match
+        // what FactoryTableLocator does with plugin-namespaced registry aliases.
+        $pos = strrpos($alias, '.');
+        if ($pos !== false) {
+            $alias = substr($alias, $pos + 1);
+        }
+        // Strip the factory-internal suffix.
+        $pos = strpos($alias, '__ff_');
+        if ($pos !== false) {
+            $alias = substr($alias, 0, $pos);
+        }
+
+        return $alias;
+    }
+
+    /**
+     * Match a registered belongsTo association against a recycle map.
+     *
+     * Tries both `$association->getClassName()` (the canonical target table)
+     * and `$association->getName()` (the association alias) so a recycle works
+     * whether the entity was built through a factory (source = canonical table)
+     * or loaded through an aliased belongsTo (source = association alias, e.g.
+     * `$author->business_address` whose `getSource()` returns `'BusinessAddress'`).
+     *
+     * @param \Cake\ORM\Association $association BelongsTo association to look up.
+     * @param array<string, \Cake\Datasource\EntityInterface> $recycles Recycle map keyed by normalized table name.
+     *
+     * @return \Cake\Datasource\EntityInterface|null Matched entity, or null when no match.
+     */
+    private static function matchRecycledEntity(Association $association, array $recycles): ?EntityInterface
+    {
+        $candidates = [
+            self::normalizeTableAlias($association->getClassName()),
+            self::normalizeTableAlias($association->getName()),
+        ];
+        foreach (array_unique($candidates) as $key) {
+            if (isset($recycles[$key])) {
+                return $recycles[$key];
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -791,6 +910,22 @@ class DataCompiler
     {
         $this->dataFromDefaultAssociations = $this->dataFromAssociations;
         $this->dataFromAssociations = [];
+    }
+
+    /**
+     * Whether the user (post-`configure()`) added any association overrides
+     * via `with()` / `for()` / `has()` on this factory.
+     *
+     * Distinguishes user customizations from `configure()` defaults: defaults
+     * end up in `$dataFromDefaultAssociations` after
+     * {@see self::collectAssociationsFromDefaultTemplate()}, while explicit
+     * user calls populate `$dataFromAssociations`.
+     *
+     * @internal
+     */
+    public function hasUserSetAssociations(): bool
+    {
+        return $this->dataFromAssociations !== [];
     }
 
     /**

--- a/tests/TestCase/Factory/BaseFactoryRecycleTest.php
+++ b/tests/TestCase/Factory/BaseFactoryRecycleTest.php
@@ -1,0 +1,327 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ */
+
+namespace CakephpFixtureFactories\Test\TestCase\Factory;
+
+use Cake\TestSuite\TestCase;
+use CakephpFixtureFactories\Error\AssociationBuilderException;
+use CakephpFixtureFactories\Test\Factory\AddressFactory;
+use CakephpFixtureFactories\Test\Factory\AuthorFactory;
+use CakephpFixtureFactories\Test\Factory\BillFactory;
+use CakephpFixtureFactories\Test\Factory\CityFactory;
+use CakephpFixtureFactories\Test\Factory\CountryFactory;
+use CakephpFixtureFactories\Test\Factory\CustomerFactory;
+use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
+use InvalidArgumentException;
+use TestApp\Model\Entity\Country;
+
+/**
+ * Behavioural tests for `BaseFactory::recycle()`.
+ *
+ * recycle() reuses an already-built entity wherever any belongsTo association
+ * in the build graph targets that entity's source table — closing the silent
+ * N-duplicate-parent gap.
+ */
+class BaseFactoryRecycleTest extends TestCase
+{
+    use TruncateDirtyTables;
+
+    public function testRecycleReturnsCloneAndIsImmutable(): void
+    {
+        $country = CountryFactory::new(['name' => 'Original'])->save();
+
+        $base = CityFactory::new();
+        $recycled = $base->recycle($country);
+
+        $this->assertNotSame($base, $recycled, 'recycle() must return a clone, never mutate.');
+    }
+
+    public function testRecycleSubstitutesExplicitBelongsTo(): void
+    {
+        $country = CountryFactory::new(['name' => 'Recycled Country'])->save();
+
+        $city = CityFactory::new()
+            ->forCountries() // would normally create a fresh Country
+            ->recycle($country)
+            ->save();
+
+        $this->assertNotNull($city->id);
+        $this->assertSame(
+            $country->id,
+            $city->country_id,
+            'City built with forCountries() + recycle($country) must reuse the recycled country.',
+        );
+        $this->assertSame(
+            1,
+            CountryFactory::query()->count(),
+            'Only one country should exist in the database — the recycled one.',
+        );
+    }
+
+    public function testRecycleAppliesAcrossCountedBatch(): void
+    {
+        $country = CountryFactory::new(['name' => 'Shared'])->save();
+
+        $cities = CityFactory::new()
+            ->count(5)
+            ->forCountries()
+            ->recycle($country)
+            ->saveMany();
+
+        $this->assertCount(5, $cities);
+        foreach ($cities as $city) {
+            $this->assertSame($country->id, $city->country_id);
+        }
+
+        $this->assertSame(1, CountryFactory::query()->count());
+    }
+
+    public function testRecyclePropagatesToChildFactories(): void
+    {
+        $country = CountryFactory::new(['name' => 'Propagated'])->save();
+
+        // AddressFactory: 3 addresses, each with a City, each City with a Country.
+        // recycle on the ROOT factory must flow down so the nested CityFactory
+        // substitutes the recycled country instead of building fresh ones.
+        $addresses = AddressFactory::new()
+            ->count(3)
+            ->with('City', CityFactory::new()->forCountries())
+            ->recycle($country)
+            ->saveMany();
+
+        $this->assertCount(3, $addresses);
+        foreach ($addresses as $address) {
+            $this->assertNotNull($address->city);
+            $this->assertSame(
+                $country->id,
+                $address->city->country_id,
+                'Nested City must inherit recycle from root AddressFactory.',
+            );
+        }
+
+        $this->assertSame(
+            1,
+            CountryFactory::query()->count(),
+            'Only one country should exist — the recycled one, reused for every nested City.',
+        );
+    }
+
+    public function testRecycleIgnoresAssociationsNotInTree(): void
+    {
+        // Address has no belongsTo Country; recycling a Country here is
+        // a silent no-op. The build must still succeed.
+        $unused = CountryFactory::new(['name' => 'Unused'])->save();
+
+        $address = AddressFactory::new()
+            ->recycle($unused)
+            ->save();
+
+        $this->assertNotNull($address->id);
+    }
+
+    public function testRecycleSubstitutesMultipleAliasesTargetingSameTable(): void
+    {
+        // AuthorsTable has two belongsTo Addresses aliases: Address + BusinessAddress.
+        // recycle($address) substitutes BOTH because both have the same source.
+        // (Per-alias control belongs to with('Address', $entity) directly.)
+        $address = AddressFactory::new()->save();
+
+        $author = AuthorFactory::new()
+            ->with('Address', AddressFactory::new())
+            ->with('BusinessAddress', AddressFactory::new())
+            ->recycle($address)
+            ->save();
+
+        $this->assertSame($address->id, $author->address_id);
+        $this->assertSame($address->id, $author->business_address_id);
+        $this->assertSame(1, AddressFactory::query()->count());
+    }
+
+    public function testRecycleAcceptsMultipleEntitiesVariadically(): void
+    {
+        $country = CountryFactory::new(['name' => 'Country'])->save();
+        $address = AddressFactory::new()->save();
+
+        // The City build chains forCountries(). recycle() takes both entities
+        // — only the Country target actually substitutes (the Address recycle
+        // is a no-op here because City has no belongsTo Addresses).
+        $city = CityFactory::new()
+            ->forCountries()
+            ->recycle($country, $address)
+            ->save();
+
+        $this->assertSame($country->id, $city->country_id);
+    }
+
+    public function testRecycleChainedCallsMergeRecycleMap(): void
+    {
+        $country = CountryFactory::new(['name' => 'C'])->save();
+        $address = AddressFactory::new()->save();
+
+        // Two separate recycle() calls should both be active.
+        $city = CityFactory::new()
+            ->forCountries()
+            ->recycle($country)
+            ->recycle($address) // unrelated — silently ignored
+            ->save();
+
+        $this->assertSame($country->id, $city->country_id);
+    }
+
+    public function testExplicitWithEntityWinsOverRecycle(): void
+    {
+        // The user's per-alias choice (with('Alias', $entity)) must NOT be
+        // silently overridden by recycle() on the parent factory.
+        $home = AddressFactory::new()->save();
+        $office = AddressFactory::new()->save();
+
+        $author = AuthorFactory::new()
+            ->with('Address', $home)
+            ->with('BusinessAddress', $office)
+            ->recycle($home) // would otherwise also override BusinessAddress
+            ->save();
+
+        $this->assertSame($home->id, $author->address_id, 'Explicit Address wins.');
+        $this->assertSame(
+            $office->id,
+            $author->business_address_id,
+            'BusinessAddress explicitly set to $office must not be overridden by recycle($home).',
+        );
+    }
+
+    public function testRecycleMatchesEntityLoadedViaAlias(): void
+    {
+        // When an entity is fetched via an aliased belongsTo (e.g. through
+        // `contain: ['BusinessAddress']`), its `getSource()` is the association
+        // *alias* ('BusinessAddress'), not the underlying table ('Addresses').
+        // recycle() must still match it for the same alias on another build.
+        $seeded = AuthorFactory::new()
+            ->with('BusinessAddress', AddressFactory::new())
+            ->save();
+        $loaded = AuthorFactory::table()
+            ->get($seeded->id, contain: ['BusinessAddress'])
+            ->business_address;
+        $this->assertNotNull($loaded);
+
+        $other = AuthorFactory::new()
+            ->with('BusinessAddress', AddressFactory::new())
+            ->recycle($loaded)
+            ->save();
+
+        $this->assertSame(
+            $loaded->id,
+            $other->business_address_id,
+            'recycle() must match entities whose source is an association alias (here `BusinessAddress`).',
+        );
+    }
+
+    public function testRecycleMatchesPluginPrefixedAssociation(): void
+    {
+        // BillsTable belongsTo Customer via className `TestPlugin.Customers`.
+        // The recycled entity's source includes the plugin prefix too — both
+        // sides must normalize to the same canonical name for the match to fire.
+        $customer = CustomerFactory::new(['name' => 'Recycled'])->save();
+
+        $bill = BillFactory::new()
+            ->forCustomer()
+            ->recycle($customer)
+            ->save();
+
+        $this->assertSame(
+            $customer->id,
+            $bill->customer_id,
+            'Plugin-prefixed `Customer` association must match recycle($customer) keyed by `Customers`.',
+        );
+    }
+
+    public function testStaleExplicitWithDoesNotBlockLaterRecycle(): void
+    {
+        // `with('Address', $home)` is later overridden by `with('Address', AddressFactory::new())`.
+        // The active (last-written) factory is the clean one, so recycle($office) on the
+        // parent must still substitute — stale earlier entries do not lock the branch.
+        $home = AddressFactory::new()->save();
+        $office = AddressFactory::new()->save();
+
+        $author = AuthorFactory::new()
+            ->with('Address', $home)
+            ->with('Address', AddressFactory::new()) // overrides the prior $home line
+            ->recycle($office)
+            ->save();
+
+        $this->assertSame(
+            $office->id,
+            $author->address_id,
+            'Stale prior with($home) must not prevent recycle($office) from substituting the active branch.',
+        );
+    }
+
+    public function testRecycleStillEnforcesSingularToOneCardinality(): void
+    {
+        // A plural factory on a to-one association is a programmer error
+        // regardless of whether recycle would substitute the result.
+        // The registration-time AssociationBuilder guard fires before
+        // recycle even comes into play.
+        $country = CountryFactory::new()->save();
+
+        $this->expectException(AssociationBuilderException::class);
+        $this->expectExceptionMessageMatches('/cannot be multiple/');
+
+        CityFactory::new()
+            ->with('Countries', CountryFactory::new()->count(2))
+            ->recycle($country)
+            ->save();
+    }
+
+    public function testRecycleRequiresPersistedEntities(): void
+    {
+        // recycle()'s fast path skips the child factory's build, so an unsaved
+        // entity can't reuse the child's persistence pipeline (PK assignment,
+        // unique-property marker, etc.). Refuse loudly with a clear message.
+        $built = CountryFactory::new(['name' => 'Built only'])->build();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/already-persisted|isNew/');
+
+        CityFactory::new()->forCountries()->recycle($built);
+    }
+
+    public function testRecycleDoesNotOverrideCustomizedChildFactory(): void
+    {
+        // When the user passes a child factory with its own chains, that
+        // explicit setup wins over recycle. AuthorsTable belongsTo Address;
+        // we configure a per-author Address via `with('Address', AddressFactory::new()->forCity())`
+        // and recycle a *different* address. Recycle must NOT override
+        // the customized branch.
+        $recycled = AddressFactory::new()->save();
+
+        $author = AuthorFactory::new()
+            ->with('Address', AddressFactory::new()->forCity())
+            ->recycle($recycled)
+            ->save();
+
+        $this->assertNotSame(
+            $recycled->id,
+            $author->address_id,
+            'A child factory with user-set chains must not be overridden by recycle.',
+        );
+    }
+
+    public function testRecycleRejectsEntityWithoutSource(): void
+    {
+        // Manually constructed entity without setSource() — recycle should refuse.
+        $detached = new Country(['name' => 'Detached']);
+        $detached->setSource('');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/source/i');
+
+        CityFactory::new()->recycle($detached);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `BaseFactory::recycle(EntityInterface ...$entities): static` — reuses an already-persisted entity wherever a `belongsTo` association in the factory's build graph targets the same source table. Closes the silent N-duplicate-parent gap.

Mirrors Laravel's `recycle($model)` and Foundry's `reuse($entity)`.

```php
$author = AuthorFactory::new()->save();

ArticleFactory::new()
    ->count(5)
    ->with('Comments[3]')
    ->recycle($author)              // both Articles AND nested Comments reuse the saved author
    ->saveMany();
```

Without `recycle()`, that build would silently create up to 20 distinct Author rows.

## What's in this PR

- `BaseFactory::recycle(EntityInterface ...$entities): static` — variadic, immutable, chainable.
- `DataCompiler` substitutes recycled entities in `mergeWithToOne()` and propagates the recycle map into nested child factories via `inheritRecycledEntities()`.
- `DataCompiler::normalizeTableAlias()` — canonical-table-name normalization (strips `__ff_<hash>` suffix, plugin prefix, FQCN namespace, and the `Table` suffix) so both sides of the match agree.
- Documented in `docs/guide/associations.md` under a new "Recycling shared parents" section.
- 16 tests in `tests/TestCase/Factory/BaseFactoryRecycleTest.php` covering immutability, single-level substitution, batch counts, nested propagation, multi-alias same-target, variadic + chained calls, explicit per-branch overrides winning over recycle, customized-child-factory opt-out, alias-loaded entity matching, plugin-prefixed associations, unpersisted-entity / no-source rejection.

## v1 contract (documented)

- Recycled entities must already be persisted (called `->save()`). Built-but-unsaved entities are rejected with a clear error pointing to `with('Alias', $entity)` for that use case. Reason: recycle's fast path skips the child factory's persistence pipeline, so unsaved entities would never get a primary key or marker fields.
- Recycle does not override branches the user customized via `with('Alias', $entity)` (per-alias entity) or `with('Alias', Factory::new()->forX())` (chained child factory). The `configure()` defaults still receive recycle substitution.
- Recycle is a fast-path substitution: when it matches, the child factory's `buildMany()` is skipped. Cardinality validation on the to-one branch is still caught at registration time by `AssociationBuilder::validateToOneAssociation()` for the common `->count(N)` case.

## Known v1 limitations / non-goals

- Recycle does not detect customizations beyond user-added associations (e.g. `state()`, `afterBuild()`, `Factory::new($arrayData)`). For per-branch state/callback control, use `with('Alias', $entity)` directly. A broader detection model could be a follow-up if real users hit this.
- An alias-explicit overload on `for()` / `has()` is a possible follow-up.

## Verification

- `vendor/bin/phpunit` — 615 tests, 0 failures.
- `composer stan` — clean (PHPStan level 8).
- `composer cs-check` — clean.
- `codex review --uncommitted` — six review rounds; major findings addressed (explicit-with precedence, plugin-prefix matching, alias-loaded entity matching, stale-prior-with non-blocking, ambiguous-alias guard, unsaved-entity rejection, customized-child-factory opt-out). Remaining flags are documented v1 trade-offs.