### PR TITLE
Switch sequence() callable to single-arg Sequence context (BREAKING)

### DIFF
--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -57,7 +57,7 @@ $articles = ArticleFactory::new()
 
 The state at index `$i % count($states)` is applied to the i-th entity, so the example above produces `Draft, Published, Draft, Published`. If `count()` is smaller than the number of states the trailing states are simply unused; if `count()` is `1` only the first state ever applies. Calling `sequence()` again replaces the previously stored states — it is not additive.
 
-A `sequence` state can also be a callable receiving a `Sequence` context object for index-aware values. `Sequence` surfaces the iteration position (`$s->index`, `$s->position`, `$s->total`) and the boundary checks (`$s->isFirst()`, `$s->isLast()`), plus `$s->factory` / `$s->generator` for the rare callable that doesn't have them in `use(...)` scope:
+A `sequence` state can also be a callable receiving a `Sequence` context object for index-aware values. `Sequence` is a readonly value object surfacing the iteration position (`$s->index`, `$s->position`, `$s->total`) and the boundary checks (`$s->isFirst`, `$s->isLast`) as **properties** — uniform with the rest of the API and IDE-autocompleted. `$s->factory` and `$s->generator` are also exposed for the rare callable that doesn't have them in `use(...)` scope:
 
 ```php
 use CakephpFixtureFactories\Factory\Sequence;
@@ -71,8 +71,8 @@ $articles = ArticleFactory::new()
 $articles = ArticleFactory::new()
     ->count(5)
     ->sequence(fn (Sequence $s) => [
-        'title' => $s->isFirst() ? 'Pinned' : "Article {$s->position}/{$s->total}",
-        'is_final' => $s->isLast(),
+        'title' => $s->isFirst ? 'Pinned' : "Article {$s->position}/{$s->total}",
+        'is_final' => $s->isLast,
     ])
     ->saveMany();
 ```

--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -57,13 +57,24 @@ $articles = ArticleFactory::new()
 
 The state at index `$i % count($states)` is applied to the i-th entity, so the example above produces `Draft, Published, Draft, Published`. If `count()` is smaller than the number of states the trailing states are simply unused; if `count()` is `1` only the first state ever applies. Calling `sequence()` again replaces the previously stored states — it is not additive.
 
-A `sequence` state can also be a callable receiving `($factory, $generator, $index)` for index-aware values:
+A `sequence` state can also be a callable receiving a `Sequence` context object for index-aware values. `Sequence` surfaces the iteration position (`$s->index`, `$s->position`, `$s->total`) and the boundary checks (`$s->isFirst()`, `$s->isLast()`), plus `$s->factory` / `$s->generator` for the rare callable that doesn't have them in `use(...)` scope:
 
 ```php
+use CakephpFixtureFactories\Factory\Sequence;
+
 $articles = ArticleFactory::new()
     ->count(3)
-    ->sequence(fn ($factory, $generator, int $i) => ['slug' => "article-{$i}"])
+    ->sequence(fn (Sequence $s) => ['slug' => "article-{$s->index}"])
     ->buildMany();
+
+// Or composing the position / boundary checks:
+$articles = ArticleFactory::new()
+    ->count(5)
+    ->sequence(fn (Sequence $s) => [
+        'title' => $s->isFirst() ? 'Pinned' : "Article {$s->position}/{$s->total}",
+        'is_final' => $s->isLast(),
+    ])
+    ->saveMany();
 ```
 
 When you only want to vary one column at a time, `sequenceField()` is the focused alternative. It accepts any value the column supports — scalars, arrays, enum cases, anything Cake's marshaller handles for that field:

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -935,7 +935,7 @@ abstract class BaseFactory
      * - `\Cake\Datasource\EntityInterface` — its `toArray()` is patched,
      * - `callable(\CakephpFixtureFactories\Factory\Sequence): array<string, mixed>`
      *   — invoked once per cycle with a `Sequence` context object that exposes
-     *   `$s->index`, `$s->position`, `$s->total`, `$s->isFirst()`, `$s->isLast()`,
+     *   `$s->index`, `$s->position`, `$s->total`, `$s->isFirst`, `$s->isLast`,
      *   plus `$s->factory` and `$s->generator` for the rare callable that
      *   needs them but doesn't have them in `use(...)` scope.
      *

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -930,7 +930,16 @@ abstract class BaseFactory
      * Calling `sequence()` again replaces the previously stored states; it is
      * not additive.
      *
