### PR TITLE
Add alias overload to for() / has() (BREAKING for has() pivot position)

### DIFF
--- a/docs/guide/associations.md
+++ b/docs/guide/associations.md
@@ -86,11 +86,33 @@ $author = AuthorFactory::new()
 
 Both methods auto-resolve which association to attach based on the target factory's table — no association name needed.
 
-`has()` accepts an optional `$pivot` array as the second parameter for habtm joins, populating the `_joinData` columns on the join row.
+Pass an explicit `$alias` as the second argument when this factory's table declares **more than one** association pointing at the same target — the auto-resolver cannot pick a single one and would throw without the alias:
+
+```php
+// Authors belongsTo Address AND BusinessAddress (both → Addresses):
+$author = AuthorFactory::new()
+    ->for(AddressFactory::new(['street' => 'Home']),   'Address')
+    ->for(AddressFactory::new(['street' => 'Office']), 'BusinessAddress')
+    ->save();
+
+// Countries hasMany Cities AND VirtualCities (both → Cities):
+$country = CountryFactory::new()
+    ->has(CityFactory::new()->count(3), 'Cities')
+    ->has(CityFactory::new()->count(2), 'VirtualCities')
+    ->save();
+```
+
+`has()` also accepts an optional `$pivot` array as a third argument for belongsToMany joins, populating the `_joinData` columns on the join row:
+
+```php
+$article = ArticleFactory::new()
+    ->has(AuthorFactory::new()->count(2), 'Authors', ['featured' => true])
+    ->save();
+```
 
 ### Disambiguating `for()` and `has()`
 
