### PR TITLE
Add bake fixture_factory --all-fields option

### DIFF
--- a/docs/reference/bake.md
+++ b/docs/reference/bake.md
@@ -40,8 +40,21 @@ bin/cake bake fixture_factory Articles -p MyPlugin
 |-------------|--------|
 | `-a`        | Bake every model in the app |
 | `-m`        | Add directional helpers based on associations (`for…()` for to-one, `has…()` for to-many) |
+| `--all-fields` | Emit default values for **every** non-primary, non-foreign-key column — including nullable columns and columns with a DB default. Without the flag, bake only fills required (NOT NULL, no DB default) columns. |
 | `-p Plugin` | Bake into a plugin's namespace |
 | `-h`        | Show all available options |
+
+### `--all-fields`: include optional columns
+
+By default, the baked `definition()` only emits values for columns the database would otherwise reject — required, no-default, non-FK columns. Optional columns and columns that the database already defaults are skipped to keep the factory minimal.
+
+Pass `--all-fields` when you want a fully populated factory body up front:
+
+```bash
+bin/cake bake fixture_factory Articles --all-fields
+```
+
+Foreign-key columns remain excluded regardless of the flag, so the baked factory keeps pushing related rows through the association APIs (`with()` / `for()` / `has()`) instead of emitting raw integer FK values.
 
 ## Customizing the generated code
 

--- a/src/Codegen/DefaultDataGuesser.php
+++ b/src/Codegen/DefaultDataGuesser.php
@@ -121,6 +121,14 @@ class DefaultDataGuesser
     ];
 
     /**
+     * When true, the guesser also emits defaults for nullable columns and
+     * columns with a DB default. Backs the `bake fixture_factory --all-fields`
+     * flag. Foreign-key and primary-key columns are still skipped regardless,
+     * so the baked factory keeps pushing users toward association-aware APIs.
+     */
+    protected bool $includeOptional = false;
+
+    /**
      * Replace the entire bundled mapping. Useful for projects whose
      * conventions diverge enough that a partial merge would be noisy.
      *
@@ -149,6 +157,25 @@ class DefaultDataGuesser
     }
 
     /**
+     * Toggle the "include optional columns" mode.
+     *
+     * When `true`, the guesser emits defaults for nullable columns and
+     * columns with a DB default — useful when you want bake to pre-populate
+     * `definition()` with every interesting column up front. Backs the
+     * `bake fixture_factory --all-fields` flag.
+     *
+     * Foreign-key columns and primary keys are still excluded regardless so
+     * the baked factory keeps pushing users toward `with()` / `for()` /
+     * `has()` for related rows.
+     */
+    public function setIncludeOptional(bool $include): static
+    {
+        $this->includeOptional = $include;
+
+        return $this;
+    }
+
+    /**
      * Build the `column => generator-expression` map for a Table's schema.
      *
      * @param \Cake\ORM\Table $table The Table being baked against.
@@ -171,7 +198,10 @@ class DefaultDataGuesser
             }
 
             $columnSchema = $schema->getColumn($column);
-            if (!$columnSchema || $columnSchema['null'] || $columnSchema['default'] !== null) {
+            if (!$columnSchema) {
+                continue;
+            }
+            if (!$this->includeOptional && ($columnSchema['null'] || $columnSchema['default'] !== null)) {
                 continue;
             }
 

--- a/src/Command/BakeFixtureFactoryCommand.php
+++ b/src/Command/BakeFixtureFactoryCommand.php
@@ -320,7 +320,7 @@ class BakeFixtureFactoryCommand extends BakeCommand
             'modelName' => $this->modelName,
             'factory' => Inflector::singularize($this->modelName) . 'Factory',
             'namespace' => $this->getFactoryNamespace($this->plugin),
-            'defaultData' => $this->defaultData(),
+            'defaultData' => $this->defaultData($arg),
         ];
         $useStatements = $methods = [];
         if ($arg->getOption('methods')) {
@@ -436,6 +436,12 @@ class BakeFixtureFactoryCommand extends BakeCommand
                 'short' => 'm',
                 'boolean' => true,
                 'help' => 'Include methods based on the table relations.',
+            ])
+            ->addOption('all-fields', [
+                'boolean' => true,
+                'help' => 'Emit default values for nullable columns and columns with DB defaults too, '
+                    . 'instead of only required NOT NULL columns. Foreign keys are still excluded '
+                    . 'so the baked factory keeps pushing related rows through with()/for()/has().',
             ]);
 
         return $parser;
@@ -444,11 +450,23 @@ class BakeFixtureFactoryCommand extends BakeCommand
     /**
      * Build the `column => generator-expression` map fed to the bake template.
      *
+     * Honours the `--all-fields` option when available — emits defaults for
+     * nullable / DB-defaulted columns too (foreign keys remain excluded).
+     *
+     * @param \Cake\Console\Arguments|null $args Bake-command arguments. Optional
+     *     for subclasses / callers that want the legacy required-only behavior.
+     *
      * @return array<string, string>
      */