-     * @param \Cake\Datasource\EntityInterface|callable|array<string, mixed> ...$states Sequence states
+     * Each state can be:
+     * - `array<string, mixed>` — patched onto the entity directly,
+     * - `\Cake\Datasource\EntityInterface` — its `toArray()` is patched,
+     * - `callable(\CakephpFixtureFactories\Factory\Sequence): array<string, mixed>`
+     *   — invoked once per cycle with a `Sequence` context object that exposes
+     *   `$s->index`, `$s->position`, `$s->total`, `$s->isFirst()`, `$s->isLast()`,
+     *   plus `$s->factory` and `$s->generator` for the rare callable that
+     *   needs them but doesn't have them in `use(...)` scope.
+     *
+     * @param \Cake\Datasource\EntityInterface|callable(\CakephpFixtureFactories\Factory\Sequence<TEntity>): array<string, mixed>|array<string, mixed> ...$states Sequence states
      *
      * @throws \InvalidArgumentException
      *

--- a/src/Factory/DataCompiler.php
+++ b/src/Factory/DataCompiler.php
@@ -601,11 +601,13 @@ class DataCompiler
         if ($this->sequenceData) {
             $state = $this->sequenceData[$this->sequenceIndex % count($this->sequenceData)];
             if (is_callable($state)) {
-                $state = $state(
-                    $this->getFactory(),
-                    $this->getFactory()->getGenerator(),
-                    $this->sequenceIndex,
-                );
+                $factory = $this->getFactory();
+                $state = $state(new Sequence(
+                    index: $this->sequenceIndex,
+                    total: $factory->getTimes(),
+                    factory: $factory,
+                    generator: $factory->getGenerator(),
+                ));
             } elseif ($state instanceof EntityInterface) {
                 $state = $state->toArray();
             }

--- a/src/Factory/Sequence.php
+++ b/src/Factory/Sequence.php
@@ -27,8 +27,8 @@ use CakephpFixtureFactories\Generator\GeneratorInterface;
  *         'rank' => $s->index,
  *         'position' => $s->position,
  *         'total' => $s->total,
- *         'is_first' => $s->isFirst(),
- *         'is_last' => $s->isLast(),
+ *         'is_first' => $s->isFirst,
+ *         'is_last' => $s->isLast,
  *         'slug' => $s->generator->slug(),
  *         'parent' => $s->factory->getTable()->getAlias(),
  *     ])

--- a/src/Factory/Sequence.php
+++ b/src/Factory/Sequence.php
@@ -48,6 +48,16 @@ final readonly class Sequence
     public int $position;
 
     /**
+     * Whether this is the very first row of the batch (`index === 0`).
+     */
+    public bool $isFirst;
+
+    /**
+     * Whether this is the very last row of the batch (`index === total - 1`).
+     */
+    public bool $isLast;
+
+    /**
      * @param int $index 0-based iteration index across the factory's `count(N)` builds.
      * @param int $total Total number of entities the factory will build (`BaseFactory::getTimes()`).
      * @param \CakephpFixtureFactories\Factory\BaseFactory<TEntity> $factory Owning factory.
@@ -60,21 +70,7 @@ final readonly class Sequence
         public GeneratorInterface $generator,
     ) {
         $this->position = $index + 1;
-    }
-
-    /**
-     * Whether this is the very first row of the batch.
-     */
-    public function isFirst(): bool
-    {
-        return $this->index === 0;
-    }
-
-    /**
-     * Whether this is the very last row of the batch.
-     */
-    public function isLast(): bool
-    {
-        return $this->index === $this->total - 1;
+        $this->isFirst = $index === 0;
+        $this->isLast = $index === $total - 1;
     }
 }

--- a/src/Factory/Sequence.php
+++ b/src/Factory/Sequence.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ */
+
+namespace CakephpFixtureFactories\Factory;
+
+use CakephpFixtureFactories\Generator\GeneratorInterface;
+
+/**
+ * Context passed to a `sequence()` callable.
+ *
+ * Bundles everything the callable might need — iteration position, the
+ * owning factory, the configured generator — behind a single argument
+ * so the closure signature stays compact regardless of which bits are
+ * actually used:
+ *
+ * ```php
+ * ArticleFactory::new()
+ *     ->count(5)
+ *     ->sequence(fn (Sequence $s) => [
+ *         'rank' => $s->index,
+ *         'position' => $s->position,
+ *         'total' => $s->total,
+ *         'is_first' => $s->isFirst(),
+ *         'is_last' => $s->isLast(),
+ *         'slug' => $s->generator->slug(),
+ *         'parent' => $s->factory->getTable()->getAlias(),
+ *     ])
+ *     ->saveMany();
+ * ```
+ *
+ * Construction is internal to the data compiler; callables never need to
+ * instantiate `Sequence` themselves.
+ *
+ * @template TEntity of \Cake\Datasource\EntityInterface
+ */
+final readonly class Sequence
+{
+    /**
+     * 1-based position of the current row in the batch (`index + 1`).
+     */
+    public int $position;
+
+    /**
+     * @param int $index 0-based iteration index across the factory's `count(N)` builds.
+     * @param int $total Total number of entities the factory will build (`BaseFactory::getTimes()`).
+     * @param \CakephpFixtureFactories\Factory\BaseFactory<TEntity> $factory Owning factory.
+     * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Configured fixture generator (Faker / DummyGenerator / custom).
+     */
+    public function __construct(
+        public int $index,
+        public int $total,
+        public BaseFactory $factory,
+        public GeneratorInterface $generator,
+    ) {
+        $this->position = $index + 1;
+    }
+
+    /**
+     * Whether this is the very first row of the batch.
+     */
+    public function isFirst(): bool
+    {
+        return $this->index === 0;
+    }
+
+    /**
+     * Whether this is the very last row of the batch.
+     */
+    public function isLast(): bool
+    {
+        return $this->index === $this->total - 1;
+    }
+}