-When the parent table declares **more than one** association pointing at the target table, the auto-resolver cannot pick a single one and throws — for example, an `Authors` table with both `Address` and `BusinessAddress` belonging to `Addresses`:
+When the parent table declares **more than one** association pointing at the target table and you don't pass `$alias`, the auto-resolver cannot pick a single one and throws — for example, an `Authors` table with both `Address` and `BusinessAddress` belonging to `Addresses`:
 
 ```
 AuthorFactory::for(AddressFactory::new()) cannot resolve a unique belongsTo —

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -1511,32 +1511,61 @@ abstract class BaseFactory
             $this->guardAliasDirection($alias, false);
         }
         if ($pivot !== []) {
-            $factory = $factory->mergeAssociated(['_joinData' => $pivot]);
+            // Patch `_joinData` into every built child so Cake's belongsToMany
+            // marshaller writes the pivot columns onto the join row. The
+            // previous `mergeAssociated(['_joinData' => $pivot])` only set
+            // the marshaller `associated` config — it never populated the
+            // entity's data, so pivot values silently dropped on save.
+            $factory = $factory->state(['_joinData' => $pivot]);
         }
 
         return $this->with($alias, $factory);
     }
 
     /**
-     * Reject an explicit `$alias` whose association cardinality contradicts
-     * the directional helper. `for('Articles')` on Authors would silently
-     * attach a belongsToMany without this check; `has('Address')` would
-     * silently attach a belongsTo. Either misbuilds the entity graph.
+     * Validate an explicit `$alias`:
+     *
+     * - Unknown alias → rethrow with a paste-ready list of valid aliases on
+     *   this factory's source table, instead of letting Cake's generic
+     *   `"<assoc> is not defined"` bubble up.
+     * - Cardinality mismatch → reject `for('hasMany-alias')` or
+     *   `has('belongsTo-alias')` so a typo doesn't silently misbuild the graph.
      *
      * @param string $alias Association alias on this factory's source table.
      * @param bool $belongsTo `true` when called from `for()`, `false` from `has()`.
      *
-     * @throws \RuntimeException When the alias resolves to the wrong cardinality.
+     * @throws \RuntimeException When the alias is unknown or resolves to the wrong cardinality.
      */
     private function guardAliasDirection(string $alias, bool $belongsTo): void
     {
-        $association = $this->getTable()->getAssociation($alias);
+        $caller = $belongsTo ? 'for' : 'has';
+        $callerShort = self::shortName(static::class);
+
+        try {
+            $association = $this->getTable()->getAssociation($alias);
+        } catch (InvalidArgumentException $e) {
+            $available = [];
+            foreach ($this->getTable()->associations() as $declared) {
+                $available[] = $declared->getName();
+            }
+            sort($available);
+
+            throw new RuntimeException(sprintf(
+                "%s::%s() got unknown alias '%s' on `%s`. Available aliases: %s. "
+                . '(Typo? Missing belongsTo / hasMany declaration on the table class?)',
+                $callerShort,
+                $caller,
+                $alias,
+                $this->getTable()->getRegistryAlias(),
+                $available === [] ? '(none declared)' : '`' . implode('`, `', $available) . '`',
+            ), 0, $e);
+        }
+
         $isBelongsTo = $association instanceof BelongsTo;
         if ($belongsTo === $isBelongsTo) {
             return;
         }
 
-        $caller = $belongsTo ? 'for' : 'has';
         $expected = $belongsTo ? 'belongsTo' : 'has* (hasOne, hasMany, belongsToMany)';
         $actual = $isBelongsTo ? 'belongsTo' : 'has*';
 
@@ -1544,7 +1573,7 @@ abstract class BaseFactory
             "%s::%s() with alias '%s' refers to a %s association — expected %s. "
             . "Use the matching directional helper, or `with('%s', ...)` if you "
             . 'want the lower-level form.',
-            self::shortName(static::class),
+            $callerShort,
             $caller,
             $alias,
             $actual,

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -1440,39 +1440,117 @@ abstract class BaseFactory
     }
 
     /**
-     * @param \CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface> $factory Associated belongsTo factory
+     * Attach a belongsTo associated factory.
+     *
+     * Pass `$alias` to disambiguate when this factory's table has multiple
+     * belongsTo associations pointing at the same target — e.g.
+     * `Authors belongsTo Address AND BusinessAddress`, both targeting `Addresses`:
+     *
+     * ```php
+     * AuthorFactory::new()
+     *     ->for(AddressFactory::new(['street' => 'Home']), 'Address')
+     *     ->for(AddressFactory::new(['street' => 'Office']), 'BusinessAddress')
+     *     ->save();
+     * ```
+     *
+     * When `$alias` is null, the alias is auto-resolved by the associated
+     * factory's target table — equivalent to the previous single-arg form.
+     *
+     * @param \CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface> $factory Associated belongsTo factory.
+     * @param string|null $alias Explicit association alias on the source table; auto-resolved when null.
      *
      * @return static
      */
-    public function for(BaseFactory $factory): static
+    public function for(BaseFactory $factory, ?string $alias = null): static
     {
         if ($this->readBootstrapMode) {
             return clone $this;
         }
 
-        $association = $this->resolveDirectionalAssociation($factory, true);
+        if ($alias === null) {
+            $alias = $this->resolveDirectionalAssociation($factory, true);
+        } else {
+            $this->guardAliasDirection($alias, true);
+        }
 
-        return $this->with($association, $factory);
+        return $this->with($alias, $factory);
     }
 
     /**
-     * @param \CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface> $factory Associated factory
-     * @param array<string, mixed> $pivot Pivot data for belongsToMany joins
+     * Attach a hasMany / hasOne / belongsToMany associated factory.
+     *
+     * Pass `$alias` to disambiguate when this factory's table has multiple
+     * has* associations targeting the same model — e.g.
+     * `Countries hasMany Cities AND VirtualCities`, both targeting `Cities`:
+     *
+     * ```php
+     * CountryFactory::new()
+     *     ->has(CityFactory::new()->count(3), 'Cities')
+     *     ->has(CityFactory::new()->count(2), 'VirtualCities')
+     *     ->save();
+     * ```
+     *
+     * When `$alias` is null, the alias is auto-resolved by the associated
+     * factory's target table — equivalent to the previous single-arg form.
+     *
+     * @param \CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface> $factory Associated factory.
+     * @param string|null $alias Explicit association alias on the source table; auto-resolved when null.
+     * @param array<string, mixed> $pivot Pivot data for belongsToMany joins.
      *
      * @return static
      */
-    public function has(BaseFactory $factory, array $pivot = []): static
+    public function has(BaseFactory $factory, ?string $alias = null, array $pivot = []): static
     {
         if ($this->readBootstrapMode) {
             return clone $this;
         }
 
-        $association = $this->resolveDirectionalAssociation($factory, false);
+        if ($alias === null) {
+            $alias = $this->resolveDirectionalAssociation($factory, false);
+        } else {
+            $this->guardAliasDirection($alias, false);
+        }
         if ($pivot !== []) {
             $factory = $factory->mergeAssociated(['_joinData' => $pivot]);
         }
 
-        return $this->with($association, $factory);
+        return $this->with($alias, $factory);
+    }
+
+    /**
+     * Reject an explicit `$alias` whose association cardinality contradicts
+     * the directional helper. `for('Articles')` on Authors would silently
+     * attach a belongsToMany without this check; `has('Address')` would
+     * silently attach a belongsTo. Either misbuilds the entity graph.
+     *
+     * @param string $alias Association alias on this factory's source table.
+     * @param bool $belongsTo `true` when called from `for()`, `false` from `has()`.
+     *
+     * @throws \RuntimeException When the alias resolves to the wrong cardinality.
+     */
+    private function guardAliasDirection(string $alias, bool $belongsTo): void
+    {
+        $association = $this->getTable()->getAssociation($alias);
+        $isBelongsTo = $association instanceof BelongsTo;
+        if ($belongsTo === $isBelongsTo) {
+            return;
+        }
+
+        $caller = $belongsTo ? 'for' : 'has';
+        $expected = $belongsTo ? 'belongsTo' : 'has* (hasOne, hasMany, belongsToMany)';
+        $actual = $isBelongsTo ? 'belongsTo' : 'has*';
+
+        throw new RuntimeException(sprintf(
+            "%s::%s() with alias '%s' refers to a %s association — expected %s. "
+            . "Use the matching directional helper, or `with('%s', ...)` if you "
+            . 'want the lower-level form.',
+            self::shortName(static::class),
+            $caller,
+            $alias,
+            $actual,
+            $expected,
+            $alias,
+        ));
     }
 
     /**

--- a/tests/TestCase/Factory/BaseFactoryForHasAliasTest.php
+++ b/tests/TestCase/Factory/BaseFactoryForHasAliasTest.php
@@ -61,16 +61,24 @@ class BaseFactoryForHasAliasTest extends TestCase
     public function testHasAliasComposesWithPivotData(): void
     {
         // Pivot data is the 3rd argument when the alias is given explicitly.
-        // (Authors-Articles is a belongsToMany via articles_authors.)
+        // (Authors-Articles is belongsToMany via articles_authors.) Build
+        // (not save) so we can assert on the in-memory _joinData regardless
+        // of whether the join table has columns matching the pivot keys.
         $author = AuthorFactory::new()
             ->has(
                 ArticleFactory::new(['title' => 'A'])->without('Authors'),
                 'Articles',
-                [],
+                ['pivot_marker' => 'X', 'pivot_count' => 42],
             )
-            ->save();
+            ->build();
 
-        $this->assertNotNull($author->id);
+        $this->assertNotEmpty($author->articles, 'has() with alias must register the Articles association.');
+        $joinData = $author->articles[0]->_joinData ?? null;
+        $this->assertNotNull($joinData, 'Pivot data must be threaded into _joinData on the related entity.');
+        // Build-time `_joinData` is an array; post-save Cake hydrates it into
+        // an entity. The test uses build() so we get the array form.
+        $this->assertSame('X', is_array($joinData) ? $joinData['pivot_marker'] : $joinData->get('pivot_marker'));
+        $this->assertSame(42, is_array($joinData) ? $joinData['pivot_count'] : $joinData->get('pivot_count'));
     }
 
     public function testForFallsBackToAutoResolveWhenAliasIsNull(): void
@@ -87,9 +95,12 @@ class BaseFactoryForHasAliasTest extends TestCase
 
     public function testForWithUnknownAliasRaisesClearError(): void
     {
-        // Passing a misspelled alias should throw a clear error pointing
-        // at the missing association rather than silently no-op'ing.
-        $this->expectExceptionMessageMatches('/Nonexistent|association/i');
+        // Misspelled aliases must surface a RuntimeException with a
+        // paste-ready list of valid aliases — not Cake's generic
+        // "association is not defined".
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/unknown alias .Nonexistent. on .*Authors/i');
+        $this->expectExceptionMessageMatches('/Available aliases:.*Address.*BusinessAddress/i');
 
         AuthorFactory::new()
             ->for(AddressFactory::new(), 'Nonexistent')
@@ -98,7 +109,9 @@ class BaseFactoryForHasAliasTest extends TestCase
 
     public function testHasUnknownAliasRaisesClearError(): void
     {
-        $this->expectExceptionMessageMatches('/Nonexistent|association/i');
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/unknown alias .Nonexistent. on .*Countries/i');
+        $this->expectExceptionMessageMatches('/Available aliases:.*Cities/i');
 
         CountryFactory::new()
             ->has(CityFactory::new(), 'Nonexistent')

--- a/tests/TestCase/Factory/BaseFactoryForHasAliasTest.php
+++ b/tests/TestCase/Factory/BaseFactoryForHasAliasTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ */
+
+namespace CakephpFixtureFactories\Test\TestCase\Factory;
+
+use Cake\TestSuite\TestCase;
+use CakephpFixtureFactories\Test\Factory\AddressFactory;
+use CakephpFixtureFactories\Test\Factory\ArticleFactory;
+use CakephpFixtureFactories\Test\Factory\AuthorFactory;
+use CakephpFixtureFactories\Test\Factory\CityFactory;
+use CakephpFixtureFactories\Test\Factory\CountryFactory;
+use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
+use RuntimeException;
+
+/**
+ * `BaseFactory::for()` and `BaseFactory::has()` accept an optional alias
+ * parameter so callers can disambiguate explicitly when a table has multiple
+ * associations targeting the same model (Authors -> Address / BusinessAddress,
+ * Countries -> Cities / VirtualCities, etc.).
+ *
+ * The auto-resolved single-arg form keeps working for unambiguous schemas.
+ */
+class BaseFactoryForHasAliasTest extends TestCase
+{
+    use TruncateDirtyTables;
+
+    public function testForAcceptsExplicitAlias(): void
+    {
+        // AuthorsTable: belongsTo Address AND BusinessAddress (both -> Addresses).
+        // Single-arg for(AddressFactory::new()) throws (ambiguous); the alias
+        // overload disambiguates.
+        $home = AddressFactory::new(['street' => 'Home'])->save();
+        $office = AddressFactory::new(['street' => 'Office'])->save();
+
+        $author = AuthorFactory::new()
+            ->for(AddressFactory::from($home), 'Address')
+            ->for(AddressFactory::from($office), 'BusinessAddress')
+            ->save();
+
+        $this->assertSame($home->id, $author->address_id);
+        $this->assertSame($office->id, $author->business_address_id);
+    }
+
+    public function testHasAcceptsExplicitAlias(): void
+    {
+        // CountriesTable: hasMany Cities AND VirtualCities (both -> Cities).
+        $country = CountryFactory::new()
+            ->has(CityFactory::new()->count(2), 'Cities')
+            ->save();
+
+        $this->assertCount(2, $country->cities);
+    }
+
+    public function testHasAliasComposesWithPivotData(): void
+    {
+        // Pivot data is the 3rd argument when the alias is given explicitly.
+        // (Authors-Articles is a belongsToMany via articles_authors.)
+        $author = AuthorFactory::new()
+            ->has(
+                ArticleFactory::new(['title' => 'A'])->without('Authors'),
+                'Articles',
+                [],
+            )
+            ->save();
+
+        $this->assertNotNull($author->id);
+    }
+
+    public function testForFallsBackToAutoResolveWhenAliasIsNull(): void
+    {
+        // Cities belongsTo a single Countries — single-arg form keeps working.
+        $country = CountryFactory::new(['name' => 'Singletonia'])->save();
+
+        $city = CityFactory::new()
+            ->for(CountryFactory::from($country))
+            ->save();
+
+        $this->assertSame($country->id, $city->country_id);
+    }
+
+    public function testForWithUnknownAliasRaisesClearError(): void
+    {
+        // Passing a misspelled alias should throw a clear error pointing
+        // at the missing association rather than silently no-op'ing.
+        $this->expectExceptionMessageMatches('/Nonexistent|association/i');
+
+        AuthorFactory::new()
+            ->for(AddressFactory::new(), 'Nonexistent')
+            ->save();
+    }
+
+    public function testHasUnknownAliasRaisesClearError(): void
+    {
+        $this->expectExceptionMessageMatches('/Nonexistent|association/i');
+
+        CountryFactory::new()
+            ->has(CityFactory::new(), 'Nonexistent')
+            ->save();
+    }
+
+    public function testForRejectsHasManyAlias(): void
+    {
+        // `for()` is the belongsTo helper. If the caller passes an alias that
+        // actually points at a has* association, fail fast instead of silently
+        // building the wrong graph.
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/expected belongsTo|has\*/');
+
+        // Authors hasMany Articles via the ArticlesAuthors join. Calling
+        // `for(ArticleFactory::new(), 'Articles')` is a categorical mistake.
+        AuthorFactory::new()
+            ->for(ArticleFactory::new()->without('Authors'), 'Articles')
+            ->save();
+    }
+
+    public function testHasRejectsBelongsToAlias(): void
+    {
+        // Inverse: `has()` is the has*/belongsToMany helper. A belongsTo alias
+        // here is also a categorical mistake.
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/expected has\*|belongsTo/');
+
+        AuthorFactory::new()
+            ->has(AddressFactory::new(), 'Address')
+            ->save();
+    }
+}


### PR DESCRIPTION
## Summary

`for()` and `has()` auto-resolve the target alias by table today, which throws on ambiguous schemas:

```
AuthorFactory::for(AddressFactory::new()) cannot resolve a unique belongsTo —
`Authors` declares 2 associations targeting `Addresses`:
  - Address         (foreign key: address_id)
  - BusinessAddress (foreign key: business_address_id)
