### PR TITLE
Detect custom-condition (uuid) join columns for foreignKey => false belongsTo

### DIFF
--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -1420,6 +1420,8 @@ abstract class BaseFactory
             if (!$association instanceof BelongsTo) {
                 continue;
             }
+
+            $declared = false;
             foreach ((array)$association->getForeignKey() as $column) {
                 // A belongsTo with 'foreignKey' => false (custom-condition /
                 // non-FK join) yields false here; (array)false === [false].
@@ -1428,13 +1430,88 @@ abstract class BaseFactory
                 if (!is_string($column) || $column === '') {
                     continue;
                 }
+                $declared = true;
                 if (!isset($columns[$column])) {
                     $columns[$column] = $association->getAlias();
+                }
+            }
+
+            // No declared scalar FK (foreignKey => false): the join is done
+            // through custom conditions (e.g. a uuid join). Recover the
+            // source-side join column(s) from the conditions so the detector
+            // still protects them. Conservative: only equality-style joins
+            // that reference BOTH this table's alias and the target alias are
+            // treated as join columns — pure filter conditions and opaque
+            // Closure conditions are ignored (no false positives).
+            if (!$declared) {
+                foreach (self::joinColumnsFromConditions($association) as $column) {
+                    if (!isset($columns[$column])) {
+                        $columns[$column] = $association->getAlias();
+                    }
                 }
             }
         }
 
         return self::$fkColumnsByRegistry[$cacheKey] = $columns;
+    }
+
+    /**
+     * Best-effort extraction of the source-table join column(s) from a
+     * belongsTo association whose `foreignKey` is `false` and whose join is
+     * expressed via custom `conditions` (the classic uuid-join pattern:
+     * `['Source.foo_uuid = Target.uuid']` or `['Source.foo_uuid' => 'Target.uuid']`).
+     *
+     * Only equality references that mention BOTH the source alias and the
+     * target alias are accepted, so a plain filter (`'Source.status' => 1`,
+     * `'Source.deleted = 0'`) is never mistaken for a join column. Closure
+     * conditions are opaque and yield nothing.
+     *
+     * @param \Cake\ORM\Association\BelongsTo<\Cake\ORM\Table> $association
+     *
+     * @return array<int, string> Source-table column names participating in the join.
+     */
+    private static function joinColumnsFromConditions(BelongsTo $association): array
+    {
+        $conditions = $association->getConditions();
+        if (!is_array($conditions)) {
+            return [];
+        }
+
+        $sourceAlias = $association->getSource()->getAlias();
+        $targetAlias = $association->getAlias();
+        $src = preg_quote($sourceAlias, '/');
+        $tgt = preg_quote($targetAlias, '/');
+
+        $cols = [];
+        foreach ($conditions as $key => $value) {
+            if (is_string($key)) {
+                // 'Source.col' => 'Target.col'  (join)
+                // 'Source.col' => <scalar>      (filter — ignored)
+                if (
+                    preg_match('/^' . $src . '\.(\w+)$/', $key, $m)
+                    && is_string($value)
+                    && preg_match('/^' . $tgt . '\.\w+$/', $value)
+                ) {
+                    $cols[] = $m[1];
+                }
+
+                continue;
+            }
+            // Integer key: a string expression such as
+            // 'Source.col = Target.col' (operator-agnostic). Require both
+            // aliases present so filters never qualify.
+            if (
+                is_string($value)
+                && preg_match('/\b' . $tgt . '\.\w+/', $value)
+                && preg_match_all('/\b' . $src . '\.(\w+)/', $value, $m)
+            ) {
+                foreach ($m[1] as $col) {
+                    $cols[] = $col;
+                }
+            }
+        }
+
+        return $cols;
     }
 
     /**

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -1421,7 +1421,11 @@ abstract class BaseFactory
                 continue;
             }
             foreach ((array)$association->getForeignKey() as $column) {
-                if ($column === '') {
+                // A belongsTo with 'foreignKey' => false (custom-condition /
+                // non-FK join) yields false here; (array)false === [false].
+                // Skip any non-string / empty key so it never lands in the
+                // map as a bogus 0 => alias entry.
+                if (!is_string($column) || $column === '') {
                     continue;
                 }
                 if (!isset($columns[$column])) {

--- a/tests/TestCase/Factory/BaseFactoryForeignKeyDetectionTest.php
+++ b/tests/TestCase/Factory/BaseFactoryForeignKeyDetectionTest.php
@@ -16,11 +16,13 @@ declare(strict_types=1);
 namespace CakephpFixtureFactories\Test\TestCase\Factory;
 
 use Cake\Core\Configure;
+use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use CakephpFixtureFactories\Factory\BaseFactory;
 use CakephpFixtureFactories\Test\Factory\AddressFactory;
 use CakephpFixtureFactories\Test\Factory\CityFactory;
 use CakephpFixtureFactories\Test\Factory\SmellyAddressFactory;
+use TestApp\Model\Table\CitiesTable;
 
 /**
  * Covers the BaseFactory FK-in-definition() detector that emits an
@@ -155,5 +157,40 @@ class BaseFactoryForeignKeyDetectionTest extends TestCase
 
         SmellyAddressFactory::new()->build();
         $this->assertCount(1, $this->capturedErrors);
+    }
+
+    /**
+     * A belongsTo declared with `'foreignKey' => false` (a custom-condition /
+     * non-FK join, e.g. joining on a uuid via `conditions`) has no foreign-key
+     * column. `Association::getForeignKey()` returns `false` there, and
+     * `(array)false === [false]`, so collectForeignKeyColumns() must skip it
+     * rather than register a bogus `0 => Alias` entry (PHP casts the `false`
+     * key to `0`). The map must only ever be keyed by real string column
+     * names — otherwise the detector and the auto-skip feature both consult a
+     * polluted map.
+     */
+    public function testForeignKeyFalseAssociationIsNotCollectedAsColumn(): void
+    {
+        $table = new Table(['table' => 'addresses', 'alias' => 'Addresses']);
+        $table->belongsTo('City', ['className' => CitiesTable::class]);
+        $table->belongsTo('GhostCity', [
+            'className' => CitiesTable::class,
+            'foreignKey' => false,
+            'conditions' => ['GhostCity.name = Addresses.street'],
+        ]);
+
+        BaseFactory::resetForeignKeyInDefinitionDetector();
+        $map = BaseFactory::collectForeignKeyColumns($table);
+
+        // Real FK still collected.
+        $this->assertArrayHasKey('city_id', $map);
+        $this->assertSame('City', $map['city_id']);
+
+        // No ghost entry from (array)false, and only string keys.
+        $this->assertArrayNotHasKey(0, $map);
+        $this->assertArrayNotHasKey('', $map);
+        foreach (array_keys($map) as $key) {
+            $this->assertIsString($key, 'collectForeignKeyColumns() must only key by string column names.');
+        }
     }
 }