-    protected function defaultData(): array
+    protected function defaultData(?Arguments $args = null): array
     {
-        return $this->getDefaultDataGuesser()->guessFor($this->getTable());
+        $guesser = $this->getDefaultDataGuesser();
+        // Always set both directions: the guesser may be cached across multiple
+        // executions on the same command instance, and a prior --all-fields run
+        // must not leak into a subsequent invocation without the flag.
+        $guesser->setIncludeOptional($args !== null && (bool)$args->getOption('all-fields'));
+
+        return $guesser->guessFor($this->getTable());
     }
 
     /**

--- a/tests/TestCase/Codegen/DefaultDataGuesserAllFieldsTest.php
+++ b/tests/TestCase/Codegen/DefaultDataGuesserAllFieldsTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ */
+
+namespace CakephpFixtureFactories\Test\TestCase\Codegen;
+
+use ArrayIterator;
+use Cake\Database\Schema\TableSchema;
+use Cake\ORM\AssociationCollection;
+use Cake\ORM\Table;
+use Cake\TestSuite\TestCase;
+use CakephpFixtureFactories\Codegen\DefaultDataGuesser;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+
+/**
+ * Tests for the "include optional columns" toggle on `DefaultDataGuesser`,
+ * which backs the `bake fixture_factory --all-fields` flag.
+ *
+ * Default behavior (off): only NOT NULL columns without a DB default and
+ * outside any foreign-key constraint are emitted. Toggle on: nullable
+ * columns and columns with DB defaults are also emitted; FKs and PKs
+ * remain skipped — per codex review feedback, since baked FKs would
+ * undermine the association-aware `with()` / `for()` / `has()` APIs.
+ */
+#[AllowMockObjectsWithoutExpectations]
+class DefaultDataGuesserAllFieldsTest extends TestCase
+{
+    public function testDefaultBehaviorSkipsNullableAndDefaultedColumns(): void
+    {
+        $table = $this->buildTable([
+            'columns' => ['id', 'name', 'optional_note', 'status'],
+            'primaryKey' => ['id'],
+            'columnSchemas' => [
+                'name' => ['type' => 'string', 'null' => false, 'default' => null, 'length' => 50],
+                'optional_note' => ['type' => 'string', 'null' => true, 'default' => null, 'length' => 200],
+                'status' => ['type' => 'string', 'null' => false, 'default' => 'active', 'length' => 20],
+            ],
+        ]);
+
+        $defaults = (new DefaultDataGuesser())->guessFor($table);
+
+        $this->assertArrayHasKey('name', $defaults);
+        // Nullable column — skipped under the default rule.
+        $this->assertArrayNotHasKey('optional_note', $defaults);
+        // Has DB default — skipped under the default rule.
+        $this->assertArrayNotHasKey('status', $defaults);
+    }
+
+    public function testAllFieldsIncludesNullableAndDefaultedColumns(): void
+    {
+        $table = $this->buildTable([
+            'columns' => ['id', 'name', 'optional_note', 'status'],
+            'primaryKey' => ['id'],
+            'columnSchemas' => [
+                'name' => ['type' => 'string', 'null' => false, 'default' => null, 'length' => 50],
+                'optional_note' => ['type' => 'string', 'null' => true, 'default' => null, 'length' => 200],
+                'status' => ['type' => 'string', 'null' => false, 'default' => 'active', 'length' => 20],
+            ],
+        ]);
+
+        $defaults = (new DefaultDataGuesser())
+            ->setIncludeOptional(true)
+            ->guessFor($table);
+
+        $this->assertArrayHasKey('name', $defaults);
+        $this->assertArrayHasKey('optional_note', $defaults);
+        $this->assertArrayHasKey('status', $defaults);
+    }
+
+    public function testAllFieldsStillSkipsPrimaryKeysAndForeignKeys(): void
+    {
+        // The proposal explicitly drops FKs even with --all-fields so the
+        // baked factory stays association-aware (users still wire `with()`
+        // / `for()` / `has()` chains instead of raw integer FK values).
+        $table = $this->buildTable([
+            'columns' => ['id', 'name', 'user_id', 'company_id'],
+            'primaryKey' => ['id'],
+            'constraints' => [
+                'user_fk' => ['type' => 'foreign', 'columns' => ['user_id']],
+                'company_fk' => ['type' => 'foreign', 'columns' => ['company_id']],
+            ],
+            'columnSchemas' => [
+                'name' => ['type' => 'string', 'null' => false, 'default' => null, 'length' => 50],
+                'user_id' => ['type' => 'integer', 'null' => true, 'default' => null],
+                'company_id' => ['type' => 'integer', 'null' => false, 'default' => null],
+            ],
+        ]);
+
+        $defaults = (new DefaultDataGuesser())
+            ->setIncludeOptional(true)
+            ->guessFor($table);
+
+        $this->assertArrayHasKey('name', $defaults);
+        $this->assertArrayNotHasKey('id', $defaults);
+        $this->assertArrayNotHasKey('user_id', $defaults);
+        $this->assertArrayNotHasKey('company_id', $defaults);
+    }
+
+    public function testSetIncludeOptionalReturnsSelfForChaining(): void
+    {
+        $guesser = new DefaultDataGuesser();
+        $this->assertSame($guesser, $guesser->setIncludeOptional(true));
+    }
+
+    /**
+     * Build a partial-mocked Table with the schema bits the guesser inspects.
+     *
+     * @param array{
+     *     columns: array<string>,
+     *     primaryKey: array<string>,
+     *     columnSchemas: array<string, array<string, mixed>>,
+     *     constraints?: array<string, array<string, mixed>>,
+     * } $config
+     */
+    private function buildTable(array $config): Table
+    {
+        $schema = $this->getMockBuilder(TableSchema::class)
+            ->onlyMethods(['constraints', 'getConstraint', 'indexes', 'columns', 'getColumn', 'getPrimaryKey'])
+            ->setConstructorArgs(['test_table'])
+            ->getMock();
+        $schema->method('columns')->willReturn($config['columns']);
+        $schema->method('getPrimaryKey')->willReturn($config['primaryKey']);
+        $constraints = $config['constraints'] ?? [];
+        $schema->method('constraints')->willReturn(array_keys($constraints));
+        $schema->method('getConstraint')->willReturnCallback(
+            static fn (string $name): ?array => $constraints[$name] ?? null,
+        );
+        $schema->method('indexes')->willReturn([]);
+        $schema->method('getColumn')->willReturnCallback(
+            static fn (string $col): ?array => $config['columnSchemas'][$col] ?? null,
+        );
+
+        $associations = $this->getMockBuilder(AssociationCollection::class)
+            ->onlyMethods(['getIterator'])
+            ->getMock();
+        $associations->method('getIterator')->willReturn(new ArrayIterator([]));
+
+        $table = $this->getMockBuilder(Table::class)
+            ->onlyMethods(['getSchema', 'getAlias', 'associations'])
+            ->getMock();
+        $table->method('getSchema')->willReturn($schema);
+        $table->method('getAlias')->willReturn('TestTable');
+        $table->method('associations')->willReturn($associations);
+
+        return $table;
+    }
+}

