### PR TITLE
Clear PHPUnit 13 mock-without-expectations notices

### DIFF
--- a/tests/TestCase/Command/BakeFixtureFactoryCommandTest.php
+++ b/tests/TestCase/Command/BakeFixtureFactoryCommandTest.php
@@ -24,6 +24,7 @@ use CakephpFixtureFactories\Factory\BaseFactory;
 use CakephpFixtureFactories\Test\Util\TestCaseWithFixtureBaking;
 use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionClass;
 use TestApp\Model\Entity\Address;
@@ -409,6 +410,7 @@ class BakeFixtureFactoryCommandTest extends TestCaseWithFixtureBaking
      * — this test covers it through the command's public guessFor() surface
      * so the bake output is verified end-to-end.
      */
+    #[AllowMockObjectsWithoutExpectations]
     public function testGetUniqueFieldsDetection(): void
     {
         // Create a mock table with schema containing unique constraints
@@ -480,6 +482,7 @@ class BakeFixtureFactoryCommandTest extends TestCaseWithFixtureBaking
         $this->assertStringNotContainsString('->unique()->', $defaults['created']);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testSchemaForeignKeyIsSkippedWithoutAssociation(): void
     {
         $schema = $this->getMockBuilder('\Cake\Database\Schema\TableSchema')
@@ -525,6 +528,7 @@ class BakeFixtureFactoryCommandTest extends TestCaseWithFixtureBaking
         $this->assertArrayHasKey('title', $defaults);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testCompositeUniqueConstraintDoesNotForcePerColumnUniqueness(): void
     {
         $schema = $this->getMockBuilder('\Cake\Database\Schema\TableSchema')
@@ -575,6 +579,7 @@ class BakeFixtureFactoryCommandTest extends TestCaseWithFixtureBaking
     /**
      * Test that unique fields get wrapped with ->unique()-> in default data
      */
+    #[AllowMockObjectsWithoutExpectations]
     public function testDefaultDataWithUniqueFields(): void
     {
         // Create a mock schema with unique constraint on username

--- a/tests/TestCase/Factory/UniquenessJanitorTest.php
+++ b/tests/TestCase/Factory/UniquenessJanitorTest.php
@@ -51,7 +51,7 @@ class UniquenessJanitorTest extends TestCase
     #[DataProvider('dataForSanitizeEntityArrayOnPrimary')]
     public function testSanitizeEntityArrayOnPrimary(array $uniqueProperties, bool $expectException): void
     {
-        $factoryStub = $this->getMockBuilder(BaseFactory::class)->disableOriginalConstructor()->getMock();
+        $factoryStub = $this->createStub(BaseFactory::class);
         $factoryStub->method('getUniqueProperties')->willReturn($uniqueProperties);
 
         $entities = [
@@ -101,7 +101,7 @@ class UniquenessJanitorTest extends TestCase
     #[DataProvider('dataForSanitizeEntityArrayOnAssociation')]
     public function testSanitizeEntityArrayOnAssociation(array $uniqueProperties, array $expectOutput): void
     {
-        $factoryStub = $this->getMockBuilder(BaseFactory::class)->disableOriginalConstructor()->getMock();
+        $factoryStub = $this->createStub(BaseFactory::class);
         $factoryStub->method('getUniqueProperties')->willReturn($uniqueProperties);
 
         $associations = [
@@ -120,7 +120,7 @@ class UniquenessJanitorTest extends TestCase
 
     public function testSanitizeEntityArrayDoesNotMutateHiddenFieldsOnOriginalEntity(): void
     {
-        $factoryStub = $this->getMockBuilder(BaseFactory::class)->disableOriginalConstructor()->getMock();
+        $factoryStub = $this->createStub(BaseFactory::class);
         $factoryStub->method('getUniqueProperties')->willReturn(['property_1']);
 
         $entity = new Entity(['property_1' => 'foo', 'secret' => 'value']);
@@ -133,7 +133,7 @@ class UniquenessJanitorTest extends TestCase
 
     public function testSanitizeEntityArrayUsesStrictComparisonForUniqueValues(): void
     {
-        $factoryStub = $this->getMockBuilder(BaseFactory::class)->disableOriginalConstructor()->getMock();
+        $factoryStub = $this->createStub(BaseFactory::class);
         $factoryStub->method('getUniqueProperties')->willReturn(['property_1']);
 
         $entities = [
@@ -148,7 +148,7 @@ class UniquenessJanitorTest extends TestCase
 
     public function testSanitizeEntityArrayDetectsFalseyDuplicateValues(): void
     {
-        $factoryStub = $this->getMockBuilder(BaseFactory::class)->disableOriginalConstructor()->getMock();
+        $factoryStub = $this->createStub(BaseFactory::class);
         $factoryStub->method('getUniqueProperties')->willReturn(['property_1']);
 
         $entities = [
@@ -162,7 +162,7 @@ class UniquenessJanitorTest extends TestCase
 
     public function testSanitizeEntityArrayRemovesAllLaterDuplicatesInNonStrictMode(): void
     {
-        $factoryStub = $this->getMockBuilder(BaseFactory::class)->disableOriginalConstructor()->getMock();
+        $factoryStub = $this->createStub(BaseFactory::class);
         $factoryStub->method('getUniqueProperties')->willReturn(['property_1']);
 
         $entities = [

--- a/tests/TestCase/ORM/SelectQueryMockerTest.php
+++ b/tests/TestCase/ORM/SelectQueryMockerTest.php
@@ -21,8 +21,10 @@ use CakephpFixtureFactories\ORM\SelectQueryMocker;
 use CakephpFixtureFactories\Test\Factory\CityFactory;
 use CakephpFixtureFactories\Test\Factory\CountryFactory;
 use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use TestApp\Model\Entity\Country;
 
+#[AllowMockObjectsWithoutExpectations]
 class SelectQueryMockerTest extends TestCase
 {
     use TruncateDirtyTables;

--- a/tests/TestCase/TestSuite/FactoryTransactionStrategyTest.php
+++ b/tests/TestCase/TestSuite/FactoryTransactionStrategyTest.php
@@ -19,6 +19,7 @@ use CakephpFixtureFactories\TestSuite\FactoryTableTracker;
 use CakephpFixtureFactories\TestSuite\FactoryTransactionStrategy;
 use CakephpFixtureFactories\TestSuite\LazyFactoryTransactionStrategy;
 use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use RuntimeException;
 
 /**
@@ -288,6 +289,7 @@ class FactoryTransactionStrategyTest extends TestCase
      *
      * @return void
      */
+    #[AllowMockObjectsWithoutExpectations]
     public function testCrossConnectionSameTableNameKeepsBoth(): void
     {
         $tracker = FactoryTableTracker::getInstance();


### PR DESCRIPTION
## Summary

PHPUnit 12 introduced a notice when a mock created via `getMockBuilder` / `createMock` / `createConfiguredMock` is used without configuring at least one `expects()` call. The package already accepts PHPUnit 12/13 via `composer.json` (`^11.5 || ^12.1 || ^13.0`), but the test suite was emitting **23 such notices** on every run — drowning real test signal in noise.

This PR clears every one of them. After the change, `vendor/bin/phpunit` reports `Tests: 615, Skipped: 11` with **0 PHPUnit notices**.

## What changed

- **`UniquenessJanitorTest`** — replace `getMockBuilder(BaseFactory)->disableOriginalConstructor()->getMock()` (×6) with `createStub(BaseFactory)`. The factory mocks are pure stubs (return values only, no call-count verification), so `createStub()` is the semantically correct primitive.
- **`BakeFixtureFactoryCommandTest`** — four tests build partial mocks of `TableSchema` / `AssociationCollection` / `Table` with `setConstructorArgs()` + `onlyMethods()`, which neither `createMock` nor `createStub` support. Annotated each affected test with `#[AllowMockObjectsWithoutExpectations]` — explicit opt-in to the stub-style mock usage.
- **`SelectQueryMockerTest`** — tagged the class with `#[AllowMockObjectsWithoutExpectations]` since all three tests route through `SelectQueryMocker::mock()`, which internally creates `SelectQuery` and `QueryFactory` partial mocks via reflection over the test case's `getMockBuilder()`.
- **`FactoryTransactionStrategyTest::testCrossConnectionSameTableNameKeepsBoth`** — the test uses `createConfiguredMock(Connection|Table)` for return-value stubs without `expects()`; annotated that method explicitly.

## Verification

- `vendor/bin/phpunit` — 615 tests pass, **0 PHPUnit notices** (was 23).
- `composer stan` — clean (PHPStan level 8).
- `composer cs-check` — clean.
- `codex review --uncommitted` — clean; no regressions flagged.

Pure test-suite hygiene; no production code touched.