--- a/tests/TestCase/Factory/BaseFactoryForeignKeyDetectionTest.php
+++ b/tests/TestCase/Factory/BaseFactoryForeignKeyDetectionTest.php
@@ -160,37 +160,74 @@ class BaseFactoryForeignKeyDetectionTest extends TestCase
     }
 
     /**
-     * A belongsTo declared with `'foreignKey' => false` (a custom-condition /
-     * non-FK join, e.g. joining on a uuid via `conditions`) has no foreign-key
-     * column. `Association::getForeignKey()` returns `false` there, and
-     * `(array)false === [false]`, so collectForeignKeyColumns() must skip it
-     * rather than register a bogus `0 => Alias` entry (PHP casts the `false`
-     * key to `0`). The map must only ever be keyed by real string column
-     * names — otherwise the detector and the auto-skip feature both consult a
-     * polluted map.
+     * A belongsTo declared with `'foreignKey' => false` joins via custom
+     * `conditions`. `Association::getForeignKey()` returns `false` there and
+     * `(array)false === [false]`, so the collector must never register a
+     * bogus `0 => Alias` entry. Instead it recovers the source-side join
+     * column from the conditions (the classic uuid join), keyed by the real
+     * string column name, so the detector still protects it.
      */
-    public function testForeignKeyFalseAssociationIsNotCollectedAsColumn(): void
+    public function testForeignKeyFalseAssociationRecoversJoinColumnFromConditions(): void
     {
         $table = new Table(['table' => 'addresses', 'alias' => 'Addresses']);
         $table->belongsTo('City', ['className' => CitiesTable::class]);
+        // string-expression form
         $table->belongsTo('GhostCity', [
             'className' => CitiesTable::class,
             'foreignKey' => false,
-            'conditions' => ['GhostCity.name = Addresses.street'],
+            'conditions' => ['Addresses.city_uuid = GhostCity.uuid'],
+        ]);
+        // key => value form
+        $table->belongsTo('KvCity', [
+            'className' => CitiesTable::class,
+            'foreignKey' => false,
+            'conditions' => ['Addresses.kv_uuid' => 'KvCity.uuid'],
         ]);
 
         BaseFactory::resetForeignKeyInDefinitionDetector();
         $map = BaseFactory::collectForeignKeyColumns($table);
 
-        // Real FK still collected.
-        $this->assertArrayHasKey('city_id', $map);
-        $this->assertSame('City', $map['city_id']);
+        // Normal FK still collected.
+        $this->assertSame('City', $map['city_id'] ?? null);
+        // Custom uuid-join columns now recovered from conditions.
+        $this->assertSame('GhostCity', $map['city_uuid'] ?? null);
+        $this->assertSame('KvCity', $map['kv_uuid'] ?? null);
 
-        // No ghost entry from (array)false, and only string keys.
+        // No ghost entry from (array)false; only string keys.
         $this->assertArrayNotHasKey(0, $map);
         $this->assertArrayNotHasKey('', $map);
         foreach (array_keys($map) as $key) {
             $this->assertIsString($key, 'collectForeignKeyColumns() must only key by string column names.');
         }
+    }
+
+    /**
+     * A pure filter condition on a foreignKey=>false association (no target
+     * alias referenced) must NOT be mistaken for a join column, and an opaque
+     * Closure condition yields nothing — both guard against false positives.
+     */
+    public function testForeignKeyFalseFilterAndClosureConditionsAreNotJoinColumns(): void
+    {
+        $table = new Table(['table' => 'addresses', 'alias' => 'Addresses']);
+        $table->belongsTo('FilteredCity', [
+            'className' => CitiesTable::class,
+            'foreignKey' => false,
+            'conditions' => ['Addresses.status' => 1, 'Addresses.deleted = 0'],
+        ]);
+        $table->belongsTo('ClosureCity', [
+            'className' => CitiesTable::class,
+            'foreignKey' => false,
+            'conditions' => function ($exp) {
+                return $exp;
+            },
+        ]);
+
+        BaseFactory::resetForeignKeyInDefinitionDetector();
+        $map = BaseFactory::collectForeignKeyColumns($table);
+
+        $this->assertArrayNotHasKey('status', $map);
+        $this->assertArrayNotHasKey('deleted', $map);
+        $this->assertArrayNotHasKey(0, $map);
+        $this->assertSame([], $map, 'Filter-only and Closure conditions must contribute no columns.');
     }
 }


