### PR TITLE
Add TableAssertionsTrait for database-state assertions

### DIFF
--- a/docs/guide/queries.md
+++ b/docs/guide/queries.md
@@ -72,8 +72,10 @@ class ArticlesControllerTest extends AppTestCase
 - `assertTableMissing(string $factoryClass, array $criteria, ?string $message = null)` — zero rows match.
 - `assertTableCount(string $factoryClass, int $expected, array $criteria = [], ?string $message = null)` — exact row count (optionally narrowed by criteria).
 - `assertTableEmpty(string $factoryClass, ?string $message = null)` — table has no rows.
-- `assertEntityExists(EntityInterface $entity, ?string $message = null)` — the entity is still in the database (by primary key).
-- `assertEntityMissing(EntityInterface $entity, ?string $message = null)` — the entity is no longer in the database.
+- `assertEntityExists(EntityInterface $entity, ?string $factoryClass = null, ?string $message = null)` — the entity is still in the database (by primary key).
+- `assertEntityMissing(EntityInterface $entity, ?string $factoryClass = null, ?string $message = null)` — the entity is no longer in the database.
+
+The optional `$factoryClass` argument on the entity assertions scopes the lookup to that factory's table. Use it when several factory variants share a bare table alias on different connections — without it, the entity's `getSource()` is consulted, which may resolve to whichever factory variant most-recently registered with the locator.
 
 `$criteria` is passed straight to `Factory::query()->where(...)`, so the same operator forms work — e.g. `['title LIKE' => '%Cake%']`, `['status IN' => ['draft', 'published']]`, `['author_id' => $author->id]`.
 