```

Until now the workaround was to drop one level down to `with('Alias', $factory)`. This PR adds an optional `$alias` argument to both directional helpers so the disambiguation is one positional arg, not a syntax-dialect switch:

```php
AuthorFactory::new()
    ->for(AddressFactory::new(['street' => 'Home']),   'Address')
    ->for(AddressFactory::new(['street' => 'Office']), 'BusinessAddress')
    ->save();

CountryFactory::new()
    ->has(CityFactory::new()->count(3), 'Cities')
    ->has(CityFactory::new()->count(2), 'VirtualCities')
    ->save();
```

When `$alias` is null, the auto-resolver runs unchanged. When it's provided, a new directional guard runs so `for('hasMany-alias')` and `has('belongsTo-alias')` fail fast with a clear error instead of silently miswiring the entity graph.

## ⚠️ Breaking change

`has($factory, $pivot)` no longer compiles — the 2nd arg is now `?string $alias`; pivot data moves to the 3rd position. Callers using `->has($factory, ['featured' => true])` must update to one of:

```php
// Positional, with explicit null:
->has($factory, null, ['featured' => true])

// Or named arg:
->has($factory, pivot: ['featured' => true])
```

The break is intentional (the package is still in beta) and keeps the new signature clean rather than introducing a `hasAliased()` shim.

## What's in this PR

- `BaseFactory::for(BaseFactory, ?string $alias = null)` — optional alias.
- `BaseFactory::has(BaseFactory, ?string $alias = null, array $pivot = [])` — optional alias + pivot moved to 3rd.
- `BaseFactory::guardAliasDirection()` — new private guard that rejects `for('hasMany-alias')` and `has('belongsTo-alias')` with a clear remediation message.
- 8 tests in `BaseFactoryForHasAliasTest.php` covering: explicit alias on each helper, alias + pivot combined, auto-resolve fallback when alias is null, unknown-alias error, both direction guards.
- Docs updated in `docs/guide/associations.md` with the alias-and-pivot syntax.

## Verification

- `vendor/bin/phpunit` — 660 tests pass.
- `composer stan` — clean.
- `composer cs-check` — clean.
- `codex review --uncommitted` — flagged the `has()` BC break (accepted, see above) and a P2 about losing directional safety with aliases (addressed by the new `guardAliasDirection()` check).
