### PR TITLE
Add Story scenario with named entity pools

### DIFF
--- a/docs/guide/scenarios.md
+++ b/docs/guide/scenarios.md
@@ -81,3 +81,58 @@ class FixtureScenarioTest extends TestCase
 }
 
 ```
+
+## Story pattern: named entity pools
+
+For scenarios that seed data and then need to be **sampled** from in the body of the test — "give me one random author from the 10 you just seeded" — extend the `Story` abstract class instead of implementing `FixtureScenarioInterface` directly. `Story` ships with a small pool API on top of the same loading machinery.
+
+```php
+use CakephpFixtureFactories\Scenario\Story;
+
+class BlogStory extends Story
+{
+    protected function build(): void
+    {
+        $this->addToPool('authors',    UserFactory::new()->count(10)->saveMany());
+        $this->addToPool('categories', CategoryFactory::new()->count(3)->saveMany());
+
+        // Seed 50 articles randomly distributed across the pooled authors:
+        ArticleFactory::new()
+            ->count(50)
+            ->afterBuild(fn ($article) => $article->set('author_id', $this->getRandom('authors')->id))
+            ->saveMany();
+    }
+}
+```
+
+In the test, `loadFixtureScenario()` returns the `Story` instance so the same handles are available for assertions and follow-up factory builds:
+
+```php
+class FeedTest extends TestCase
+{
+    use ScenarioAwareTrait;
+
+    public function testRandomArticleHasAPooledAuthor(): void
+    {
+        $story = $this->loadFixtureScenario(BlogStory::class);
+
+        $author  = $story->getRandom('authors');                // one entity
+        $threeOf = $story->getRandomSet('categories', 3);       // n distinct entities
+
+        $this->assertContains($author, $story->getPool('authors'));
+        $this->assertCount(3, $threeOf);
+    }
+}
+```
+
+### API
+
+- `addToPool(string $pool, EntityInterface|array $entities)` — register one or more entities under a named pool; repeated calls append.
+- `getPool(string $pool): array<EntityInterface>` — return every entity in a pool.
+- `getRandom(string $pool): EntityInterface` — uniform random pick from a pool.
+- `getRandomSet(string $pool, int $count): array<EntityInterface>` — `$count` distinct entities drawn from a pool (raises if the pool holds fewer).
+
+Unknown pool names raise `FixtureScenarioException` with a paste-ready list of the pools that *do* exist on the story.
+
+> [!NOTE]
+> `Story` `implements FixtureScenarioInterface`, so it works with `ScenarioAwareTrait::loadFixtureScenario(...)` exactly like plain scenarios. Existing scenarios that implement the interface directly keep working unchanged — `Story` is purely additive.

--- a/src/Scenario/ScenarioAwareTrait.php
+++ b/src/Scenario/ScenarioAwareTrait.php
@@ -46,7 +46,22 @@ trait ScenarioAwareTrait
             }
             $scenarioNamespace = $factoryNamespace . 'Scenario';
             $scenarioName = str_replace('/', '\\', $scenarioName);
-            $scenario = $scenarioNamespace . '\\' . $scenarioName . 'Scenario';
+            // Two resolution candidates:
+            // 1. `<name>Scenario` — the legacy convention; tried first so
+            //    existing scenario classes keep resolving unchanged.
+            // 2. `<name>` verbatim — a fallback for Story subclasses (or any
+            //    other naming) where the class doesn't follow the legacy suffix.
+            $legacy = $scenarioNamespace . '\\' . $scenarioName . 'Scenario';
+            $verbatim = $scenarioNamespace . '\\' . $scenarioName;
+            if (class_exists($legacy)) {
+                $scenario = $legacy;
+            } elseif (class_exists($verbatim)) {
+                $scenario = $verbatim;
+            } else {
+                // Neither resolves; pick the legacy form so the eventual
+                // FixtureScenarioException references the canonical name.
+                $scenario = $legacy;
+            }
         }
 
         try {

--- a/src/Scenario/Story.php
+++ b/src/Scenario/Story.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ */
+
+namespace CakephpFixtureFactories\Scenario;
+
+use Cake\Datasource\EntityInterface;
+use CakephpFixtureFactories\Error\FixtureScenarioException;
+
+/**
+ * Scenario abstract that adds **named entity pools** on top of
+ * `FixtureScenarioInterface`.
+ *
+ * Use a Story when you want to seed test data once, store named handles to
+ * subsets of it, and then sample from those handles in the body of the
+ * test — without rebuilding entities or threading explicit variables.
+ *
+ * ```php
+ * class BlogStory extends Story
+ * {
+ *     protected function build(): void
+ *     {
+ *         $this->addToPool('authors', UserFactory::new()->count(10)->saveMany());
+ *         $this->addToPool('categories', CategoryFactory::new()->count(3)->saveMany());
+ *
+ *         ArticleFactory::new()->count(50)->saveMany();
+ *     }
+ * }
+ *
+ * // In the test:
+ * $story = $this->loadFixtureScenario(BlogStory::class);
+ * $anyAuthor = $story->getRandom('authors');
+ * $someTags = $story->getRandomSet('categories', 2);
+ * ```
+ *
+ * Backwards-compatible: `Story` `implements FixtureScenarioInterface`, so
+ * `ScenarioAwareTrait::loadFixtureScenario(...)` resolves and calls `load()`
+ * the same way it does for plain scenarios. Existing scenarios that
+ * implement the interface directly keep working unchanged.
+ */
+abstract class Story implements FixtureScenarioInterface
+{
+    /**
+     * @var array<string, array<int, \Cake\Datasource\EntityInterface>>
+     */
+    private array $pools = [];
+
+    /**
+     * @inheritDoc
+     *
+     * Dispatches to a `build(...)` method on the concrete subclass and
+     * returns `$this` so the caller keeps a typed handle for `getRandom()`
+     * / `getPool()` lookups.
+     *
+     * The `build()` signature isn't declared abstract — PHP's strict-types
+     * LSP would prevent subclasses from accepting specific parameters
+     * (`build(int $n)`, `build(string $kind)`, etc.). Instead, this method
+     * dispatches via callable so subclasses can declare whatever signature
+     * fits their needs, and `loadFixtureScenario($story, ...$args)` forwards
+     * the arguments unchanged.
+     *
+     * @throws \CakephpFixtureFactories\Error\FixtureScenarioException When the
+     *     subclass does not define a `build()` method.
+     *
+     * @return static
+     */
+    public function load(mixed ...$args): static
+    {
+        if (!method_exists($this, 'build')) {
+            throw new FixtureScenarioException(sprintf(
+                '`%s` extends `Story` but does not define a `build(...)` method. '
+                . 'Declare `protected function build(): void` (or with whatever '
+                . 'parameters your scenario takes) to seed your data.',
+                static::class,
+            ));
+        }
+        /** @var callable $build */
+        $build = [$this, 'build'];
+        $build(...$args);
+
+        return $this;
+    }
+
+    /**
+     * Register one or more entities under a named pool. Repeated calls with
+     * the same pool name append.
+     *
+     * @param string $pool Pool identifier (any non-empty string).
+     * @param \Cake\Datasource\EntityInterface|array<int, \Cake\Datasource\EntityInterface> $entities
+     */
+    protected function addToPool(string $pool, EntityInterface|array $entities): static
+    {
+        if ($entities instanceof EntityInterface) {
+            $entities = [$entities];
+        }
+        if (!isset($this->pools[$pool])) {
+            $this->pools[$pool] = [];
+        }
+        foreach ($entities as $entity) {
+            $this->pools[$pool][] = $entity;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Return every entity registered under the given pool name.
+     *
+     * @return array<int, \Cake\Datasource\EntityInterface>
+     */
+    public function getPool(string $pool): array
+    {
+        $this->guardPoolExists($pool);
+
+        return $this->pools[$pool];
+    }
+
+    /**
+     * Return a uniformly random entity from the named pool.
+     *
+     * @throws \CakephpFixtureFactories\Error\FixtureScenarioException When the pool does not exist or is empty.
+     */
+    public function getRandom(string $pool): EntityInterface
+    {
+        $this->guardPoolExists($pool);
+        $entities = $this->pools[$pool];
+        if ($entities === []) {
+            throw new FixtureScenarioException(sprintf(
+                'Cannot draw from empty pool `%s`.',
+                $pool,
+            ));
+        }
+
+        return $entities[array_rand($entities)];
+    }
+
+    /**
+     * Return `$count` distinct entities drawn from the named pool.
+     *
+     * @throws \CakephpFixtureFactories\Error\FixtureScenarioException When the pool does not
+     *     exist or holds fewer entities than requested.
+     *
+     * @return array<int, \Cake\Datasource\EntityInterface>
+     */
+    public function getRandomSet(string $pool, int $count): array
+    {
+        if ($count < 0) {
+            throw new FixtureScenarioException(sprintf(
+                '$count must be ≥ 0, got %d.',
+                $count,
+            ));
+        }
+        // Validate the pool name even on zero-count requests so that typoed
+        // pool names surface immediately instead of returning a silent [].
+        $this->guardPoolExists($pool);
+        if ($count === 0) {
+            return [];
+        }
+        $entities = $this->pools[$pool];
+        $available = count($entities);
+        if ($count > $available) {
+            throw new FixtureScenarioException(sprintf(
+                'Cannot draw %d entities from pool `%s`: pool holds %d.',
+                $count,
+                $pool,
+                $available,
+            ));
+        }
+        $keys = array_rand($entities, $count);
+        if (!is_array($keys)) {
+            $keys = [$keys];
+        }
+
+        return array_values(array_map(static fn ($k) => $entities[$k], $keys));
+    }
+
+    private function guardPoolExists(string $pool): void
+    {
+        if (!isset($this->pools[$pool])) {
+            throw new FixtureScenarioException(sprintf(
+                'Pool `%s` does not exist on `%s`. Available pools: %s.',
+                $pool,
+                static::class,
+                $this->pools === [] ? '(none)' : '`' . implode('`, `', array_keys($this->pools)) . '`',
+            ));
+        }
+    }
+}

--- a/tests/Scenario/BlogStory.php
+++ b/tests/Scenario/BlogStory.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ */
+
+namespace CakephpFixtureFactories\Test\Scenario;
+
+use CakephpFixtureFactories\Scenario\Story;
+use CakephpFixtureFactories\Test\Factory\CityFactory;
+use CakephpFixtureFactories\Test\Factory\CountryFactory;
+
+/**
+ * Test scenario for `Story` — seeds named pools of countries and cities so
+ * tests can `getRandom('countries')` / `getRandomSet('cities', $n)` to
+ * compose follow-up factory builds against them.
+ */
+class BlogStory extends Story
+{
+    protected function build(): void
+    {
+        $countries = CountryFactory::new()->count(3)->saveMany();
+        $this->addToPool('countries', $countries);
+
+        // Build 5 cities all anchored to the first country so we get a
+        // deterministic, dependency-free pool for tests to sample from.
+        $cities = CityFactory::new()
+            ->count(5)
+            ->forCountries()
+            ->recycle($countries[0])
+            ->saveMany();
+        $this->addToPool('cities', $cities);
+    }
+}

--- a/tests/TestCase/Scenario/StoryTest.php
+++ b/tests/TestCase/Scenario/StoryTest.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ */
+
+namespace CakephpFixtureFactories\Test\TestCase\Scenario;
+
+use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
+use CakephpFixtureFactories\Error\FixtureScenarioException;
+use CakephpFixtureFactories\Scenario\ScenarioAwareTrait;
+use CakephpFixtureFactories\Scenario\Story;
+use CakephpFixtureFactories\Test\Factory\CityFactory;
+use CakephpFixtureFactories\Test\Factory\CountryFactory;
+use CakephpFixtureFactories\Test\Scenario\BlogStory;
+use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
+use TestApp\Model\Entity\Country;
+
+/**
+ * Tests for the `Story` abstract class — a Foundry-style scenario with named
+ * entity pools that tests can sample from after loading.
+ */
+class StoryTest extends TestCase
+{
+    use ScenarioAwareTrait;
+    use TruncateDirtyTables;
+
+    public static function setUpBeforeClass(): void
+    {
+        // Point short-name scenario resolution at this package's test factory
+        // namespace so `loadFixtureScenario('BlogStory')` finds
+        // `CakephpFixtureFactories\Test\Scenario\BlogStory`.
+        Configure::write('FixtureFactories.testFixtureNamespace', 'CakephpFixtureFactories\Test\Factory');
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        Configure::delete('FixtureFactories.testFixtureNamespace');
+    }
+
+    public function testLoadFixtureScenarioReturnsStoryInstance(): void
+    {
+        $story = $this->loadFixtureScenario(BlogStory::class);
+
+        $this->assertInstanceOf(Story::class, $story);
+        $this->assertInstanceOf(BlogStory::class, $story);
+    }
+
+    public function testStoryBuildsSeedsTheTables(): void
+    {
+        $this->loadFixtureScenario(BlogStory::class);
+
+        // BlogStory seeds 3 countries, then 5 cities that all recycle the
+        // first country — so the total country count stays at 3.
+        $this->assertSame(3, CountryFactory::query()->count());
+        $this->assertSame(5, CityFactory::query()->count());
+    }
+
+    public function testGetPoolReturnsAllEntitiesInPool(): void
+    {
+        /** @var \CakephpFixtureFactories\Test\Scenario\BlogStory $story */
+        $story = $this->loadFixtureScenario(BlogStory::class);
+
+        $countries = $story->getPool('countries');
+        $this->assertCount(3, $countries);
+        foreach ($countries as $country) {
+            $this->assertInstanceOf(Country::class, $country);
+        }
+    }
+
+    public function testGetRandomReturnsOneEntityFromPool(): void
+    {
+        /** @var \CakephpFixtureFactories\Test\Scenario\BlogStory $story */
+        $story = $this->loadFixtureScenario(BlogStory::class);
+
+        $country = $story->getRandom('countries');
+        $this->assertInstanceOf(Country::class, $country);
+        $this->assertContains($country, $story->getPool('countries'));
+    }
+
+    public function testGetRandomSetReturnsRequestedNumberOfDistinctEntities(): void
+    {
+        /** @var \CakephpFixtureFactories\Test\Scenario\BlogStory $story */
+        $story = $this->loadFixtureScenario(BlogStory::class);
+
+        $set = $story->getRandomSet('cities', 3);
+        $this->assertCount(3, $set);
+
+        // All entries must be distinct (no repeats within one draw).
+        $ids = array_map(static fn ($e) => $e->id, $set);
+        $this->assertCount(3, array_unique($ids), 'getRandomSet must return distinct entities.');
+
+        // Each entry must be from the pool.
+        $poolIds = array_map(static fn ($e) => $e->id, $story->getPool('cities'));
+        foreach ($ids as $id) {
+            $this->assertContains($id, $poolIds);
+        }
+    }
+
+    public function testGetRandomThrowsOnUnknownPool(): void
+    {
+        /** @var \CakephpFixtureFactories\Test\Scenario\BlogStory $story */
+        $story = $this->loadFixtureScenario(BlogStory::class);
+
+        $this->expectException(FixtureScenarioException::class);
+        $this->expectExceptionMessageMatches('/pool .*unknown.* does not exist/i');
+
+        $story->getRandom('unknown');
+    }
+
+    public function testGetRandomSetThrowsWhenRequestingMoreThanPoolSize(): void
+    {
+        /** @var \CakephpFixtureFactories\Test\Scenario\BlogStory $story */
+        $story = $this->loadFixtureScenario(BlogStory::class);
+
+        $this->expectException(FixtureScenarioException::class);
+        $this->expectExceptionMessageMatches('/cannot draw 99.*countries.*holds 3/i');
+
+        $story->getRandomSet('countries', 99);
+    }
+
+    public function testAddToPoolAcceptsSingleEntity(): void
+    {
+        // Anonymous Story to test addToPool's single-entity overload.
+        $story = new class () extends Story {
+            protected function build(): void
+            {
+                $only = CountryFactory::new(['name' => 'Solo'])->save();
+                $this->addToPool('one', $only);
+            }
+        };
+        /** @var \CakephpFixtureFactories\Scenario\Story $story */
+        $story = $story->load();
+
+        $this->assertCount(1, $story->getPool('one'));
+        $this->assertSame('Solo', $story->getPool('one')[0]->name);
+    }
+
+    public function testAddToPoolAppendsAcrossMultipleCalls(): void
+    {
+        $story = new class () extends Story {
+            protected function build(): void
+            {
+                $this->addToPool('countries', CountryFactory::new()->count(2)->saveMany());
+                $this->addToPool('countries', CountryFactory::new()->count(3)->saveMany());
+            }
+        };
+        /** @var \CakephpFixtureFactories\Scenario\Story $story */
+        $story = $story->load();
+
+        $this->assertCount(5, $story->getPool('countries'));
+    }
+
+    public function testShortNameLoadResolvesStoryClass(): void
+    {
+        // Short-name loading must resolve *Story classes verbatim,
+        // not by appending the `Scenario` suffix.
+        $story = $this->loadFixtureScenario('BlogStory');
+
+        $this->assertInstanceOf(BlogStory::class, $story);
+    }
+
+    public function testStorySupportsParameterizedBuild(): void
+    {
+        // Subclasses can declare build() with their own params; load() forwards
+        // the scenario args unchanged. This is the codex-flagged use case.
+        $story = new class () extends Story {
+            protected function build(int $n, string $name): void
+            {
+                $this->addToPool(
+                    'countries',
+                    CountryFactory::new(['name' => $name])->count($n)->saveMany(),
+                );
+            }
+        };
+        /** @var \CakephpFixtureFactories\Scenario\Story $story */
+        $story = $story->load(4, 'Repeated');
+
+        $this->assertCount(4, $story->getPool('countries'));
+        foreach ($story->getPool('countries') as $country) {
+            $this->assertSame('Repeated', $country->get('name'));
+        }
+    }
+
+    public function testStoryWithoutBuildMethodThrows(): void
+    {
+        $story = new class () extends Story {
+            // No build() declared — Story::load() must complain clearly.
+        };
+
+        $this->expectException(FixtureScenarioException::class);
+        $this->expectExceptionMessageMatches('/does not define a `build/');
+
+        $story->load();
+    }
+
+    public function testGetRandomSetValidatesPoolEvenForZeroCount(): void
+    {
+        /** @var \CakephpFixtureFactories\Test\Scenario\BlogStory $story */
+        $story = $this->loadFixtureScenario(BlogStory::class);
+
+        $this->expectException(FixtureScenarioException::class);
+        $this->expectExceptionMessageMatches('/pool .*typo.* does not exist/i');
+
+        $story->getRandomSet('typo', 0);
+    }
+
+    public function testGetRandomSetWithZeroReturnsEmptyArray(): void
+    {
+        /** @var \CakephpFixtureFactories\Test\Scenario\BlogStory $story */
+        $story = $this->loadFixtureScenario(BlogStory::class);
+
+        $this->assertSame([], $story->getRandomSet('countries', 0));
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `Story` abstract that layers **named entity pools** on top of `FixtureScenarioInterface`. Foundry-inspired.

```php
use CakephpFixtureFactories\Scenario\Story;

class BlogStory extends Story
{
    protected function build(): void
    {
        $this->addToPool('authors',    UserFactory::new()->count(10)->saveMany());
        $this->addToPool('categories', CategoryFactory::new()->count(3)->saveMany());

        ArticleFactory::new()->count(50)->saveMany();
    }
}

// In the test:
$story  = $this->loadFixtureScenario(BlogStory::class);
$author = $story->getRandom('authors');
$tags   = $story->getRandomSet('categories', 2);
```

`loadFixtureScenario()` returns the Story instance so the same handles are available for both build-time composition and post-load assertions.

## What's in this PR

- New `src/Scenario/Story.php` — abstract class with pool API:
  - `addToPool(string $pool, EntityInterface|array $entities)` (append-on-repeat)
  - `getPool(string): array<EntityInterface>`
  - `getRandom(string): EntityInterface`
  - `getRandomSet(string, int $count): array<EntityInterface>`
- Updated `src/Scenario/ScenarioAwareTrait.php` — short-name loading now tries both `<name>Scenario` (legacy, BC) and `<name>` verbatim (Story subclasses).
- New `tests/Scenario/BlogStory.php` — test scenario that recycles one country across 5 cities for deterministic pool counts.
- 12 new tests in `tests/TestCase/Scenario/StoryTest.php`.
- Docs section in `docs/guide/scenarios.md`.

## Design choices

- **Backwards-compatible** — `Story implements FixtureScenarioInterface`; existing scenarios keep working unchanged. Short-name loading tries the legacy `*Scenario` form first, then falls back to the verbatim class name, so projects with an existing `UserStoryScenario` class still resolve correctly via `loadFixtureScenario('UserStory')`.
- **`build()` is NOT declared abstract** — PHP strict-types LSP would block subclasses from declaring `build(int $n)` / `build(string $name)`. `load()` dispatches via callable so subclasses can declare whatever signature their scenario needs, and the `loadFixtureScenario(class, ...$args)` forwarding chain stays intact. Missing-`build()` raises a clear exception.
- **`getRandomSet()` validates the pool name even on `count === 0`** — typoed pool names surface immediately instead of silently returning `[]`.
- **Failure messages** include the list of pools that DO exist so debugging a typo is one read away.

## Verification

- `vendor/bin/phpunit tests/TestCase/Scenario/` — 22 tests pass.
- Full suite — passes; PHPUnit 13 mock-notice cleanup is its own PR.
- `composer stan` — clean.
- `composer cs-check` — clean.