--- a/tests/TestCase/Command/BakeFixtureFactoryCommandTest.php
+++ b/tests/TestCase/Command/BakeFixtureFactoryCommandTest.php
@@ -322,6 +322,48 @@ class BakeFixtureFactoryCommandTest extends TestCaseWithFixtureBaking
         $this->assertEquals($title, $article['title']);
     }
 
+    public function testBakeAllFieldsEmitsDefaultsForOptionalColumns(): void
+    {
+        $bakedPath = TESTS . 'Factory' . DS . 'ArticleFactory.php';
+        if (file_exists($bakedPath)) {
+            unlink($bakedPath);
+        }
+
+        $this->bake(['Articles'], ['all-fields' => true]);
+
+        $this->assertFileExists($bakedPath);
+        $contents = (string)file_get_contents($bakedPath);
+
+        // The Articles table has a `published` column that defaults to 0
+        // — it's skipped by default but should appear with --all-fields.
+        $this->assertStringContainsString("'published'", $contents);
+    }
+
+    public function testAllFieldsToggleDoesNotLeakAcrossInvocations(): void
+    {
+        // Codex P2: the cached DefaultDataGuesser must be reset both ways,
+        // otherwise a previous --all-fields run leaks into a later run
+        // without the flag on the same command instance.
+        $bakedPath = TESTS . 'Factory' . DS . 'ArticleFactory.php';
+
+        // First run: with --all-fields → 'published' should appear.
+        if (file_exists($bakedPath)) {
+            unlink($bakedPath);
+        }
+        $this->bake(['Articles'], ['all-fields' => true]);
+        $this->assertStringContainsString("'published'", (string)file_get_contents($bakedPath));
+
+        // Second run on the SAME command instance: without --all-fields.
+        // 'published' must NOT appear; the guesser must have been reset.
+        unlink($bakedPath);
+        $this->bake(['Articles']);
+        $this->assertStringNotContainsString(
+            "'published'",
+            (string)file_get_contents($bakedPath),
+            'Second bake without --all-fields must not leak the prior all-fields state.',
+        );
+    }
+
     public function testRunBakeAllInTestApp(): void
     {
         $this->bake([], ['all' => true]);


### PR DESCRIPTION
## Summary

Adds a `--all-fields` flag on `bin/cake bake fixture_factory` that emits default values for nullable columns and columns with a DB default — not just required, NOT NULL, no-default columns.

```bash
# Today: only required columns appear in definition()
bin/cake bake fixture_factory Articles

# New: every non-PK, non-FK column appears, even optional/defaulted ones
bin/cake bake fixture_factory Articles --all-fields
```

Foreign-key columns remain excluded regardless of the flag, so the baked factory keeps pushing related rows through `with()` / `for()` / `has()` instead of emitting raw integer FK scalars.

## What's in this PR

- `DefaultDataGuesser::setIncludeOptional(bool)` — new toggle for the "include optional columns" mode.
- `DefaultDataGuesser::guessFor()` — when the toggle is on, the skip-on-nullable / skip-on-default branch no longer fires.
- `BakeFixtureFactoryCommand` — new `--all-fields` option wired into `defaultData()`. The toggle is always set explicitly (both directions) per invocation so a long-lived command instance does not leak prior `--all-fields` state into a later call without the flag.
- 4 unit tests for `DefaultDataGuesser` (default skip, all-fields include, FK/PK still skipped, fluent setter).
- 2 integration tests on `BakeFixtureFactoryCommand` — verifies `'published'` (Articles' integer column with `default => 0`) appears in baked output only when `--all-fields` is set, and that the toggle resets cleanly between invocations.
- Docs section in `docs/reference/bake.md` covering the flag and the FK exclusion rationale.

## Why no short flag (`-a`)?

`-a` is already taken by the existing `--all` (bake every model in the app). `--all-fields` is long-form-only.

## Verification

- `vendor/bin/phpunit` — 620 tests pass.
- `composer stan` — clean.
- `composer cs-check` — clean.
- `codex review --uncommitted` — one P2 about cached-guesser state leaking across invocations on the same command instance; addressed by always setting the toggle explicitly (both directions) per call. Test added.