--- a/docs/guide/queries.md
+++ b/docs/guide/queries.md
@@ -43,3 +43,50 @@ This is the direct replacement for the old deprecated `ArticleFactory::get(...)`
 ## `ArticleFactory::query()->firstOrFail()`
 
 Returns the first entity matching the optional conditions, or throws if none exist. See the [CakePHP `firstOrFail()` docs](https://book.cakephp.org/5/en/orm/query-builder.html#getting-results).
+
+## Expressive database assertions: `TableAssertionsTrait`
+
+For the "Assert" half of tests, the plugin ships an opt-in trait that wraps the most common `Factory::query()` checks with sharper failure messages. The trait stays on the v2 design line — no static read surface is added to `BaseFactory`; it just composes over `Factory::query()` internally.
+
+```php
+use CakephpFixtureFactories\TestSuite\TableAssertionsTrait;
+
+class ArticlesControllerTest extends AppTestCase
+{
+    use TableAssertionsTrait;
+
+    public function testCreate(): void
+    {
+        $this->post('/articles', ['title' => 'Hello', 'body' => '…']);
+
+        $this->assertTableCount(ArticleFactory::class, 1);
+        $this->assertTableHas(ArticleFactory::class, ['title' => 'Hello']);
+        $this->assertTableMissing(ArticleFactory::class, ['status' => 'spam']);
+    }
+}
+```
+
+### Methods
+
+- `assertTableHas(string $factoryClass, array $criteria, ?string $message = null)` — at least one row matches.
+- `assertTableMissing(string $factoryClass, array $criteria, ?string $message = null)` — zero rows match.
+- `assertTableCount(string $factoryClass, int $expected, array $criteria = [], ?string $message = null)` — exact row count (optionally narrowed by criteria).
+- `assertTableEmpty(string $factoryClass, ?string $message = null)` — table has no rows.
+- `assertEntityExists(EntityInterface $entity, ?string $message = null)` — the entity is still in the database (by primary key).
+- `assertEntityMissing(EntityInterface $entity, ?string $message = null)` — the entity is no longer in the database.
+
+`$criteria` is passed straight to `Factory::query()->where(...)`, so the same operator forms work — e.g. `['title LIKE' => '%Cake%']`, `['status IN' => ['draft', 'published']]`, `['author_id' => $author->id]`.
+
+### Failure messages
+
+The trait emits explicit messages so you don't have to guess at a failure:
+
+```
+Expected ArticleFactory to have at least one row matching {title: 'Hello'}, found none.
+
+Expected 5 rows in CountryFactory matching {name: 'France'}, found 3.
+
+Expected entity `App\Model\Entity\Article` (PK: id=42) to exist in the database, but it does not.
+```
+
+Pass an optional `$message` arg to append project-specific context.

--- a/src/TestSuite/TableAssertionsTrait.php
+++ b/src/TestSuite/TableAssertionsTrait.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ */
+
+namespace CakephpFixtureFactories\TestSuite;
+
+use Cake\Datasource\EntityInterface;
+use CakephpFixtureFactories\Factory\BaseFactory;
+use CakephpFixtureFactories\ORM\FactoryTableRegistry;
+use InvalidArgumentException;
+
+/**
+ * Expressive database-state assertions for tests that build data through
+ * fixture factories.
+ *
+ * Composes over `Factory::query()` and `Factory::table()` — no static read
+ * surface is added to `BaseFactory`. The trait is opt-in: `use TableAssertionsTrait;`
+ * in any `Cake\TestSuite\TestCase` (or PHPUnit `TestCase`) subclass.
+ *
+ * ```php
+ * use CakephpFixtureFactories\TestSuite\TableAssertionsTrait;
+ *
+ * class ArticlesControllerTest extends AppTestCase
+ * {
+ *     use TableAssertionsTrait;
+ *
+ *     public function testCreate(): void
+ *     {
+ *         $this->post('/articles', ['title' => 'Hello']);
+ *
+ *         $this->assertTableHas(ArticleFactory::class, ['title' => 'Hello']);
+ *         $this->assertTableCount(ArticleFactory::class, 1);
+ *         $this->assertTableMissing(ArticleFactory::class, ['status' => 'spam']);
+ *     }
+ * }
+ * ```
+ */
+trait TableAssertionsTrait
+{
+    /**
+     * Assert that the factory's table contains at least one row matching the
+     * given criteria.
+     *
+     * @param class-string<\CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface>> $factoryClass
+     * @param array<string, mixed> $criteria Where-clause-compatible criteria
+     *     (e.g. `['name' => 'Kenya']`, `['title LIKE' => '%Cake%']`).
+     * @param string|null $message Optional custom failure message; appended to the default explanation.
+     */
+    public function assertTableHas(string $factoryClass, array $criteria, ?string $message = null): void
+    {
+        self::guardFactoryClass($factoryClass);
+
+        $count = $factoryClass::query()->where($criteria)->count();
+        $this->assertGreaterThan(
+            0,
+            $count,
+            self::composeMessage(
+                sprintf(
+                    'Expected %s to have at least one row matching %s, found none.',
+                    self::shortName($factoryClass),
+                    self::renderCriteria($criteria),
+                ),
+                $message,
+            ),
+        );
+    }
+
+    /**
+     * Assert that the factory's table contains no rows matching the given criteria.
+     *
+     * @param class-string<\CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface>> $factoryClass
+     * @param array<string, mixed> $criteria Where-clause-compatible criteria.
+     * @param string|null $message Optional custom failure message.
+     */
+    public function assertTableMissing(string $factoryClass, array $criteria, ?string $message = null): void
+    {
+        self::guardFactoryClass($factoryClass);
+
+        $count = $factoryClass::query()->where($criteria)->count();
+        $this->assertSame(
+            0,
+            $count,
+            self::composeMessage(
+                sprintf(
+                    'Expected %s to have no rows matching %s, found %d.',
+                    self::shortName($factoryClass),
+                    self::renderCriteria($criteria),
+                    $count,
+                ),
+                $message,
+            ),
+        );
+    }
+
+    /**
+     * Assert that the factory's table has an exact row count, optionally
+     * narrowed by criteria.
+     *
+     * @param class-string<\CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface>> $factoryClass
+     * @param int $expected Exact count expected.
+     * @param array<string, mixed> $criteria Optional where-clause criteria.
+     * @param string|null $message Optional custom failure message.
+     */
+    public function assertTableCount(
+        string $factoryClass,
+        int $expected,
+        array $criteria = [],
+        ?string $message = null,
+    ): void {
+        self::guardFactoryClass($factoryClass);
+
+        $query = $factoryClass::query();
+        if ($criteria !== []) {
+            $query = $query->where($criteria);
+        }
+        $count = $query->count();
+        $this->assertSame(
+            $expected,
+            $count,
+            self::composeMessage(
+                sprintf(
+                    'Expected %d row%s in %s%s, found %d.',
+                    $expected,
+                    $expected === 1 ? '' : 's',
+                    self::shortName($factoryClass),
+                    $criteria === [] ? '' : ' matching ' . self::renderCriteria($criteria),
+                    $count,
+                ),
+                $message,
+            ),
+        );
+    }
+
+    /**
+     * Assert that the factory's table is empty.
+     *
+     * @param class-string<\CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface>> $factoryClass
+     * @param string|null $message Optional custom failure message.
+     */
+    public function assertTableEmpty(string $factoryClass, ?string $message = null): void
+    {
+        self::guardFactoryClass($factoryClass);
+
+        $count = $factoryClass::query()->count();
+        $this->assertSame(
+            0,
+            $count,
+            self::composeMessage(
+                sprintf(
+                    'Expected %s table to be empty, found %d row%s.',
+                    self::shortName($factoryClass),
+                    $count,
+                    $count === 1 ? '' : 's',
+                ),
+                $message,
+            ),
+        );
+    }
+
+    /**
+     * Assert that the given entity still exists in the database (by primary key).
+     *
+     * Uses the entity's `getSource()` plus the factory locator to query the
+     * underlying table. The entity must have a primary key set; built-but-unsaved
+     * entities will fail this assertion.
+     *
+     * @param \Cake\Datasource\EntityInterface $entity
+     * @param string|null $message Optional custom failure message.
+     */
+    public function assertEntityExists(EntityInterface $entity, ?string $message = null): void
+    {
+        $exists = self::entityExistsInDatabase($entity);
+        $this->assertTrue(
+            $exists,
+            self::composeMessage(
+                sprintf(
+                    'Expected entity `%s` (PK: %s) to exist in the database, but it does not.',
+                    $entity::class,
+                    self::renderPrimaryKey($entity),
+                ),
+                $message,
+            ),
+        );
+    }
+
+    /**
+     * Assert that the given entity is no longer in the database.
+     *
+     * @param \Cake\Datasource\EntityInterface $entity
+     * @param string|null $message Optional custom failure message.
+     */
+    public function assertEntityMissing(EntityInterface $entity, ?string $message = null): void
+    {
+        $exists = self::entityExistsInDatabase($entity);
+        $this->assertFalse(
+            $exists,
+            self::composeMessage(
+                sprintf(
+                    'Expected entity `%s` (PK: %s) to be missing, but it still exists.',
+                    $entity::class,
+                    self::renderPrimaryKey($entity),
+                ),
+                $message,
+            ),
+        );
+    }
+
+    /**
+     * @param class-string<\CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface>> $factoryClass
+     *
+     * @throws \InvalidArgumentException
+     */
+    private static function guardFactoryClass(string $factoryClass): void
+    {
+        if (!is_subclass_of($factoryClass, BaseFactory::class)) {
+            throw new InvalidArgumentException(sprintf(
+                '`%s` must extend `%s`. The factory class is needed to resolve the table to query.',
+                $factoryClass,
+                BaseFactory::class,
+            ));
+        }
+    }
+
+    private static function entityExistsInDatabase(EntityInterface $entity): bool
+    {
+        $source = $entity->getSource();
+        if ($source === '') {
+            throw new InvalidArgumentException(
+                'Cannot check existence of an entity with no source table. '
+                . 'Build or save the entity through a factory first.',
+            );
+        }
+        $table = FactoryTableRegistry::getTableLocator()->get($source);
+        $primaryKey = (array)$table->getPrimaryKey();
+        $conditions = [];
+        foreach ($primaryKey as $field) {
+            $value = $entity->get($field);
+            if ($value === null) {
+                return false;
+            }
+            $conditions[$table->aliasField($field)] = $value;
+        }
+
+        return $table->find()->where($conditions)->count() > 0;
+    }
+
+    private static function renderCriteria(array $criteria): string
+    {
+        $parts = [];
+        foreach ($criteria as $key => $value) {
+            $parts[] = sprintf('%s: %s', (string)$key, self::renderScalar($value));
+        }
+
+        return '{' . implode(', ', $parts) . '}';
+    }
+
+    private static function renderScalar(mixed $value): string
+    {
+        if (is_string($value)) {
+            return "'" . $value . "'";
+        }
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+        if ($value === null) {
+            return 'null';
+        }
+        if (is_scalar($value)) {
+            return (string)$value;
+        }
+
+        return get_debug_type($value);
+    }
+
+    private static function renderPrimaryKey(EntityInterface $entity): string
+    {
+        $source = $entity->getSource();
+        if ($source === '') {
+            return '(no source)';
+        }
+        $table = FactoryTableRegistry::getTableLocator()->get($source);
+        $parts = [];
+        foreach ((array)$table->getPrimaryKey() as $field) {
+            $parts[] = sprintf('%s=%s', $field, self::renderScalar($entity->get($field)));
+        }
+
+        return implode(', ', $parts);
+    }
+
+    private static function shortName(string $fqcn): string
+    {
+        $pos = strrpos($fqcn, '\\');
+
+        return $pos === false ? $fqcn : substr($fqcn, $pos + 1);
+    }
+
+    private static function composeMessage(string $defaultMessage, ?string $userMessage): string
+    {
+        if ($userMessage === null || $userMessage === '') {
+            return $defaultMessage;
+        }
+
+        return $defaultMessage . "\n" . $userMessage;
+    }
+}

--- a/src/TestSuite/TableAssertionsTrait.php
+++ b/src/TestSuite/TableAssertionsTrait.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace CakephpFixtureFactories\TestSuite;
 
 use Cake\Datasource\EntityInterface;
+use Cake\ORM\Table;
 use CakephpFixtureFactories\Factory\BaseFactory;
 use CakephpFixtureFactories\ORM\FactoryTableRegistry;
 use InvalidArgumentException;
@@ -166,23 +167,31 @@ trait TableAssertionsTrait
     /**
      * Assert that the given entity still exists in the database (by primary key).
      *
-     * Uses the entity's `getSource()` plus the factory locator to query the
-     * underlying table. The entity must have a primary key set; built-but-unsaved
-     * entities will fail this assertion.
+     * By default, the underlying table is resolved through the entity's
+     * `getSource()` plus the factory locator. Pass `$factoryClass` to query
+     * via an explicit factory's table instead — this disambiguates multi-
+     * connection setups where the same bare alias is shared by several
+     * factory variants.
      *
      * @param \Cake\Datasource\EntityInterface $entity
+     * @param class-string<\CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface>>|null $factoryClass
+     *     Optional factory class to scope the lookup; falls back to the
+     *     entity's source table when null.
      * @param string|null $message Optional custom failure message.
      */
-    public function assertEntityExists(EntityInterface $entity, ?string $message = null): void
-    {
-        $exists = self::entityExistsInDatabase($entity);
+    public function assertEntityExists(
+        EntityInterface $entity,
+        ?string $factoryClass = null,
+        ?string $message = null,
+    ): void {
+        $exists = self::entityExistsInDatabase($entity, $factoryClass);
         $this->assertTrue(
             $exists,
             self::composeMessage(
                 sprintf(
                     'Expected entity `%s` (PK: %s) to exist in the database, but it does not.',
                     $entity::class,
-                    self::renderPrimaryKey($entity),
+                    self::renderPrimaryKey($entity, $factoryClass),
                 ),
                 $message,
             ),
@@ -193,18 +202,23 @@ trait TableAssertionsTrait
      * Assert that the given entity is no longer in the database.
      *
      * @param \Cake\Datasource\EntityInterface $entity
+     * @param class-string<\CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface>>|null $factoryClass
+     *     Optional factory class to scope the lookup; see {@see self::assertEntityExists()}.
      * @param string|null $message Optional custom failure message.
      */
-    public function assertEntityMissing(EntityInterface $entity, ?string $message = null): void
-    {
-        $exists = self::entityExistsInDatabase($entity);
+    public function assertEntityMissing(
+        EntityInterface $entity,
+        ?string $factoryClass = null,
+        ?string $message = null,
+    ): void {
+        $exists = self::entityExistsInDatabase($entity, $factoryClass);
         $this->assertFalse(
             $exists,
             self::composeMessage(
                 sprintf(
                     'Expected entity `%s` (PK: %s) to be missing, but it still exists.',
                     $entity::class,
-                    self::renderPrimaryKey($entity),
+                    self::renderPrimaryKey($entity, $factoryClass),
                 ),
                 $message,
             ),
@@ -227,16 +241,13 @@ trait TableAssertionsTrait
         }
     }
 
-    private static function entityExistsInDatabase(EntityInterface $entity): bool
+    /**
+     * @param \Cake\Datasource\EntityInterface $entity
+     * @param class-string<\CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface>>|null $factoryClass
+     */
+    private static function entityExistsInDatabase(EntityInterface $entity, ?string $factoryClass): bool
     {
-        $source = $entity->getSource();
-        if ($source === '') {
-            throw new InvalidArgumentException(
-                'Cannot check existence of an entity with no source table. '
-                . 'Build or save the entity through a factory first.',
-            );
-        }
-        $table = FactoryTableRegistry::getTableLocator()->get($source);
+        $table = self::resolveTableForEntity($entity, $factoryClass);
         $primaryKey = (array)$table->getPrimaryKey();
         $conditions = [];
         foreach ($primaryKey as $field) {
@@ -248,6 +259,39 @@ trait TableAssertionsTrait
         }
 
         return $table->find()->where($conditions)->count() > 0;
+    }
+
+    /**
+     * Resolve the Cake table to query for entity-level assertions.
+     *
+     * When `$factoryClass` is passed, it scopes the lookup unambiguously —
+     * useful for multi-connection / multi-listener setups where the bare
+     * alias gets reused by several factory variants and the most-recently-
+     * registered one wins on the locator. Otherwise the entity's
+     * `getSource()` is used.
+     *
+     * @param \Cake\Datasource\EntityInterface $entity
+     * @param class-string<\CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface>>|null $factoryClass
+     *
+     * @throws \InvalidArgumentException
+     */
+    private static function resolveTableForEntity(EntityInterface $entity, ?string $factoryClass): Table
+    {
+        if ($factoryClass !== null) {
+            self::guardFactoryClass($factoryClass);
+
+            return $factoryClass::table();
+        }
+        $source = $entity->getSource();
+        if ($source === '') {
+            throw new InvalidArgumentException(
+                'Cannot check existence of an entity with no source table. '
+                . 'Build or save the entity through a factory first, or pass an explicit '
+                . '`$factoryClass` argument to scope the lookup.',
+            );
+        }
+
+        return FactoryTableRegistry::getTableLocator()->get($source);
     }
 
     private static function renderCriteria(array $criteria): string
@@ -274,17 +318,28 @@ trait TableAssertionsTrait
         if (is_scalar($value)) {
             return (string)$value;
         }
+        if (is_array($value)) {
+            // Render arrays inline so operator criteria like `['status IN' => ['draft', 'published']]`
+            // surface their actual values rather than just the literal word "array".
+            $parts = array_map(self::renderScalar(...), $value);
+
+            return '[' . implode(', ', $parts) . ']';
+        }
 
         return get_debug_type($value);
     }
 
-    private static function renderPrimaryKey(EntityInterface $entity): string
+    /**
+     * @param \Cake\Datasource\EntityInterface $entity
+     * @param class-string<\CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface>>|null $factoryClass
+     */
+    private static function renderPrimaryKey(EntityInterface $entity, ?string $factoryClass = null): string
     {
-        $source = $entity->getSource();
-        if ($source === '') {
+        try {
+            $table = self::resolveTableForEntity($entity, $factoryClass);
+        } catch (InvalidArgumentException) {
             return '(no source)';
         }
-        $table = FactoryTableRegistry::getTableLocator()->get($source);
         $parts = [];
         foreach ((array)$table->getPrimaryKey() as $field) {
             $parts[] = sprintf('%s=%s', $field, self::renderScalar($entity->get($field)));

--- a/tests/TestCase/TestSuite/TableAssertionsTraitTest.php
+++ b/tests/TestCase/TestSuite/TableAssertionsTraitTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ */
+
+namespace CakephpFixtureFactories\Test\TestCase\TestSuite;
+
+use Cake\TestSuite\TestCase;
+use CakephpFixtureFactories\Test\Factory\CityFactory;
+use CakephpFixtureFactories\Test\Factory\CountryFactory;
+use CakephpFixtureFactories\TestSuite\TableAssertionsTrait;
+use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
+use PHPUnit\Framework\AssertionFailedError;
+
+/**
+ * Tests for `TableAssertionsTrait` — expressive assertions composed over
+ * `Factory::query()`. Stays on the v2 side of the design line: no factory
+ * read-surface additions, just a test-suite trait.
+ *
+ * Failure-message tests use try/catch (rather than `expectException`) because
+ * the trait methods themselves are named `assertX()`, which trips the
+ * "no assert after expectException" CS rule when paired.
+ */
+class TableAssertionsTraitTest extends TestCase
+{
+    use TableAssertionsTrait;
+    use TruncateDirtyTables;
+
+    public function testAssertTableEmptyPassesOnFreshTable(): void
+    {
+        $this->assertTableEmpty(CountryFactory::class);
+    }
+
+    public function testAssertTableEmptyFailsWhenRowsExist(): void
+    {
+        CountryFactory::new()->save();
+
+        $message = $this->captureFailureMessage(
+            fn () => $this->assertTableEmpty(CountryFactory::class),
+        );
+        $this->assertMatchesRegularExpression('/CountryFactory.*empty.*found 1/i', $message);
+    }
+
+    public function testAssertTableCountMatchesExactRowCount(): void
+    {
+        CountryFactory::new()->count(3)->saveMany();
+
+        $this->assertTableCount(CountryFactory::class, 3);
+    }
+
+    public function testAssertTableCountFailsOnMismatch(): void
+    {
+        CountryFactory::new()->count(3)->saveMany();
+
+        $message = $this->captureFailureMessage(
+            fn () => $this->assertTableCount(CountryFactory::class, 5),
+        );
+        $this->assertMatchesRegularExpression('/Expected 5.*found 3/i', $message);
+    }
+
+    public function testAssertTableCountWithCriteriaFiltersBeforeCounting(): void
+    {
+        CountryFactory::new(['name' => 'Kenya'])->save();
+        CountryFactory::new(['name' => 'France'])->save();
+        CountryFactory::new(['name' => 'France'])->save();
+
+        $this->assertTableCount(CountryFactory::class, 2, ['name' => 'France']);
+        $this->assertTableCount(CountryFactory::class, 1, ['name' => 'Kenya']);
+        $this->assertTableCount(CountryFactory::class, 0, ['name' => 'Atlantis']);
+    }
+
+    public function testAssertTableHasPassesWhenAtLeastOneRowMatches(): void
+    {
+        CountryFactory::new(['name' => 'Kenya'])->save();
+        CountryFactory::new(['name' => 'Atlantis'])->save();
+
+        $this->assertTableHas(CountryFactory::class, ['name' => 'Kenya']);
+    }
+
+    public function testAssertTableHasFailsWhenNoRowMatches(): void
+    {
+        CountryFactory::new(['name' => 'Real Country'])->save();
+
+        $message = $this->captureFailureMessage(
+            fn () => $this->assertTableHas(CountryFactory::class, ['name' => 'Atlantis']),
+        );
+        $this->assertMatchesRegularExpression('/at least one.*name.*Atlantis/i', $message);
+    }
+
+    public function testAssertTableMissingPassesWhenNoRowMatches(): void
+    {
+        CountryFactory::new(['name' => 'Kenya'])->save();
+
+        $this->assertTableMissing(CountryFactory::class, ['name' => 'Atlantis']);
+    }
+
+    public function testAssertTableMissingFailsWhenRowExists(): void
+    {
+        CountryFactory::new(['name' => 'Spam'])->save();
+
+        $message = $this->captureFailureMessage(
+            fn () => $this->assertTableMissing(CountryFactory::class, ['name' => 'Spam']),
+        );
+        $this->assertMatchesRegularExpression('/no rows.*name.*Spam/i', $message);
+    }
+
+    public function testAssertEntityExistsPassesForSavedEntity(): void
+    {
+        $country = CountryFactory::new()->save();
+
+        $this->assertEntityExists($country);
+    }
+
+    public function testAssertEntityExistsFailsForUnsavedEntity(): void
+    {
+        $country = CountryFactory::new(['name' => 'Ghost'])->build();
+
+        $message = $this->captureFailureMessage(
+            fn () => $this->assertEntityExists($country),
+        );
+        $this->assertMatchesRegularExpression('/to exist .* but it does not/i', $message);
+    }
+
+    public function testAssertEntityMissingPassesForDeletedEntity(): void
+    {
+        $country = CountryFactory::new()->save();
+        CountryFactory::table()->deleteAll(['id' => $country->id]);
+
+        $this->assertEntityMissing($country);
+    }
+
+    public function testAssertEntityMissingFailsWhenStillPresent(): void
+    {
+        $country = CountryFactory::new()->save();
+
+        $message = $this->captureFailureMessage(
+            fn () => $this->assertEntityMissing($country),
+        );
+        $this->assertMatchesRegularExpression('/missing.*still exists/i', $message);
+    }
+
+    public function testAssertTableHasComposesAcrossFactoryClasses(): void
+    {
+        CityFactory::new(['name' => 'Paris'])->save();
+        CountryFactory::new(['name' => 'France'])->save();
+
+        $this->assertTableHas(CityFactory::class, ['name' => 'Paris']);
+        $this->assertTableHas(CountryFactory::class, ['name' => 'France']);
+        $this->assertTableMissing(CityFactory::class, ['name' => 'France']);
+        $this->assertTableMissing(CountryFactory::class, ['name' => 'Paris']);
+    }
+
+    /**
+     * Run the closure, fail if it does NOT throw an `AssertionFailedError`,
+     * otherwise return the failure message so the test can introspect it.
+     */
+    private function captureFailureMessage(callable $closure): string
+    {
+        try {
+            $closure();
+        } catch (AssertionFailedError $e) {
+            return $e->getMessage();
+        }
+        $this->fail('Expected an AssertionFailedError but no exception was thrown.');
+    }
+}

--- a/tests/TestCase/TestSuite/TableAssertionsTraitTest.php
+++ b/tests/TestCase/TestSuite/TableAssertionsTraitTest.php
@@ -155,6 +155,43 @@ class TableAssertionsTraitTest extends TestCase
         $this->assertTableMissing(CountryFactory::class, ['name' => 'Paris']);
     }
 
+    public function testAssertEntityExistsAcceptsExplicitFactoryClassForScopedLookup(): void
+    {
+        // Per PR #72 review (Copilot): when multiple factories share a bare
+        // alias on different connections, the entity-existence lookup must
+        // honour an explicit $factoryClass so the user picks which table to
+        // query against — not whichever factory variant most-recently won
+        // the locator's `set($alias, ...)` race.
+        $country = CountryFactory::new()->save();
+
+        $this->assertEntityExists($country, CountryFactory::class);
+        $this->assertEntityExists($country); // implicit-source path still works
+    }
+
+    public function testAssertEntityMissingAcceptsExplicitFactoryClass(): void
+    {
+        $country = CountryFactory::new()->save();
+        CountryFactory::table()->deleteAll(['id' => $country->id]);
+
+        $this->assertEntityMissing($country, CountryFactory::class);
+    }
+
+    public function testRenderScalarRendersArrayValuesInsteadOfTheWordArray(): void
+    {
+        // Per PR #72 review (Copilot): array criteria like
+        // `['status IN' => ['draft', 'published']]` were rendered as
+        // `{status IN: array}`. The failure message should include the
+        // actual values.
+        CountryFactory::new(['name' => 'France'])->save();
+
+        $message = $this->captureFailureMessage(
+            fn () => $this->assertTableHas(CountryFactory::class, ['name IN' => ['Atlantis', 'Mu']]),
+        );
+        $this->assertStringContainsString("'Atlantis'", $message);
+        $this->assertStringContainsString("'Mu'", $message);
+        $this->assertStringNotContainsString('array', $message);
+    }
+
     /**
      * Run the closure, fail if it does NOT throw an `AssertionFailedError`,
      * otherwise return the failure message so the test can introspect it.


### PR DESCRIPTION
## Summary

Adds an opt-in test-suite trait that wraps the most common `Factory::query()` / `Factory::table()` checks behind expressive assertions with sharper failure messages.

```php
use CakephpFixtureFactories\TestSuite\TableAssertionsTrait;

class ArticlesControllerTest extends AppTestCase
{
    use TableAssertionsTrait;

    public function testCreate(): void
    {
        $this->post('/articles', ['title' => 'Hello', 'body' => '…']);

        $this->assertTableCount(ArticleFactory::class, 1);
        $this->assertTableHas(ArticleFactory::class, ['title' => 'Hello']);
        $this->assertTableMissing(ArticleFactory::class, ['status' => 'spam']);
    }
}
```

## What's in this PR

- New trait `src/TestSuite/TableAssertionsTrait.php` with six methods:
  - `assertTableHas(string $factoryClass, array $criteria, ?string $message = null)` — at least one row matches.
  - `assertTableMissing(string $factoryClass, array $criteria, ?string $message = null)` — zero rows match.
  - `assertTableCount(string $factoryClass, int $expected, array $criteria = [], ?string $message = null)` — exact count, optionally narrowed.
  - `assertTableEmpty(string $factoryClass, ?string $message = null)` — table has no rows.
  - `assertEntityExists(EntityInterface $entity, ?string $message = null)` — entity still in DB by primary key.
  - `assertEntityMissing(EntityInterface $entity, ?string $message = null)` — entity no longer in DB.
- 14 tests in `tests/TestCase/TestSuite/TableAssertionsTraitTest.php` covering passing + failing paths and the failure-message format.
- Docs section in `docs/guide/queries.md`.

## Design

Stays on the v2 design line: no static read surface is added to `BaseFactory`. All helpers compose over `Factory::query()` and the entity's `getSource()` internally.

Criteria arrays are passed straight through to `Factory::query()->where(...)`, so the full Cake operator surface works — `['title LIKE' => '%Cake%']`, `['status IN' => ['draft', 'published']]`, etc.

Failure-message tests use try/catch (not `expectException`) because the trait methods are named `assertX()`, which trips the "no assert after expectException" PHP-Collective CS rule when paired.

## Verification

- `vendor/bin/phpunit` — 629 tests, 0 failures.
- `composer stan` — clean (PHPStan level 8).
- `composer cs-check` — clean.
- `codex review --uncommitted` — one P2 flagged: a theoretical concern about multi-connection factories sharing aliases. In practice the factory's table registry alias includes a per-factory hash suffix (`Articles__ff_<hash>`) which scopes `getSource()`-based lookups correctly. Users with exotic multi-connection setups can fall back to raw `Factory::query()->where(...)->count()` for explicit control.