### PR DESCRIPTION
## Problem

A `belongsTo` declared with `'foreignKey' => false` joins via custom
`conditions` (the classic legacy uuid join,
`['Child.parent_uuid = Parent.uuid']`). The FK-in-`definition()` detector
and the `autoSkipComposeOnExplicitForeignKey` feature both consult
`collectForeignKeyColumns()`, which only ever looked at
`Association::getForeignKey()`. For these associations that returns
`false`, so:

1. `(array)false === [false]` and the `=== ''` guard let it through — PHP
   cast the key to `0`, leaving a junk `0 => Alias` entry in the cached map.
2. The real de-facto join column (e.g. `parent_uuid`) lived only inside
   `conditions` and was **completely invisible** to the detector — a
   structural blind spot, so a factory `definition()` returning that column
   was never flagged.

## Fix

`collectForeignKeyColumns()` now:

- Skips non-string / `false` declared foreign keys (no more ghost `0`
  entry).
- When an association has **no** declared scalar FK, recovers the
  source-side join column(s) from its `conditions` via a new conservative
  helper `joinColumnsFromConditions()`.

The extraction is deliberately conservative to avoid false positives:

- Handles both `['Src.col = Tgt.col']` (string expression, operator-
  agnostic) and `['Src.col' => 'Tgt.col']` (key/value) forms.
- A condition only counts as a join if it references **both** the source
  alias and the target alias. A pure filter (`['Src.status' => 1]`,
  `['Src.deleted = 0']`) has no target reference and is ignored.
- `Closure` conditions are opaque → contribute nothing (no guessing).

## Tests

`BaseFactoryForeignKeyDetectionTest` gains:

- `testForeignKeyFalseAssociationRecoversJoinColumnFromConditions` —
  string-expression and key/value uuid joins are recovered, keyed by the
  real string column, normal FK still collected, no `0`/`''` key.
- `testForeignKeyFalseFilterAndClosureConditionsAreNotJoinColumns` —
  filter-only and Closure conditions contribute nothing.

Full suite green (sqlite, 685 tests), CS and PHPStan clean.