### PR TITLE
Auto-skip belongsTo composition when its FK is explicitly provided

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -62,6 +62,26 @@ return [
         // 'strictDefinition' => true,
 
         /**
+         * When enabled (the default), a belongsTo association composed in
+         * configure() is automatically NOT composed for a given build when the
+         * caller explicitly provides that association's foreign-key column at
+         * the call site — via new(['foo_id' => $x]), setField('foo_id', $x),
+         * state(['foo_id' => $x]) or sequence(). The explicitly-set FK then
+         * wins instead of being silently overwritten by the composed parent's
+         * fresh id, and no throw-away parent row is created (equivalent to an
+         * automatic ->without('Alias')).
+         *
+         * An explicit ->with('Alias', ...) always wins over this auto-skip:
+         * the caller clearly asked for composition, so it is never skipped.
+         *
+         * Set to false to restore the legacy behavior where a configure()-
+         * composed parent overrides an explicitly-set foreign key.
+         *
+         * Default: true
+         */
+        // 'autoSkipComposeOnExplicitForeignKey' => true,
+
+        /**
          * Namespace where factory classes are located.
          * Default: App\Test\Factory (auto-detected from table registry name)
          */

--- a/docs/guide/foreign-keys-in-definition.md
+++ b/docs/guide/foreign-keys-in-definition.md
@@ -101,6 +101,32 @@ For each factory the detector flags:
 4. Decide whether the association should be auto-composed in `configure()` (always-on parent) or stay opt-in at the call site (sometimes-on parent).
 5. Update tests that previously asserted on the random FK value — they should now assert against the composed parent's real id.
 
+## Pinning the FK at the call site Just Works
+
+The detector steers FK population out of `definition()` and into association
+composition. The natural follow-up question is: *if the parent is now composed
+in `configure()`, how do I still test "this row belongs to that specific
+parent"?* Historically you had to add a manual `->without('Alias')` next to
+every `Factory::new(['foo_id' => $x])`, because the composed parent's id would
+otherwise overwrite the explicit FK.
+
+That manual `->without()` is no longer needed. With
+[`autoSkipComposeOnExplicitForeignKey`](/reference/configuration#autoskipcomposeonexplicitforeignkey)
+(default `true`), explicitly providing the FK at the call site automatically
+suppresses the `configure()`-composed parent for that build, so the explicit
+value wins:
+
+```php
+// Factory composes the parent in configure()->with('Author').
+// Pinning author_id at the call site auto-skips that composition:
+$article = ArticleFactory::new(['author_id' => $author->id])->persist();
+// $article->author_id === $author->id  (no throw-away Author row)
+```
+
+An explicit `->with('Author', ...)` still always composes — that is an
+unambiguous request for a parent and wins over the auto-skip. Turn the flag
+off only if a suite relied on the old override behavior.
+
 ## Opt-out while migrating
 
 If a downstream suite has many offenders and can't migrate in one pass:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -15,6 +15,7 @@ return [
         'seed' => 1234,
         'instanceLevelGenerator' => true,
         'strictDefinition' => true,
+        'autoSkipComposeOnExplicitForeignKey' => true,
         'testFixtureNamespace' => 'App\\Test\\Factory',
         'testFixtureOutputDir' => 'Factory/',
         'testFixtureGlobalBehaviors' => [],
@@ -74,6 +75,36 @@ the opt-out is transitional and will be removed in the next major release,
 when the deprecation becomes a hard exception. See
 [Foreign keys in `definition()`](/guide/foreign-keys-in-definition) for the
 full rationale and a migration cookbook.
+
+Default: `true`.
+
+### `autoSkipComposeOnExplicitForeignKey`
+
+Controls whether a `configure()`-composed `belongsTo` parent is automatically
+skipped for a build when the caller explicitly supplies that association's
+foreign-key column.
+
+When `true` (the default) and a factory composes a parent in `configure()`
+(e.g. `configure()->with('Homes')`), a call site that pins the FK —
+`Factory::new(['home_id' => 123])`, `->setField('home_id', 123)`,
+`->state(['home_id' => 123])`, or `sequence()` — makes the factory **not**
+compose that parent for that build (an implicit `->without('Homes')`). The
+explicitly-set `123` then survives instead of being silently overwritten by
+the composed parent's freshly-persisted id, and no throw-away parent row is
+created. This is almost always the intent and complements the
+[FK-in-`definition()` detector](/guide/foreign-keys-in-definition): the
+detector says "don't put the FK in `definition()`", this makes "pin the FK at
+the call site" Just Work.
+
+An explicit `->with('Alias', ...)` always wins over the auto-skip — the caller
+clearly asked for composition, so it is never skipped even if the FK is also
+set. Only `configure()` defaults are auto-skipped, and only when the FK value
+comes from caller-supplied state (not a `definition()` default) and is
+non-null.
+
+Set to `false` to restore the legacy behavior where a `configure()`-composed
+parent overrides an explicitly-set foreign key (e.g. for a suite that relied
+on that override).
 
 Default: `true`.
 

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -1397,11 +1397,18 @@ abstract class BaseFactory
      * per registry alias. Only belongsTo associations contribute, because that
      * is the side that owns the FK column locally.
      *
+     * Shared with the auto-skip-composition feature in {@see DataCompiler}: both
+     * the FK-in-definition() detector and the auto-skip need the same belongsTo
+     * FK enumeration, so the mapping is defined once here and reused rather than
+     * duplicated.
+     *
+     * @internal
+     *
      * @param \Cake\ORM\Table $table
      *
      * @return array<int|string, string> Map of FK column name to declaring association alias.
      */
-    private static function collectForeignKeyColumns(Table $table): array
+    public static function collectForeignKeyColumns(Table $table): array
     {
         $cacheKey = $table->getRegistryAlias();
         if (isset(self::$fkColumnsByRegistry[$cacheKey])) {

--- a/src/Factory/DataCompiler.php
+++ b/src/Factory/DataCompiler.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace CakephpFixtureFactories\Factory;
 
+use Cake\Core\Configure;
 use Cake\Database\Driver\Postgres;
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\Association;
@@ -642,8 +643,12 @@ class DataCompiler
         if ($isEntityInjected) {
             $associatedData = $this->dataFromAssociations;
         } else {
+            $defaultAssociations = $this->skipComposedAssociationsWithExplicitForeignKey(
+                $entity,
+                $this->dataFromDefaultAssociations,
+            );
             // Overwrite the default associations if these are found in the associations
-            $associatedData = array_merge($this->dataFromDefaultAssociations, $this->dataFromAssociations);
+            $associatedData = array_merge($defaultAssociations, $this->dataFromAssociations);
         }
 
         foreach ($associatedData as $propertyName => $data) {
@@ -658,6 +663,108 @@ class DataCompiler
         }
 
         return $this;
+    }
+
+    /**
+     * Drop `configure()`-composed belongsTo associations whose foreign-key
+     * column was set explicitly by the caller.
+     *
+     * When a factory composes a parent in `configure()` (e.g.
+     * `configure()->with('Homes')`) and the caller also pins that parent's FK
+     * at the call site — `Factory::new(['home_id' => 123])`,
+     * `->setField('home_id', 123)`, `->state(['home_id' => 123])` — the
+     * composed parent would be built, persisted, and its fresh id would
+     * silently overwrite the explicit `123`. That is almost never the intent:
+     * a caller who names the FK wants that exact parent. Auto-skipping the
+     * composition (an implicit `->without('Alias')`) lets the explicit FK win
+     * and avoids creating a throw-away parent row.
+     *
+     * Scope and guarantees:
+     *  - Only `configure()` defaults are considered. An explicit
+     *    `->with('Alias', ...)` lands in `$dataFromAssociations` (merged after
+     *    this filter) and always wins — the caller clearly asked for
+     *    composition, so it is never auto-skipped.
+     *  - The FK must come from caller-supplied state, tracked by
+     *    {@see self::getEnforcedFields()} — instantiation array, `state()`,
+     *    `setField()`, `sequence()`. Values produced only by `definition()`
+     *    defaults never reach the enforced-fields list, so a default FK does
+     *    not trigger the skip.
+     *  - The resolved FK value on the entity must be non-null. An explicit
+     *    `null` is intentionally out of scope: it is indistinguishable here
+     *    from "not provided", and the legacy compose-then-overwrite behavior
+     *    is preserved for that case. To deliberately build an orphan with a
+     *    `null` FK, use an explicit `->without('Alias')` at the call site.
+     *  - Behind `FixtureFactories.autoSkipComposeOnExplicitForeignKey`
+     *    (default `true`). Set to `false` to restore the legacy behavior where
+     *    the composed parent overrides an explicitly-set FK.
+     *
+     * @param \Cake\Datasource\EntityInterface $entity Entity carrying the resolved scalar data.
+     * @param array<string, array<int, \CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface>>> $defaultAssociations Associations composed by configure().
+     *
+     * @return array<string, array<int, \CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface>>>
+     */
+    private function skipComposedAssociationsWithExplicitForeignKey(
+        EntityInterface $entity,
+        array $defaultAssociations,
+    ): array {
+        if (!$defaultAssociations) {
+            return $defaultAssociations;
+        }
+        if (!Configure::read('FixtureFactories.autoSkipComposeOnExplicitForeignKey', true)) {
+            return $defaultAssociations;
+        }
+
+        $enforcedFields = $this->getEnforcedFields();
+        if (!$enforcedFields) {
+            return $defaultAssociations;
+        }
+
+        // Reuse the belongsTo FK→alias enumeration shared with the
+        // FK-in-definition() detector (see BaseFactory::collectForeignKeyColumns())
+        // as a cheap gate: if the table declares no belongsTo FK columns there
+        // is nothing this feature can ever skip.
+        if (!BaseFactory::collectForeignKeyColumns($this->getFactory()->getTable())) {
+            return $defaultAssociations;
+        }
+        $enforcedFields = array_fill_keys($enforcedFields, true);
+
+        foreach (array_keys($defaultAssociations) as $associationName) {
+            // An explicit ->with('Alias', ...) re-added the same alias: the
+            // caller asked for composition, so never auto-skip it.
+            if (isset($this->dataFromAssociations[$associationName])) {
+                continue;
+            }
+            $association = $this->getAssociationByPropertyName($associationName);
+            if (!$association instanceof BelongsTo) {
+                continue;
+            }
+
+            // Only skip when the WHOLE foreign key (every component of a
+            // composite key) was explicitly provided and resolves to a
+            // non-null value — otherwise composing the parent would still be
+            // the only way to populate the missing key parts.
+            $allExplicit = null;
+            foreach ((array)$association->getForeignKey() as $foreignKey) {
+                if (!is_string($foreignKey) || $foreignKey === '') {
+                    continue;
+                }
+                if (
+                    !isset($enforcedFields[$foreignKey])
+                    || !$entity->has($foreignKey)
+                    || $entity->get($foreignKey) === null
+                ) {
+                    $allExplicit = false;
+
+                    break;
+                }
+                $allExplicit = true;
+            }
+            if ($allExplicit === true) {
+                unset($defaultAssociations[$associationName]);
+            }
+        }
+
+        return $defaultAssociations;
     }
 
     /**

--- a/tests/TestCase/Factory/BaseFactorySkipComposeOnExplicitForeignKeyTest.php
+++ b/tests/TestCase/Factory/BaseFactorySkipComposeOnExplicitForeignKeyTest.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link https://webrider.de/
+ * @since 2.0.0
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace CakephpFixtureFactories\Test\TestCase\Factory;
+
+use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
+use CakephpFixtureFactories\Test\Factory\AddressFactory;
+use CakephpFixtureFactories\Test\Factory\BillFactory;
+use CakephpFixtureFactories\Test\Factory\CityFactory;
+use CakephpFixtureFactories\Test\Factory\CountryFactory;
+use CakephpFixtureFactories\Test\Factory\CustomerFactory;
+use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
+
+/**
+ * Covers the auto-skip-composition feature: when a factory composes a
+ * belongsTo parent in `configure()` and the caller explicitly provides that
+ * association's foreign-key column at the call site, the composition is
+ * automatically dropped so the explicit FK wins (an implicit
+ * `->without('Alias')`).
+ *
+ * AddressFactory composes `City` via `configure()->forCity()`; the addresses
+ * table's belongsTo `City` owns `city_id`. BillFactory composes both `Article`
+ * and `Customer` via `configure()`; bills owns `article_id` and `customer_id`.
+ */
+class BaseFactorySkipComposeOnExplicitForeignKeyTest extends TestCase
+{
+    use TruncateDirtyTables;
+
+    public static function setUpBeforeClass(): void
+    {
+        Configure::write('FixtureFactories.testFixtureNamespace', 'CakephpFixtureFactories\Test\Factory');
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        Configure::delete('FixtureFactories.testFixtureNamespace');
+    }
+
+    protected function tearDown(): void
+    {
+        Configure::delete('FixtureFactories.autoSkipComposeOnExplicitForeignKey');
+        parent::tearDown();
+    }
+
+    /**
+     * Pinning the configure()-composed parent's FK via `new([...])` drops the
+     * composition for that build: the explicit value persists unchanged and no
+     * parent row is created.
+     */
+    public function testExplicitForeignKeyViaNewSkipsComposition(): void
+    {
+        $city = CityFactory::new()->save();
+
+        $address = AddressFactory::new(['city_id' => $city->id])->save();
+
+        $this->assertSame($city->id, $address->city_id);
+        $this->assertNull($address->city);
+        $this->assertSame(1, CityFactory::query()->count());
+    }
+
+    /**
+     * `setField()` is caller-supplied state too — same auto-skip as `new()`.
+     */
+    public function testExplicitForeignKeyViaSetFieldSkipsComposition(): void
+    {
+        $city = CityFactory::new()->save();
+
+        $address = AddressFactory::new()->setField('city_id', $city->id)->save();
+
+        $this->assertSame($city->id, $address->city_id);
+        $this->assertSame(1, CityFactory::query()->count());
+    }
+
+    /**
+     * `state()` (the patch layer) is caller-supplied state too — same
+     * auto-skip.
+     */
+    public function testExplicitForeignKeyViaStateSkipsComposition(): void
+    {
+        $city = CityFactory::new()->save();
+
+        $address = AddressFactory::new()->state(['city_id' => $city->id])->save();
+
+        $this->assertSame($city->id, $address->city_id);
+        $this->assertSame(1, CityFactory::query()->count());
+    }
+
+    /**
+     * No explicit FK → the `configure()` composition still happens exactly as
+     * before. A City is built and persisted, and the address points at it.
+     */
+    public function testWithoutExplicitForeignKeyCompositionStillHappens(): void
+    {
+        $address = AddressFactory::new()->save();
+
+        $this->assertNotNull($address->city_id);
+        $this->assertNotNull($address->city);
+        $this->assertSame($address->city_id, $address->city->id);
+        $this->assertSame(1, CityFactory::query()->count());
+    }
+
+    /**
+     * An explicit `->with('Alias', $entity)` is an unambiguous request for
+     * composition and wins over the auto-skip, even when the FK is also set.
+     * The composed entity is the parent, and its id overrides the scalar FK.
+     */
+    public function testExplicitWithEntityStillComposesEvenWhenForeignKeySet(): void
+    {
+        $pinned = CityFactory::new()->save();
+        $composed = CityFactory::new();
+
+        $address = AddressFactory::new(['city_id' => $pinned->id])
+            ->with('City', $composed)
+            ->save();
+
+        $this->assertNotNull($address->city);
+        $this->assertNotSame($pinned->id, $address->city_id);
+        $this->assertSame($address->city->id, $address->city_id);
+        $this->assertSame(2, CityFactory::query()->count());
+    }
+
+    /**
+     * An explicit `->with('Alias', [...])` array payload also still composes.
+     */
+    public function testExplicitWithArrayStillComposesEvenWhenForeignKeySet(): void
+    {
+        $pinned = CityFactory::new()->save();
+
+        $address = AddressFactory::new(['city_id' => $pinned->id])
+            ->with('City', ['name' => 'Composed City'])
+            ->save();
+
+        $this->assertNotNull($address->city);
+        $this->assertSame('Composed City', $address->city->name);
+        $this->assertNotSame($pinned->id, $address->city_id);
+        $this->assertSame(2, CityFactory::query()->count());
+    }
+
+    /**
+     * The opt-out flag restores the legacy behavior: the composed parent is
+     * built and its fresh id overwrites the explicitly-set FK.
+     */
+    public function testOptOutRestoresLegacyOverrideBehavior(): void
+    {
+        Configure::write('FixtureFactories.autoSkipComposeOnExplicitForeignKey', false);
+
+        $city = CityFactory::new()->save();
+
+        $address = AddressFactory::new(['city_id' => $city->id])->save();
+
+        $this->assertNotNull($address->city);
+        $this->assertNotSame($city->id, $address->city_id);
+        $this->assertSame($address->city->id, $address->city_id);
+        $this->assertSame(2, CityFactory::query()->count());
+    }
+
+    /**
+     * With multiple belongsTo composed in `configure()`, only the pinned one
+     * is skipped. BillFactory composes both Article and Customer; pinning
+     * `customer_id` skips Customer composition but Article is still composed.
+     */
+    public function testOnlyPinnedAssociationIsSkippedAmongMultipleBelongsTo(): void
+    {
+        $customer = CustomerFactory::new()->save();
+
+        $bill = BillFactory::new(['customer_id' => $customer->id])->save();
+
+        $this->assertSame($customer->id, $bill->customer_id);
+        $this->assertNull($bill->customer);
+        $this->assertSame(1, CustomerFactory::query()->count());
+
+        // Article was NOT pinned, so it is still composed and persisted.
+        $this->assertNotNull($bill->article_id);
+        $this->assertNotNull($bill->article);
+        $this->assertSame($bill->article_id, $bill->article->id);
+    }
+
+    /**
+     * A `definition()` default for the FK column must NOT trigger the skip:
+     * only caller-supplied state (enforced fields) counts. AddressFactory's
+     * definition() returns only `street`, so the City composition stays in
+     * effect when nothing pins `city_id`. (Guards the enforced-fields gate.)
+     */
+    public function testDefinitionDefaultDoesNotTriggerSkip(): void
+    {
+        $address = AddressFactory::new(['street' => 'Pinned Street'])->save();
+
+        $this->assertSame('Pinned Street', $address->street);
+        $this->assertNotNull($address->city);
+        $this->assertSame($address->city_id, $address->city->id);
+    }
+
+    /**
+     * Explicit `null` is intentionally out of scope: it is indistinguishable
+     * from "not provided", so the legacy compose-then-overwrite behavior is
+     * preserved and a parent is still composed. Callers wanting a genuine
+     * orphan must use an explicit `->without('City')`.
+     */
+    public function testExplicitNullForeignKeyDoesNotSkipComposition(): void
+    {
+        $address = AddressFactory::new(['city_id' => null])->save();
+
+        $this->assertNotNull($address->city);
+        $this->assertSame($address->city_id, $address->city->id);
+        $this->assertSame(1, CityFactory::query()->count());
+    }
+
+    /**
+     * The documented escape hatch: pinning the FK and adding an explicit
+     * `->without('City')` builds a genuine orphan with the requested null and
+     * no parent composed. (Built, not persisted — the addresses schema has a
+     * NOT NULL city_id, which is irrelevant to the composition behavior under
+     * test here.)
+     */
+    public function testExplicitWithoutBuildsOrphanWithNullForeignKey(): void
+    {
+        $address = AddressFactory::new(['city_id' => null])->without('City')->build();
+
+        $this->assertNull($address->city);
+        $this->assertNull($address->city_id);
+        $this->assertSame(0, CityFactory::query()->count());
+    }
+
+    /**
+     * Pinning the root FK skips the entire composed sub-graph, not just the
+     * direct parent. AddressFactory composes `City`, and CityFactory itself
+     * composes `Countries` in its own configure(). Pinning `city_id` on the
+     * address must drop the `City` composition outright — so no City AND no
+     * Country are built beyond the one explicitly created for the pin.
+     */
+    public function testPinningRootForeignKeySkipsTheWholeComposedSubGraph(): void
+    {
+        $country = CountryFactory::new()->save();
+        $city = CityFactory::new()->with('Countries', $country)->save();
+
+        $address = AddressFactory::new(['city_id' => $city->id])->save();
+
+        $this->assertSame($city->id, $address->city_id);
+        $this->assertNull($address->city);
+        $this->assertSame(1, CityFactory::query()->count());
+        $this->assertSame(1, CountryFactory::query()->count());
+    }
+}


### PR DESCRIPTION
## The override surprise

When a factory composes a `belongsTo` parent in `configure()` (e.g.
`configure()->with('Homes')`) and a caller pins that parent's FK at the call
site — `Factory::new(['home_id' => 123])`, `->setField()`, `->state()`,
`sequence()` — the composed parent is still built, persisted, and its fresh
id **silently overwrites** the explicit `123`. Nothing errors; the row just
points at the wrong parent.

Migrating a large real app (~100 factories, ~1700 tests) off FK-in-`definition()`
hit this in ~65 test files, each needing a hand-added `->without('Alias')`
next to the pinned FK. That churn is pure boilerplate for what is almost
always the obvious intent: a caller who names the FK wants that exact parent.

## The fix

When the **whole** foreign key of a `configure()`-composed `belongsTo` is
explicitly provided by caller state and resolves non-null, the association is
automatically dropped for that build (an implicit `->without('Alias')`), so
the explicit FK wins and no throw-away parent row is created.

This complements PR #79's FK-in-`definition()` detector: the detector says
"don't put the FK in `definition()`", this makes "pin the FK at the call
site" Just Work — eliminating the ~65-file `->without()` churn.

## Design / guarantees

- Gated behind `FixtureFactories.autoSkipComposeOnExplicitForeignKey`,
  **default `true`** (the intuitive behavior, matches the detector's
  direction). Set `false` to restore the legacy override behavior for suites
  that relied on it.
- An explicit `->with('Alias', $entity)` / `->with('Alias', [...])` always
  wins — the caller unambiguously asked for composition, never auto-skipped.
- Only `configure()` defaults are considered; the FK must come from
  caller-supplied state (enforced fields), not a `definition()` default.
- Composite foreign keys require **every** component pinned before the
  association is skipped (no partial-key holes).
- Explicit `null` FK is intentionally out of scope (indistinguishable from
  "not provided"); use `->without('Alias')` for a deliberate orphan.
- Reuses `BaseFactory::collectForeignKeyColumns()` (PR #79's belongsTo FK
  enumeration, now an `@internal` shared helper) as the cheap pre-gate
  instead of duplicating the association walk.
- Documented in `config/app.example.php`, the configuration reference, and
  the foreign-keys-in-definition guide.

## Tests

`BaseFactorySkipComposeOnExplicitForeignKeyTest` (12 cases): skip via
`new`/`setField`/`state`; composition unchanged without a pin; explicit
`->with()` entity/array still composes; opt-out flag restores old behavior;
multi-belongsTo (only the pinned one skipped); `definition()`-default does
not trigger; explicit-`null` out of scope; `->without()` orphan escape
hatch; whole composed sub-graph skipped when the root FK is pinned.

## Verification

- `composer test` — 683 tests, all green (11 pre-existing skips)
- `composer cs-check` — clean
- `composer stan` — no errors
