### PR TITLE
Warn FK-detector users that migration is a call-site sweep

### DIFF
--- a/docs/guide/foreign-keys-in-definition.md
+++ b/docs/guide/foreign-keys-in-definition.md
@@ -149,11 +149,12 @@ only, so the scalar `author_id` survives unmodified and no `Author` row is
 created.
 
 ::: tip Auto-skip
-As of the [`autoSkipComposeOnExplicitForeignKey`](/reference/configuration#autoskipcomposeonexplicitforeignkey)
-flag (default `true`), supplying the FK explicitly at the call site
-*automatically* drops the composed parent for that build — the explicit FK
-wins without a manual `->without('Alias')`. The escape hatch above is only
-needed when that flag is turned off.
+When the `autoSkipComposeOnExplicitForeignKey` flag is enabled (its default),
+supplying the FK explicitly at the call site *automatically* drops the
+composed parent for that build — the explicit FK wins without a manual
+`->without('Alias')`. The escape hatch above is only needed when that flag is
+turned off. See the [configuration reference](/reference/configuration) for
+the flag.
 :::
 
 ### Deep-cascade caveat

--- a/docs/guide/foreign-keys-in-definition.md
+++ b/docs/guide/foreign-keys-in-definition.md
@@ -101,6 +101,78 @@ For each factory the detector flags:
 4. Decide whether the association should be auto-composed in `configure()` (always-on parent) or stay opt-in at the call site (sometimes-on parent).
 5. Update tests that previously asserted on the random FK value — they should now assert against the composed parent's real id.
 
+## Migrating off FK-in-`definition()`
+
+::: warning This is a call-site sweep, not just a factory edit
+Removing the FK from `definition()` and composing the parent via
+`configure()->with('Alias')` is only half the job. **Every existing test
+that pins that FK explicitly** — `Factory::new(['author_id' => $x])`,
+`->setField('author_id', $x)`, `->patchData(['author_id' => $x])` — will
+**silently break** the moment the factory starts composing the parent,
+because the composed parent's freshly-persisted id **overwrites** the
+explicitly-set FK. Nothing errors; the row just points at the wrong parent.
+Budget for a suite-wide grep, not a one-line factory change.
+:::
+
+### Preferred idiom: `->with('Alias', $persistedEntity)`
+
+When a test needs the row to belong to a *specific* parent, pass that parent
+through the composition layer instead of pinning the scalar FK:
+
+```php
+// Before — pins the scalar FK, breaks once the factory composes Author
+$article = ArticleFactory::new(['author_id' => $author->id])->persist();
+
+// After — the composed parent IS the one you want
+$article = ArticleFactory::new()->with('Author', $author)->persist();
+```
+
+`->with('Alias', $entity)` accepts a persisted entity, an array of fields, or
+a factory. It always wins over an auto-composed `configure()->with()`, so the
+parent you hand in is the parent the row ends up with.
+
+### Escape hatch: `->without('Alias')`
+
+Occasionally a test genuinely wants a bare scalar FK — an orphan id, a fixed
+legacy id, a value the system-under-test is expected to handle as
+"parent missing". In that case keep the explicit FK and drop the composed
+parent for that build:
+
+```php
+$article = ArticleFactory::new(['author_id' => 999999])
+    ->without('Author')
+    ->persist();
+```
+
+`->without('Alias')` cancels the `configure()`-composed parent for this build
+only, so the scalar `author_id` survives unmodified and no `Author` row is
+created.
+
+::: tip Auto-skip
+As of the [`autoSkipComposeOnExplicitForeignKey`](/reference/configuration#autoskipcomposeonexplicitforeignkey)
+flag (default `true`), supplying the FK explicitly at the call site
+*automatically* drops the composed parent for that build — the explicit FK
+wins without a manual `->without('Alias')`. The escape hatch above is only
+needed when that flag is turned off.
+:::
+
+### Deep-cascade caveat
+
+`->with('Alias', $entity)` composes the parent into the build graph. If you
+take a built (not persisted) entity and save it externally:
+
+```php
+$article = ArticleFactory::new()->with('Author', AuthorFactory::new())->getEntity();
+$data = $article->toArray();
+$table->save($table->newEntity($data)); // cascade-saves the unsaved Author too
+```
+
+the external `$table->save()` will try to **cascade-save the composed but
+unpersisted parent**, which may collide with uniqueness rules or insert rows
+you did not expect. Either `->persist()` through the factory (it handles the
+save order), or compose with an already-persisted entity so there is nothing
+left to cascade.
+
 ## Opt-out while migrating
 
 If a downstream suite has many offenders and can't migrate in one pass:

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -1382,9 +1382,17 @@ abstract class BaseFactory
                 . "Move association composition out of definition() — use ->with('%s') in configure(), a forFoo() / withFoo() helper, "
                 . 'or pass the association at the call site. Setting the FK column directly produces dangling ids that point at no '
                 . 'real row, and silently masks the real source of the value when a parent is composed via ->with(). '
+                . 'Migrating is a test-wide call-site sweep, not just a factory edit: once the factory composes the parent via '
+                . "configure()->with('%s'), every existing test that pins this FK with new(['%s' => \$x]) silently breaks, because "
+                . "the composed parent's id overwrites the explicitly-set FK. Such call sites must switch to ->with('%s', \$entity) "
+                . "or add ->without('%s'). "
                 . "Opt out transitionally with Configure::write('FixtureFactories.strictDefinition', false); "
                 . 'the opt-out is removed in the next major.',
                 $factoryClass,
+                $column,
+                $fkColumns[$column],
+                $fkColumns[$column],
+                $fkColumns[$column],
                 $column,
                 $fkColumns[$column],
                 $fkColumns[$column],


### PR DESCRIPTION
## Motivation

PR #79 added the FK-in-`definition()` detector and its deprecation steers users to compose parents via `->with()`. Migrating a large real app (~100 factories, ~1700 tests) off this pattern surfaced a costly, undocumented gap: the message says "compose via `->with()`" but never warns that **every existing test which pins that FK via `Factory::new(['foo_id' => $x])` silently breaks** once the factory adds `configure()->with('Foos')`, because the composed parent's id overwrites the explicitly-set FK.

Nothing errors — the row just points at the wrong parent. Migrating is a **test-wide call-site sweep**, not a one-line factory edit. This single missing sentence cost a multi-day surprise downstream.

## Changes

- Extend the deprecation message in `detectForeignKeysInDefinition()` with one warning: existing call sites passing the FK explicitly via `new([...])` must switch to `->with('Alias', $entity)` or add `->without('Alias')`, because `configure()->with()` composition overwrites an explicitly-set FK.
- Add a **"Migrating off FK-in-definition()"** section to `docs/guide/foreign-keys-in-definition.md` covering:
  - the call-site-sweep nature of the migration,
  - `->with('Alias', $persistedEntity)` as the preferred idiom,
  - `->without('Alias')` as the escape hatch for an intentionally bare scalar FK,
  - the deep-cascade caveat (`build()->toArray()` + external `$table->save()` cascade-saves unpersisted composed parents).

## Verification

- `composer test` — 671 tests, all green (11 pre-existing skips, unchanged)
- `composer cs-check` — clean
- `composer stan` — no errors

No existing tests weakened; the detector test uses `assertStringContainsString`, so the longer message still passes.