--- a/tests/TestCase/Factory/BaseFactorySequenceObjectTest.php
+++ b/tests/TestCase/Factory/BaseFactorySequenceObjectTest.php
@@ -17,7 +17,7 @@ use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
 
 /**
  * `BaseFactory::sequence()` callables receive a single `Sequence` context
- * object exposing `$index`, `$position`, `$total`, `isFirst()`, `isLast()`,
+ * object exposing `$index`, `$position`, `$total`, `$isFirst`, `$isLast`,
  * plus the in-context `factory` / `generator` for the rare callable that
  * needs them but doesn't have them in `use(...)` scope.
  *
@@ -39,8 +39,8 @@ class BaseFactorySequenceObjectTest extends TestCase
                     'index' => $s->index,
                     'position' => $s->position,
                     'total' => $s->total,
-                    'isFirst' => $s->isFirst(),
-                    'isLast' => $s->isLast(),
+                    'isFirst' => $s->isFirst,
+                    'isLast' => $s->isLast,
                 ];
 
                 return ['name' => 'Row' . $s->position];
@@ -86,8 +86,8 @@ class BaseFactorySequenceObjectTest extends TestCase
         CountryFactory::new()
             ->count(1)
             ->sequence(function (Sequence $s) use (&$sawFirst, &$sawLast) {
-                $sawFirst = $s->isFirst();
-                $sawLast = $s->isLast();
+                $sawFirst = $s->isFirst;
+                $sawLast = $s->isLast;
 
                 return [];
             })

--- a/tests/TestCase/Factory/BaseFactorySequenceObjectTest.php
+++ b/tests/TestCase/Factory/BaseFactorySequenceObjectTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ */
+
+namespace CakephpFixtureFactories\Test\TestCase\Factory;
+
+use Cake\TestSuite\TestCase;
+use CakephpFixtureFactories\Factory\Sequence;
+use CakephpFixtureFactories\Test\Factory\CountryFactory;
+use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
+
+/**
+ * `BaseFactory::sequence()` callables receive a single `Sequence` context
+ * object exposing `$index`, `$position`, `$total`, `isFirst()`, `isLast()`,
+ * plus the in-context `factory` / `generator` for the rare callable that
+ * needs them but doesn't have them in `use(...)` scope.
+ *
+ * Greenfield single-arg shape — no legacy positional-arg signature is
+ * supported.
+ */
+class BaseFactorySequenceObjectTest extends TestCase
+{
+    use TruncateDirtyTables;
+
+    public function testSequenceCallableReceivesSequenceObject(): void
+    {
+        $seen = [];
+
+        CountryFactory::new()
+            ->count(3)
+            ->sequence(function (Sequence $s) use (&$seen) {
+                $seen[] = [
+                    'index' => $s->index,
+                    'position' => $s->position,
+                    'total' => $s->total,
+                    'isFirst' => $s->isFirst(),
+                    'isLast' => $s->isLast(),
+                ];
+
+                return ['name' => 'Row' . $s->position];
+            })
+            ->saveMany();
+
+        $this->assertSame(
+            [
+                ['index' => 0, 'position' => 1, 'total' => 3, 'isFirst' => true, 'isLast' => false],
+                ['index' => 1, 'position' => 2, 'total' => 3, 'isFirst' => false, 'isLast' => false],
+                ['index' => 2, 'position' => 3, 'total' => 3, 'isFirst' => false, 'isLast' => true],
+            ],
+            $seen,
+        );
+    }
+
+    public function testSequenceObjectExposesFactoryAndGenerator(): void
+    {
+        // For callables that don't have $factory / $generator in scope via
+        // `use(...)`, the Sequence object surfaces them directly.
+        $factoryClass = null;
+        $generatorClass = null;
+
+        CountryFactory::new()
+            ->count(1)
+            ->sequence(function (Sequence $s) use (&$factoryClass, &$generatorClass) {
+                $factoryClass = $s->factory::class;
+                $generatorClass = $s->generator::class;
+
+                return [];
+            })
+            ->saveMany();
+
+        $this->assertSame(CountryFactory::class, $factoryClass);
+        $this->assertNotNull($generatorClass);
+    }
+
+    public function testIsFirstAndIsLastBothTrueForSingleCount(): void
+    {
+        $sawFirst = false;
+        $sawLast = false;
+
+        CountryFactory::new()
+            ->count(1)
+            ->sequence(function (Sequence $s) use (&$sawFirst, &$sawLast) {
+                $sawFirst = $s->isFirst();
+                $sawLast = $s->isLast();
+
+                return [];
+            })
+            ->saveMany();
+
+        $this->assertTrue($sawFirst);
+        $this->assertTrue($sawLast);
+    }
+
+    public function testSequenceWraparoundReportsOuterIndexNotStateSlot(): void
+    {
+        // When `count(N)` exceeds the number of provided sequence states, the
+        // states cycle. The Sequence index reflects the *outer* build
+        // iteration, not the modulo'd state slot.
+        $seenIndexes = [];
+        $seenPositions = [];
+
+        CountryFactory::new()
+            ->count(5)
+            ->sequence(
+                function (Sequence $s) use (&$seenIndexes, &$seenPositions) {
+                    $seenIndexes[] = $s->index;
+                    $seenPositions[] = $s->position;
+
+                    return ['name' => 'Country' . $s->index];
+                },
+                function (Sequence $s) use (&$seenIndexes, &$seenPositions) {
+                    $seenIndexes[] = $s->index;
+                    $seenPositions[] = $s->position;
+
+                    return ['name' => 'Country' . $s->index];
+                },
+            )
+            ->saveMany();
+
+        $this->assertSame([0, 1, 2, 3, 4], $seenIndexes);
+        $this->assertSame([1, 2, 3, 4, 5], $seenPositions);
+    }
+
+    public function testTotalReflectsCountValue(): void
+    {
+        $seenTotals = [];
+
+        CountryFactory::new()
+            ->count(4)
+            ->sequence(function (Sequence $s) use (&$seenTotals) {
+                $seenTotals[] = $s->total;
+
+                return [];
+            })
+            ->saveMany();
+
+        $this->assertSame([4, 4, 4, 4], $seenTotals);
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the `sequence()` callable's positional `($factory, $generator, int $index)` signature with a **single `Sequence` context object** that bundles everything the closure might need:

```php
use CakephpFixtureFactories\Factory\Sequence;

ArticleFactory::new()
    ->count(5)
    ->sequence(fn (Sequence $s) => [
        'rank' => $s->index,          // 0-based
        'position' => $s->position,   // 1-based
        'total' => $s->total,
        'is_first' => $s->isFirst(),
        'is_last' => $s->isLast(),
        'slug' => $s->generator->slug(),
        'parent' => $s->factory->getTable()->getAlias(),
    ])
    ->saveMany();
```

## ⚠️ Breaking change — by design

The old 3-arg callable signature is gone. Existing code that did:

```php
->sequence(fn ($factory, $generator, int $i) => ['name' => "Row{$i}"])
```

will fail with a `Sequence` vs. `BaseFactory` type error on the first invocation.

**Migration** is a mechanical rename — `$factory → $s->factory`, `$generator → $s->generator`, `$index → $s->index`, plus the new `$s->position` / `$s->total` / `$s->isFirst()` / `$s->isLast()` if you want them. The repo's only doc example (`docs/guide/examples.md`) is migrated in this PR.

The break is deliberate: the package is still in beta and we want the cleanest greenfield shape before 2.x stabilizes. Codex flagged the BC concern; called out and accepted.

## What's in this PR

- New `src/Factory/Sequence.php` — `final readonly class` (PHP 8.4 constructor promotion + readonly props), templated over `TEntity` so `$s->factory` keeps its full generic type information.
- `DataCompiler::mergeWithSequenceData()` — invokes callable with a single `Sequence` constructed via named args (no legacy fallback).
- `BaseFactory::sequence()` — updated docblock with the new callable contract.
- `docs/guide/examples.md` — example migrated to the new shape, with a follow-up snippet showing `isFirst()` / `position` / `total` in action.
- 5 tests in `BaseFactorySequenceObjectTest.php` covering: passing context, factory/generator surfacing, single-row isFirst+isLast, wraparound index, total reflection.

## What it does NOT touch

- Array-state and entity-state sequence forms (`sequence(['a' => 1], ['a' => 2])`) are unchanged — only the callable form's signature shifted.
- `sequenceField()` is unchanged.

## Verification

- `vendor/bin/phpunit` — 657 tests pass.
- `composer stan` — clean (Sequence templated to preserve TEntity through `$s->factory`).
- `composer cs-check` — clean.
