### PR TITLE
Add BaseFactory::withRequiredParents() — ergonomic counterpart to strictDefinition

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -59,6 +59,7 @@ export default defineConfig({
             { text: 'Associations', link: '/guide/associations' },
             { text: 'Associations (standalone cakephp/orm)', link: '/guide/non-cakephp-associations' },
             { text: 'Foreign keys in definition()', link: '/guide/foreign-keys-in-definition' },
+            { text: 'Required parents', link: '/guide/required-parents' },
             { text: 'Scenarios', link: '/guide/scenarios' },
             { text: 'Best Practices', link: '/guide/best-practices' },
           ],

--- a/docs/guide/foreign-keys-in-definition.md
+++ b/docs/guide/foreign-keys-in-definition.md
@@ -160,3 +160,18 @@ Configure::write('FixtureFactories.strictDefinition', false);
 ```
 
 The opt-out silences the detector entirely. It is transitional — the next major release removes the flag and promotes the deprecation to an exception. Plan the migration before then; the detector's report tells you exactly which factories and columns to touch.
+
+### Per-factory exception for non-managed join columns
+
+`strictDefinition` exists to stop a dangling *managed* foreign-key id from masking a real composed parent. A `foreignKey => false` custom-condition belongsTo (for example a uuid-condition join, `Child.parent_uuid = Parents.uuid`) has a column CakePHP never manages — there is no managed pointer to dangle, so a generated value there is not that anti-pattern, yet the detector still recognises it as a join column.
+
+For those columns only, a factory can declare the column intentional instead of switching the detector off globally:
+
+```php
+protected function allowedForeignKeysInDefinition(): array
+{
+    return ['parent_uuid'];
+}
+```
+
+The detector skips listed columns for that factory while staying fully active for every other factory and for every genuinely managed FK. Reserve it for non-managed condition-join columns — listing a managed FK column there defeats the check.

--- a/docs/guide/foreign-keys-in-definition.md
+++ b/docs/guide/foreign-keys-in-definition.md
@@ -127,6 +127,29 @@ An explicit `->with('Author', ...)` still always composes — that is an
 unambiguous request for a parent and wins over the auto-skip. Turn the flag
 off only if a suite relied on the old override behavior.
 
+## The ergonomic counterpart: `withRequiredParents()`
+
+Steering FK population out of `definition()` is correct, but on its own it
+leaves a cliff: a factory whose root table has NOT NULL belongsTo FKs now
+needs explicit `->with('Alias')` / `->for(...)` boilerplate just to persist
+one row.
+
+[`withRequiredParents()`](/guide/required-parents) closes that cliff. One call
+composes every belongsTo whose single scalar FK column is NOT NULL,
+recursively down the chain:
+
+```php
+$author = AuthorFactory::new()->withRequiredParents()->save();
+// address_id → city_id → country_id all satisfied, no boilerplate.
+```
+
+It is the pragmatic default for *"I just need a persistable row"*. When a test
+asserts on a specific parent, keep attaching it explicitly with
+`->with('Alias', $entity)` so the intent stays visible. Composite-key and
+`foreignKey => false` associations are never guessed — see the
+[Required parents guide](/guide/required-parents) for the override hook and the
+shared-ancestor recycle default.
+
 ## Opt-out while migrating
 
 If a downstream suite has many offenders and can't migrate in one pass:

--- a/docs/guide/required-parents.md
+++ b/docs/guide/required-parents.md
@@ -84,12 +84,36 @@ AuthorFactory::new()->count(50)
 ```
 
 Without `recycle()`, each produced row gets its own full required chain, which
-is the correct default for independent fixtures.
+is the correct default for independent fixtures. Note the cost is the *whole
+transitive chain* per row: `->count(50)` on a root three levels deep inserts
+50 × every level, not 50 rows. `recycle()` the shared table(s) when that matters
+— a recycled entity is substituted at every depth of the chain by table name,
+for the whole batch.
 
 Two **distinct-alias** belongsTo that happen to target the same table (e.g.
 `Address` and `BusinessAddress`, both → `addresses`) each get their own parent
 — that is per-alias intent, preserved on purpose. Use `->with('Alias', $entity)`
 when you want two aliases to point at the *same* parent.
+
+### Diamond required graphs
+
+When two *different* required parents of the root each require the same
+grandparent table — root → `B` and root → `C`, with both `B` → `D` and
+`C` → `D` all `NOT NULL` — the two branches are composed independently, so a
+single root produces **two `D` rows**. This is consistent with the
+independent-fixtures default above, not a bug: nothing is persisted at
+composition time, so there is no shared row to reuse. When the diamond should
+collapse to one shared grandparent, `recycle()` it — the same table-keyed
+substitution applies, so both branches reuse it:
+
+```php
+$d = DFactory::new()->save();
+
+RootFactory::new()
+    ->withRequiredParents()
+    ->recycle($d) // both B's and C's required D resolve to this one row
+    ->save();
+```
 
 ## Shared-primary-key and cyclic graphs
 

--- a/docs/guide/required-parents.md
+++ b/docs/guide/required-parents.md
@@ -143,6 +143,73 @@ $author = AuthorFactory::new(['address_id' => $address->id])
 // $author->address_id === $address->id; no throw-away Address built.
 ```
 
+## `maxDepth`: cap the recursion depth
+
+By default `withRequiredParents()` recurses the *whole* NOT NULL chain. Pass
+`maxDepth` to compose only the first N levels below the root:
+
+```php
+// Only the root's direct required parents — not their parents.
+AuthorFactory::new()->withRequiredParents(maxDepth: 1)->build();
+
+// Root's parents and their parents, but not the third level.
+AuthorFactory::new()->withRequiredParents(maxDepth: 2)->build();
+
+// Explicit null is the unbounded default (same as no argument).
+AuthorFactory::new()->withRequiredParents(maxDepth: null)->build();
+```
+
+`$except` and `maxDepth` are independent — pass both as named arguments:
+`->withRequiredParents(['BusinessAddress'], maxDepth: 2)`.
+
+`maxDepth` caps the *auto-recursion* this method performs. It does **not**
+suppress a composed parent factory's own `configure()` / `for()` defaults —
+those are the factory author's deliberate choice and always apply. So a depth
+cap is fully effective for the bare factories `withRequiredParents()` targets
+(no FKs in `definition()`/`configure()`, the `strictDefinition` model); if a
+parent factory self-composes a chain via `configure()`, that chain is still
+built regardless of `maxDepth`.
+
+::: warning A cap below the real required depth produces an un-persistable row
+This is by design — the exact same contract as `$except`. If `maxDepth`
+stops before a deeper `NOT NULL` FK is satisfied, `->build()` still returns an
+in-memory entity, but `->save()` fails with a `NOT NULL` violation. Use
+`maxDepth` only when you know the deeper levels are nullable, pinned, or
+recycled; otherwise omit it and let the full chain compose.
+
+This also applies to the [required-parent cycle fast-fail](#shared-primary-key-and-cyclic-graphs):
+a cycle *beyond* the cap is never reached, so it degrades from the actionable
+`FixtureFactoryException` to a generic save-time `NOT NULL` error. A cycle
+*within* the cap still throws as usual.
+:::
+
+### `strict`: turn the silent shortfall into a clear error
+
+Opt in with `strict: true` when you want a capped chain that is *too shallow*
+to fail loudly at the call site instead of silently producing an
+un-persistable row:
+
+```php
+// Throws FixtureFactoryException: maxDepth:1 leaves Address's required
+// City unsatisfied.
+AuthorFactory::new()->withRequiredParents(maxDepth: 1, strict: true);
+
+// No throw — the cap covers the whole required chain.
+AuthorFactory::new()->withRequiredParents(maxDepth: 9, strict: true)->save();
+```
+
+`strict` only fires when `maxDepth` actually truncates a *needed* parent: a
+boundary parent that still has its own required belongsTo not already composed
+(`configure()` / `->with()` / `->for()`), pinned, or excepted. It is a no-op
+without `maxDepth` (a full chain is never truncated), and it also restores an
+actionable message for a [cycle beyond the cap](#shared-primary-key-and-cyclic-graphs)
+instead of the generic save-time error. Default is `strict: false` — the
+silent contract above.
+
+`maxDepth` must be a positive integer or `null`. `0` or a negative value
+throws an `InvalidArgumentException` at call time — "compose zero required
+parents" is just not calling `withRequiredParents()`.
+
 ## Composes cleanly with the rest of the layer
 
 - An alias already composed as a **factory** —

--- a/docs/guide/required-parents.md
+++ b/docs/guide/required-parents.md
@@ -1,0 +1,182 @@
+---
+title: Required parents
+description: One call composes every NOT NULL belongsTo parent — the ergonomic counterpart to the FK-in-definition() detector
+---
+
+# Required parents
+
+`withRequiredParents()` composes every belongsTo parent the root table
+*requires* — recursively down the chain — so a row built by the factory
+satisfies its NOT NULL foreign-key constraints with no hand-written
+`->with('Alias')` boilerplate.
+
+```php
+// Authors.address_id is NOT NULL (belongsTo Address);
+// Addresses.city_id is NOT NULL (belongsTo City);
+// Cities.country_id is NOT NULL (belongsTo Country).
+$author = AuthorFactory::new()->withRequiredParents()->save();
+// $author->address_id points at a real Address → real City → real Country.
+```
+
+## Why this exists
+
+This is the ergonomic counterpart to the
+[FK-in-`definition()` detector](/guide/foreign-keys-in-definition)
+(`FixtureFactories.strictDefinition`). That detector pushes foreign-key
+population *out* of `definition()` and into association composition — correct,
+but without a counterpart it leaves a cliff: every factory whose root table
+has NOT NULL belongsTo FKs then needs explicit `->with('Alias')` /
+`->for(...)` boilerplate just to persist a single row.
+
+`withRequiredParents()` is that counterpart. The detector says *"don't put the
+FK in `definition()`"*; this says *"and here's the one call that builds the
+required parents for you."*
+
+## What counts as "required"
+
+Auto-resolved:
+
+- a belongsTo whose foreign key is a **single scalar column** that is
+  **`NOT NULL`** in the table schema.
+
+Never auto-resolved:
+
+- a **nullable** FK — the row persists fine without it; silently fabricating
+  an optional parent hides intent.
+- a **composite-key** belongsTo.
+- a belongsTo declared **`'foreignKey' => false`** (custom-condition /
+  non-FK join, e.g. the classic uuid join).
+
+The last two are exactly the brittle edge cases that
+[PR #85](https://github.com/dereuromark/cakephp-fixture-factories/pull/85) hit:
+guessing how to build them is unsafe, so automatic detection refuses. Opt them
+in explicitly (see [Override hook](#override-hook)) — never guessed.
+
+## Side-effect free, atomic
+
+`withRequiredParents()` is a composition method like every other `with*()` /
+`for*()` call: it only wires parent factories onto the build graph. **Nothing
+is written to the database until the root factory is persisted.** The required
+parents are created in the same unit as the root entity, so:
+
+- `->build()` stays purely in-memory — no rows are inserted.
+- A failed root save does not leave orphaned parent rows behind.
+- Chaining order is forgiving: a `->with('Alias', $x)` placed *after*
+  `withRequiredParents()` still wins, and no stray parent for that alias is
+  written.
+
+## Sharing a parent across a batch
+
+Because the method never persists anything itself, it cannot reuse a
+pre-existing row. To make a counted batch — or several factories — share one
+parent, build it yourself and hand it to
+[`recycle()`](/guide/associations), the established pattern, which composes
+cleanly with `withRequiredParents()`:
+
+```php
+$country = CountryFactory::new()->save();
+
+AuthorFactory::new()->count(50)
+    ->withRequiredParents()
+    ->recycle($country) // every author's whole chain reuses this one Country
+    ->saveMany();
+// 50 authors, 50 addresses, 50 cities — but exactly one country.
+```
+
+Without `recycle()`, each produced row gets its own full required chain, which
+is the correct default for independent fixtures.
+
+Two **distinct-alias** belongsTo that happen to target the same table (e.g.
+`Address` and `BusinessAddress`, both → `addresses`) each get their own parent
+— that is per-alias intent, preserved on purpose. Use `->with('Alias', $entity)`
+when you want two aliases to point at the *same* parent.
+
+## Shared-primary-key and cyclic graphs
+
+Shared-primary-key 1:1 associations (the FK column *is* the table's primary
+key, `child.id` → `parent.id`) are treated as ordinary required parents and
+auto-composed.
+
+A cycle of **required** (NOT NULL) belongsTo FKs — a self-referential parent,
+or `A -> B -> A` — is mathematically unsatisfiable: no row in the cycle can be
+inserted without a parent row that itself needs one. `withRequiredParents()`
+detects this and throws a `FixtureFactoryException` with an actionable message
+rather than silently producing a factory that dies on a confusing NOT NULL
+violation at save time. Break the cycle yourself: pin the cyclic FK at the
+call site and exclude the alias via `$except`
+(`->withRequiredParents(['CyclicAlias'])`), or exclude it through the
+`requiredParentAssociations()` override hook.
+
+## `$except`: pin one FK literally
+
+Skip a named association when the test pins that FK at the call site for a
+column-scope assertion:
+
+```php
+$author = AuthorFactory::new(['address_id' => $address->id])
+    ->withRequiredParents(['Address'])
+    ->save();
+// $author->address_id === $address->id; no throw-away Address built.
+```
+
+## Composes cleanly with the rest of the layer
+
+- An alias already composed as a **factory** —
+  `->with('Alias', SomeFactory::new())`, `->for(...)`, or a `configure()`
+  default — is **kept** (your parent is never replaced) and **recursively
+  enriched**, so that parent's *own* required grandchildren are satisfied too.
+  This means `->with('Address', AddressFactory::new())->withRequiredParents()`
+  still persists: the `Address` you supplied gets its required `City` → `Country`.
+- An alias composed from a **concrete entity** —
+  `->with('Alias', $savedEntity)` — is left completely untouched: you
+  specified that exact row.
+- A FK pinned at the call site (`Factory::new(['fk' => x])`, `->state()`,
+  `->setField()`, `->patchData()`, `->sequenceField()`, or `->sequence()` when
+  every row sets it non-null) is detected: the alias is treated as already
+  satisfied, so it composes cleanly with
+  [`autoSkipComposeOnExplicitForeignKey`](/reference/configuration#autoskipcomposeonexplicitforeignkey)
+  and never double-composes.
+
+## Override hook
+
+Return a non-null list from `requiredParentAssociations()` to take explicit
+control. The list is **authoritative**: only listed aliases are composed,
+automatic detection is bypassed entirely, and the factory author owns
+correctness for the listed associations. This is the supported, non-guessing
+way to include a composite-key or `foreignKey => false` belongsTo that
+automatic detection refuses to build:
+
+```php
+class BillFactory extends BaseFactory
+{
+    /**
+     * @return array<int, string>|null
+     */
+    protected function requiredParentAssociations(): ?array
+    {
+        // Build these exactly — including a custom-join one automatic
+        // detection would never touch.
+        return ['Customer', 'Article', 'LegacyUuidParent'];
+    }
+}
+```
+
+Return `null` (the default) to use automatic NOT NULL single-scalar-FK
+detection.
+
+## It's the pragmatic default — not the assertion tool
+
+`withRequiredParents()` is for *"I just need a persistable row and don't care
+which parents"*. When a test **asserts** on a specific parent, still attach it
+explicitly so the assertion's intent is visible:
+
+```php
+$city = CityFactory::new()->save();
+$author = AuthorFactory::new()
+    ->with('Address', AddressFactory::new()->with('City', $city))
+    ->save();
+$this->assertSame($city->id, $author->address->city_id); // intent is visible
+```
+
+Mixing both is fine: an explicit `->with()` for the asserted branch, plus
+`->withRequiredParents()` for everything else the row needs to persist.

--- a/docs/guide/required-parents.md
+++ b/docs/guide/required-parents.md
@@ -163,30 +163,28 @@ $author = AuthorFactory::new(['address_id' => $address->id])
 
 ## Override hook
 
-Return a non-null list from `requiredParentAssociations()` to take explicit
-control. The list is **authoritative**: only listed aliases are composed,
-automatic detection is bypassed entirely, and the factory author owns
-correctness for the listed associations. This is the supported, non-guessing
-way to include a composite-key or `foreignKey => false` belongsTo that
-automatic detection refuses to build:
+Return extra aliases from `requiredParentAssociations()` to union them onto
+the automatically detected set. This is the supported, non-guessing way to
+include a composite-key or `foreignKey => false` belongsTo that automatic
+detection refuses to build:
 
 ```php
 class BillFactory extends BaseFactory
 {
     /**
-     * @return array<int, string>|null
+     * @return array<int, string>
      */
-    protected function requiredParentAssociations(): ?array
+    protected function requiredParentAssociations(): array
     {
-        // Build these exactly — including a custom-join one automatic
-        // detection would never touch.
-        return ['Customer', 'Article', 'LegacyUuidParent'];
+        // Add this custom-join one on top of the ordinary auto-detected
+        // required parents.
+        return ['LegacyUuidParent'];
     }
 }
 ```
 
-Return `null` (the default) to use automatic NOT NULL single-scalar-FK
-detection.
+Return an empty array (the default) to use only automatic NOT NULL
+single-scalar-FK detection.
 
 ## It's the pragmatic default — not the assertion tool
 

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -1673,13 +1673,50 @@ abstract class BaseFactory
      * Note: a root table with an unsatisfiable required (NOT NULL) belongsTo
      * cycle raises a `FixtureFactoryException` — see the cycle handling below.
      *
+     * Depth: by default the whole NOT NULL chain is recursed. Pass `$maxDepth`
+     * to compose only the first N levels below the root (`1` = direct parents
+     * only). A cap below the real required depth yields an un-persistable row
+     * — the caller's responsibility, exactly like `$except`. This includes the
+     * cycle fast-fail: a required-parent cycle *beyond* the cap is not reached,
+     * so it surfaces as a save-time NOT NULL error rather than the
+     * `FixtureFactoryException`. A cycle *within* the cap still throws. Opt into
+     * `$strict` to turn that silent shortfall into an actionable exception at
+     * call time (it also restores an actionable message for a capped cycle).
+     *
      * @param array<int, string> $except Association aliases to skip.
+     * @param int|null $maxDepth Cap how many *levels* of required parents are
+     *   composed below the root. `null` (default) recurses the whole NOT NULL
+     *   chain. `1` composes only the root's direct required parents, `2` those
+     *   plus their parents, and so on. A cap below the real required depth can
+     *   produce an un-persistable row (a deeper NOT NULL FK left unsatisfied) —
+     *   by design, the caller's responsibility, exactly like `$except`.
+     * @param bool $strict When `true` and `$maxDepth` truncates the chain so a
+     *   composed boundary parent still has its own unsatisfied required
+     *   belongsTo, fail loudly at call time with an actionable
+     *   `FixtureFactoryException` instead of silently producing an
+     *   un-persistable row. Default `false` keeps the silent contract. A no-op
+     *   without `$maxDepth` (a full chain is never truncated).
+     *
+     * @throws \InvalidArgumentException When `$maxDepth` is provided but not at
+     *   least 1 — "compose zero required parents" is just not calling this.
+     *   `$strict` is set and `$maxDepth` leaves a required parent unsatisfied.
      *
      * @return static
      */
-    public function withRequiredParents(array $except = []): static
-    {
-        return $this->doWithRequiredParents($except, []);
+    public function withRequiredParents(
+        array $except = [],
+        ?int $maxDepth = null,
+        bool $strict = false,
+    ): static {
+        if ($maxDepth !== null && $maxDepth < 1) {
+            throw new InvalidArgumentException(sprintf(
+                'withRequiredParents() $maxDepth must be a positive integer or null, got %d. '
+                . 'To compose no required parents, simply do not call withRequiredParents().',
+                $maxDepth,
+            ));
+        }
+
+        return $this->doWithRequiredParents($except, [], $maxDepth, 0, $strict);
     }
 
     /**
@@ -1689,14 +1726,25 @@ abstract class BaseFactory
      *   unsatisfiable required-parent cycle (self-referential or
      *   `A -> B -> A` NOT NULL graphs) and fail fast with an actionable
      *   exception instead of recursing until the stack overflows.
+     * @param int|null $maxDepth Remaining recursion budget (see
+     *   {@see self::withRequiredParents()}); `null` is unbounded.
+     * @param int $depth Current level below the root (0 = root).
+     * @param bool $strict Throw when `$maxDepth` truncates the chain leaving a
+     *   composed boundary parent with its own unsatisfied required belongsTo.
      *
      * @throws \CakephpFixtureFactories\Error\FixtureFactoryException When a
-     *   required (NOT NULL) belongsTo cycle is detected.
+     *   required (NOT NULL) belongsTo cycle is detected, or when `$strict` and
+     *   the depth cap leaves a required parent unsatisfied.
      *
      * @return static
      */
-    private function doWithRequiredParents(array $except, array $visitedTables): static
-    {
+    private function doWithRequiredParents(
+        array $except,
+        array $visitedTables,
+        ?int $maxDepth,
+        int $depth,
+        bool $strict,
+    ): static {
         if ($this->readBootstrapMode) {
             return clone $this;
         }
@@ -1764,7 +1812,49 @@ abstract class BaseFactory
             // first level. `$except` is intentionally root-scoped: a deeper
             // level's required parents are always needed for that row to
             // persist regardless of what the caller pinned.
-            $parentFactory = $parentFactory->doWithRequiredParents([], $visitedTables);
+            //
+            // `maxDepth` caps how deep that recursion goes: the parent itself
+            // (at $depth + 1) is still composed below, but it is only enriched
+            // with ITS own required parents while that next level stays within
+            // the cap. Reaching the cap with a deeper NOT NULL FK unsatisfied
+            // is the caller's responsibility — same contract as `$except`.
+            if ($maxDepth === null || $depth + 1 < $maxDepth) {
+                $parentFactory = $parentFactory->doWithRequiredParents(
+                    [],
+                    $visitedTables,
+                    $maxDepth,
+                    $depth + 1,
+                    $strict,
+                );
+            } elseif ($strict) {
+                // The cap stops us recursing into $parentFactory. If that
+                // boundary parent still has a required belongsTo that is NOT
+                // already composed on it (configure()/with()/for()) and NOT
+                // pinned/excepted, the composed row cannot persist. Note a
+                // later recycle() cannot rescue it: recycle only substitutes
+                // *composed* branches, and the cap stopped that branch from
+                // being composed. Opt-in strictness turns that silent
+                // shortfall — and a capped cycle — into an actionable failure
+                // at call time.
+                $composedOnParent = $parentFactory->getAssociationBuilder()->getAssociations();
+                foreach ($parentFactory->resolveRequiredParentAliases([]) as $unmetAlias) {
+                    if (isset($composedOnParent[$unmetAlias])) {
+                        continue;
+                    }
+
+                    throw new FixtureFactoryException(sprintf(
+                        'withRequiredParents(maxDepth: %d, strict: true): the depth cap leaves the '
+                        . 'required belongsTo "%s" on table "%s" (reached via "%s") unsatisfied, so '
+                        . 'the composed row cannot persist. Raise maxDepth, pin or recycle that FK, '
+                        . 'add "%s" to $except, or drop strict to accept the silent contract.',
+                        $maxDepth,
+                        $unmetAlias,
+                        $parentFactory->getTable()->getTable(),
+                        $alias,
+                        $alias,
+                    ));
+                }
+            }
 
             // Compose the parent *factory* only — no persistence here. The
             // parent is built and saved as part of the root factory's own

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -1785,8 +1785,8 @@ abstract class BaseFactory
      *
      * - aliases listed in `$except`,
      * - aliases whose FK the caller pinned (non-null) at the call site,
-     * - aliases excluded by the {@see self::requiredParentAssociations()}
-     *   override hook.
+     * - aliases added explicitly by the {@see self::requiredParentAssociations()}
+     *   hook.
      *
      * An alias already composed via `->with()` / `->for()` / `configure()` is
      * still returned: the caller's factory is recursively enriched (or, if it
@@ -1805,7 +1805,7 @@ abstract class BaseFactory
         $table = $this->getTable();
         $schema = $table->getSchema();
 
-        $override = $this->requiredParentAssociations();
+        $additional = $this->requiredParentAssociations();
         // Caller-pinned FK columns (Factory::new(['fk' => x]), ->state(),
         // ->setField(), ->patchData(), sequence*()), resolvable at chain time.
         // A *non-null* pinned FK means the parent is already satisfied, so the
@@ -1870,17 +1870,6 @@ abstract class BaseFactory
                 }
             }
 
-            if ($override !== null) {
-                // Explicit opt-in list: the caller takes full responsibility
-                // for which aliases (including composite / custom-join ones)
-                // are buildable, so honour it verbatim.
-                if (in_array($alias, $override, true)) {
-                    $aliases[] = $alias;
-                }
-
-                continue;
-            }
-
             $foreignKeys = (array)$association->getForeignKey();
             // Composite key, or `foreignKey => false` (custom-condition join):
             // never auto-resolved — see PR #85. Opt in via the override hook.
@@ -1905,28 +1894,35 @@ abstract class BaseFactory
             $aliases[] = $alias;
         }
 
+        foreach ($additional as $alias) {
+            if (in_array($alias, $except, true)) {
+                continue;
+            }
+            if (!in_array($alias, $aliases, true)) {
+                $aliases[] = $alias;
+            }
+        }
+
         return $aliases;
     }
 
     /**
-     * Override hook to take explicit control over which belongsTo aliases
-     * {@see self::withRequiredParents()} composes.
+     * Add extra belongsTo aliases to the automatic required-parent set used by
+     * {@see self::withRequiredParents()}.
      *
-     * Return `null` (the default) to use automatic NOT NULL single-scalar-FK
-     * detection. Return an array of aliases to opt in *exactly* those — this
-     * is the supported, non-guessing way to include a composite-key or
+     * Automatic detection always includes the root table's belongsTo
+     * associations whose foreign key is a single scalar NOT NULL column in the
+     * schema. Return additional aliases here to opt in edge cases that
+     * automatic detection deliberately refuses to guess, such as a composite-key or
      * `foreignKey => false` custom-join belongsTo, which automatic detection
-     * deliberately refuses to build (the PR #85 brittle cases).
+     * deliberately refuses to build (the PR #85 brittle cases). Returned
+     * aliases are unioned onto the automatically detected set.
      *
-     * When a non-null list is returned it is authoritative: only listed
-     * aliases are composed, automatic detection is bypassed entirely, and the
-     * factory author owns correctness for the listed associations.
-     *
-     * @return array<int, string>|null Aliases to compose, or null for auto.
+     * @return array<int, string> Additional aliases to compose.
      */
-    protected function requiredParentAssociations(): ?array
+    protected function requiredParentAssociations(): array
     {
-        return null;
+        return [];
     }
 
     /**

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -1594,6 +1594,331 @@ abstract class BaseFactory
     }
 
     /**
+     * Compose every belongsTo parent the root table *requires* — i.e. each
+     * belongsTo whose single scalar foreign-key column is `NOT NULL` in the
+     * schema — recursively down the chain, so a row built by this factory
+     * satisfies its NOT NULL FK constraints out of the box.
+     *
+     * This is the ergonomic counterpart to the FK-in-`definition()` detector
+     * (`FixtureFactories.strictDefinition`, see
+     * {@link https://dereuromark.github.io/cakephp-fixture-factories/guide/foreign-keys-in-definition Foreign keys in definition()}).
+     * `strictDefinition` pushes FK population *out* of `definition()`; without
+     * a counterpart, every factory for a table with NOT NULL belongsTo FKs then
+     * needs hand-written `->with('Alias')` boilerplate just to persist.
+     * `withRequiredParents()` is that counterpart: one call composes the whole
+     * required chain.
+     *
+     * What counts as "required" — and what does NOT:
+     *
+     * - A belongsTo whose foreign key is a *single scalar column* that is
+     *   `NOT NULL` in the table schema is auto-resolved.
+     * - A belongsTo with a *composite* foreign key, or one declared
+     *   `'foreignKey' => false` (custom-condition / non-FK join), is **never**
+     *   auto-resolved. These are exactly the brittle edge cases that PR #85 hit
+     *   — guessing how to build them is unsafe. Opt them in explicitly by
+     *   overriding {@see self::requiredParentAssociations()}.
+     * - A nullable FK is not composed: the row persists fine without it, and
+     *   silently fabricating an optional parent hides intent.
+     *
+     * Side-effect free: like every other `with*()` / `for*()` chain method,
+     * this only *composes* parent factories. Nothing is written to the
+     * database until the root factory is persisted (`->save()` /
+     * `->persist()` / `->saveMany()`), so the parents are created in the same
+     * unit as the root entity — atomic, no orphan rows on a later override or
+     * a failed root save, and `->build()` stays purely in-memory.
+     *
+     * Composes cleanly with the rest of the composition layer:
+     *
+     * - An alias already composed via `->with('Alias', SomeFactory::new())`
+     *   or a `configure()` default is kept (the caller's parent is not
+     *   replaced) but is itself recursively enriched, so the parent's *own*
+     *   required grandchildren are satisfied too. A parent composed from a
+     *   concrete entity (`->with('Alias', $entity)`) is left fully untouched —
+     *   the caller specified that row exactly.
+     * - An alias listed in `$except` is skipped (pin its FK literally at the
+     *   call site for a column-scope assertion).
+     * - Behaves correctly alongside `autoSkipComposeOnExplicitForeignKey`: an
+     *   alias whose FK the caller already pinned (with a non-null value) is
+     *   not double-composed.
+     *
+     * Sharing a parent (dedup): `withRequiredParents()` deliberately does NOT
+     * persist anything itself, so it cannot reuse a pre-existing row. When you
+     * want a counted batch — or several factories — to share one parent, build
+     * it yourself and hand it to {@see self::recycle()} (the established
+     * pattern), which composes cleanly with this method:
+     *
+     * ```php
+     * $country = CountryFactory::new()->save();
+     * AuthorFactory::new()->count(50)
+     *     ->withRequiredParents()
+     *     ->recycle($country) // every row's chain reuses this one Country
+     *     ->saveMany();
+     * ```
+     *
+     * This is the *pragmatic default* for "I just need a persistable row".
+     * When a test asserts on a specific parent, still attach it explicitly
+     * with `->with('Alias', $entity)` so the assertion's intent is visible.
+     *
+     * Note: a root table with an unsatisfiable required (NOT NULL) belongsTo
+     * cycle raises a `FixtureFactoryException` — see the cycle handling below.
+     *
+     * @param array<int, string> $except Association aliases to skip.
+     *
+     * @return static
+     */
+    public function withRequiredParents(array $except = []): static
+    {
+        return $this->doWithRequiredParents($except, []);
+    }
+
+    /**
+     * @param array<int, string> $except Root-scoped association aliases to skip.
+     * @param array<int, string> $visitedTables Target table registry names
+     *   already on the current recursion chain — used to detect an
+     *   unsatisfiable required-parent cycle (self-referential or
+     *   `A -> B -> A` NOT NULL graphs) and fail fast with an actionable
+     *   exception instead of recursing until the stack overflows.
+     *
+     * @throws \CakephpFixtureFactories\Error\FixtureFactoryException When a
+     *   required (NOT NULL) belongsTo cycle is detected.
+     *
+     * @return static
+     */
+    private function doWithRequiredParents(array $except, array $visitedTables): static
+    {
+        if ($this->readBootstrapMode) {
+            return clone $this;
+        }
+
+        $factory = clone $this;
+        // Identify tables by their physical DB table name. A factory's own
+        // registry alias carries an internal `__ff_<hash>` suffix and a
+        // belongsTo target's registry alias is the *association* alias, so
+        // only getTable() is a stable cross-level identity for cycle checks.
+        $ownTable = $factory->getTable()->getTable();
+        $visitedTables[] = $ownTable;
+
+        $aliases = $factory->resolveRequiredParentAliases($except);
+        if ($aliases === []) {
+            return $factory;
+        }
+
+        foreach ($aliases as $alias) {
+            $association = $factory->getAssociationBuilder()->getAssociation($alias);
+            $targetTable = $association->getTarget()->getTable();
+
+            // If the caller already composed this alias with a *factory*
+            // (explicitly or via configure() defaults), enrich THAT factory
+            // rather than skipping it — otherwise its own required parents
+            // (the grandchildren) stay unsatisfied and the save still fails.
+            // A parent instantiated from a concrete entity is left untouched:
+            // the caller fully specified that row (and, importantly, it
+            // terminates an otherwise self-referential / cyclic chain).
+            $composed = $factory->getAssociationBuilder()->getAssociations();
+            $existing = $composed[$alias] ?? null;
+            if ($existing instanceof BaseFactory) {
+                if ($existing->isInstantiatedFromEntity()) {
+                    continue;
+                }
+                $parentFactory = $existing;
+            } else {
+                $parentFactory = $factory->getAssociationBuilder()->getAssociatedFactory($alias);
+            }
+
+            // Only now — for an alias we would actually recurse into — reject
+            // an unsatisfiable required (NOT NULL) belongsTo cycle
+            // (self-referential, or A -> B -> A). The check runs *after* the
+            // explicit-parent handling above so a caller who already broke the
+            // cycle with `->with('Alias', $entity)` is honored, not rejected.
+            // A real cycle cannot be auto-resolved: no row in it can be
+            // inserted without a parent row that itself needs one, so fail
+            // loudly here instead of with a confusing NOT NULL at save time.
+            if (in_array($targetTable, $visitedTables, true)) {
+                throw new FixtureFactoryException(sprintf(
+                    'withRequiredParents() found a required (NOT NULL) belongsTo cycle through the "%s" '
+                    . 'association (table "%s" is already on the chain: %s). Such a cycle cannot be '
+                    . 'auto-resolved. Break it manually: compose a terminating parent explicitly with '
+                    . '->with(\'%s\', $entity), pin the FK and pass the alias in $except '
+                    . '(e.g. ->withRequiredParents([\'%s\'])), or exclude it via the '
+                    . 'requiredParentAssociations() override hook.',
+                    $alias,
+                    $targetTable,
+                    implode(' -> ', $visitedTables),
+                    $alias,
+                    $alias,
+                ));
+            }
+
+            // Recurse so the whole NOT NULL chain is satisfied, not just the
+            // first level. `$except` is intentionally root-scoped: a deeper
+            // level's required parents are always needed for that row to
+            // persist regardless of what the caller pinned.
+            $parentFactory = $parentFactory->doWithRequiredParents([], $visitedTables);
+
+            // Compose the parent *factory* only — no persistence here. The
+            // parent is built and saved as part of the root factory's own
+            // persist unit, so this stays side-effect free and atomic, and a
+            // caller's recycle() still dedups the chain across a batch.
+            $factory = $factory->with($alias, $parentFactory);
+        }
+
+        return $factory;
+    }
+
+    /**
+     * Resolve which belongsTo aliases of the root table are *required* parents
+     * for {@see self::withRequiredParents()}.
+     *
+     * By default this is every belongsTo whose foreign key is a single scalar
+     * column that is `NOT NULL` in the schema, minus:
+     *
+     * - aliases listed in `$except`,
+     * - aliases whose FK the caller pinned (non-null) at the call site,
+     * - aliases excluded by the {@see self::requiredParentAssociations()}
+     *   override hook.
+     *
+     * An alias already composed via `->with()` / `->for()` / `configure()` is
+     * still returned: the caller's factory is recursively enriched (or, if it
+     * was instantiated from a concrete entity, left untouched) by
+     * {@see self::doWithRequiredParents()}.
+     *
+     * Composite-key and `foreignKey => false` associations are never included
+     * automatically — only the override hook can opt them in.
+     *
+     * @param array<int, string> $except Association aliases to skip.
+     *
+     * @return array<int, string> Ordered list of belongsTo aliases to compose.
+     */
+    private function resolveRequiredParentAliases(array $except): array
+    {
+        $table = $this->getTable();
+        $schema = $table->getSchema();
+
+        $override = $this->requiredParentAssociations();
+        // Caller-pinned FK columns (Factory::new(['fk' => x]), ->state(),
+        // ->setField(), ->patchData(), sequence*()), resolvable at chain time.
+        // A *non-null* pinned FK means the parent is already satisfied, so the
+        // alias is skipped — but ONLY while autoSkipComposeOnExplicitForeignKey
+        // is on (its default). With the opt-out flag off the library's legacy
+        // contract is "composed parent overrides the explicit FK", so to stay
+        // consistent withRequiredParents() must still compose the parent then.
+        // A null pin never satisfies a NOT NULL FK (matches the auto-skip
+        // feature's non-null semantics).
+        $honorPinnedFks = (bool)Configure::read(
+            'FixtureFactories.autoSkipComposeOnExplicitForeignKey',
+            true,
+        );
+        $pinnedFields = $honorPinnedFks ? $this->getDataCompiler()->getPinnedFields() : [];
+        // Probe hidden FK columns on a Factory::new($entity) payload via
+        // has()/get() (toArray() drops hidden properties) — matches the
+        // build-time auto-skip path.
+        $instantiationEntity = $honorPinnedFks
+            ? $this->getDataCompiler()->getInstantiationEntity()
+            : null;
+
+        $aliases = [];
+        foreach ($table->associations() as $association) {
+            if (!$association instanceof BelongsTo) {
+                continue;
+            }
+
+            $alias = $association->getAlias();
+            if (in_array($alias, $except, true)) {
+                continue;
+            }
+            // Note: an alias already composed via ->with()/configure() is NOT
+            // skipped here — doWithRequiredParents() recurses into an attached
+            // *factory* so its own required grandchildren get satisfied too
+            // (an entity-instantiated parent is left untouched there).
+            // The caller pinned this association's FK literally at the call
+            // site: the parent is already satisfied. Composing it would
+            // override the pinned value (an explicit ->with() always wins over
+            // autoSkipComposeOnExplicitForeignKey), so skip the alias entirely.
+            $foreignKeysForAlias = array_values(array_filter(
+                (array)$association->getForeignKey(),
+                static fn ($fk): bool => is_string($fk) && $fk !== '',
+            ));
+            if ($foreignKeysForAlias !== []) {
+                $allPinnedNonNull = true;
+                foreach ($foreignKeysForAlias as $fkColumn) {
+                    $pinned =
+                        (array_key_exists($fkColumn, $pinnedFields) && $pinnedFields[$fkColumn] !== null)
+                        || (
+                            $instantiationEntity !== null
+                            && $instantiationEntity->has($fkColumn)
+                            && $instantiationEntity->get($fkColumn) !== null
+                        );
+                    if (!$pinned) {
+                        $allPinnedNonNull = false;
+
+                        break;
+                    }
+                }
+                if ($allPinnedNonNull) {
+                    continue;
+                }
+            }
+
+            if ($override !== null) {
+                // Explicit opt-in list: the caller takes full responsibility
+                // for which aliases (including composite / custom-join ones)
+                // are buildable, so honour it verbatim.
+                if (in_array($alias, $override, true)) {
+                    $aliases[] = $alias;
+                }
+
+                continue;
+            }
+
+            $foreignKeys = (array)$association->getForeignKey();
+            // Composite key, or `foreignKey => false` (custom-condition join):
+            // never auto-resolved — see PR #85. Opt in via the override hook.
+            if (count($foreignKeys) !== 1) {
+                continue;
+            }
+            $column = $foreignKeys[0];
+            if (!is_string($column) || $column === '') {
+                continue;
+            }
+            if (!$schema->hasColumn($column)) {
+                continue;
+            }
+            // A shared-primary-key 1:1 (child.id is both PK and the belongsTo
+            // FK) is intentionally NOT excluded: it is a legitimate single
+            // scalar NOT NULL belongsTo and the parent must be composed for
+            // the child to persist.
+            if ($schema->isNullable($column)) {
+                continue;
+            }
+
+            $aliases[] = $alias;
+        }
+
+        return $aliases;
+    }
+
+    /**
+     * Override hook to take explicit control over which belongsTo aliases
+     * {@see self::withRequiredParents()} composes.
+     *
+     * Return `null` (the default) to use automatic NOT NULL single-scalar-FK
+     * detection. Return an array of aliases to opt in *exactly* those — this
+     * is the supported, non-guessing way to include a composite-key or
+     * `foreignKey => false` custom-join belongsTo, which automatic detection
+     * deliberately refuses to build (the PR #85 brittle cases).
+     *
+     * When a non-null list is returned it is authoritative: only listed
+     * aliases are composed, automatic detection is bypassed entirely, and the
+     * factory author owns correctness for the listed associations.
+     *
+     * @return array<int, string>|null Aliases to compose, or null for auto.
+     */
+    protected function requiredParentAssociations(): ?array
+    {
+        return null;
+    }
+
+    /**
      * @internal Not for normal use, only used for testing.
      *
      * @param array<string, mixed> $data Data to merge

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -307,7 +307,12 @@ abstract class BaseFactory
         $factory = $factory->setDefaultData(
             function (GeneratorInterface $generator) use ($definitionFactory, $factoryClass): array {
                 $data = $definitionFactory->definition($generator);
-                self::detectForeignKeysInDefinition($data, $definitionFactory->getTable(), $factoryClass);
+                self::detectForeignKeysInDefinition(
+                    $data,
+                    $definitionFactory->getTable(),
+                    $factoryClass,
+                    $definitionFactory->allowedForeignKeysInDefinition(),
+                );
 
                 return $data;
             },
@@ -1347,8 +1352,11 @@ abstract class BaseFactory
      * @param array<string, mixed> $data Data returned by definition().
      * @param \Cake\ORM\Table $table The factory's root table.
      * @param string $factoryClass FQCN of the factory, used in the message.
+     * @param array<int, string> $allowed Columns the factory explicitly
+     *   declares as intentional via {@see self::allowedForeignKeysInDefinition()}
+     *   — not flagged. Reserved for non-managed join columns.
      */
-    private static function detectForeignKeysInDefinition(array $data, Table $table, string $factoryClass): void
+    private static function detectForeignKeysInDefinition(array $data, Table $table, string $factoryClass, array $allowed = []): void
     {
         if (!$data) {
             return;
@@ -1368,6 +1376,9 @@ abstract class BaseFactory
                 continue;
             }
             if (!isset($fkColumns[$column])) {
+                continue;
+            }
+            if (in_array($column, $allowed, true)) {
                 continue;
             }
 
@@ -1916,6 +1927,26 @@ abstract class BaseFactory
     protected function requiredParentAssociations(): ?array
     {
         return null;
+    }
+
+    /**
+     * Columns that `definition()` intentionally returns and the
+     * `strictDefinition` detector must NOT flag.
+     *
+     * Reserved for **non-managed** join columns: a `foreignKey => false`
+     * custom-condition belongsTo (e.g. a uuid-condition join) whose column
+     * CakePHP never manages. strictDefinition exists to stop a dangling
+     * *managed* FK id from masking a real composed parent; a non-managed
+     * condition-join column has no managed pointer to dangle, so a generated
+     * value there is not that anti-pattern. The detector still flags every
+     * genuinely managed FK — listing a managed FK column here defeats the
+     * check, so don't.
+     *
+     * @return array<int, string> Column names exempt from the detector.
+     */
+    protected function allowedForeignKeysInDefinition(): array
+    {
+        return [];
     }
 
     /**

--- a/src/Factory/DataCompiler.php
+++ b/src/Factory/DataCompiler.php
@@ -178,6 +178,26 @@ class DataCompiler
     }
 
     /**
+     * The entity passed to `Factory::new($entity)` / `Factory::from($entity)`,
+     * or `null` when the factory was not instantiated from an entity.
+     *
+     * Exposed so {@see \CakephpFixtureFactories\Factory\BaseFactory::withRequiredParents()}
+     * can probe specific FK columns via `has()`/`get()` (which see hidden
+     * fields), matching the build-time auto-skip path instead of going through
+     * `toArray()` (which drops hidden properties).
+     *
+     * @internal
+     *
+     * @return \Cake\Datasource\EntityInterface|null
+     */
+    public function getInstantiationEntity(): ?EntityInterface
+    {
+        return $this->dataFromInstantiation instanceof EntityInterface
+            ? $this->dataFromInstantiation
+            : null;
+    }
+
+    /**
      * Data passed in the instantiation by callable.
      *
      * The callable is stored as-is and invoked once per build iteration during
@@ -1351,6 +1371,114 @@ class DataCompiler
     public function getEnforcedFields(): array
     {
         return $this->enforcedFields;
+    }
+
+    /**
+     * Field name => value pairs the caller has pinned via array instantiation
+     * (`Factory::new(['fk' => x])`), `->state([...])`, `->setField()` or
+     * `->patchData([...])`, resolvable *before* the build runs.
+     *
+     * Unlike {@see self::getEnforcedFields()} (populated during the build),
+     * this is available at chain-construction time, so
+     * {@see \CakephpFixtureFactories\Factory\BaseFactory::withRequiredParents()}
+     * can treat a *non-null* pinned FK as "this parent is already satisfied"
+     * and not compose it (matching the non-null semantics of the
+     * autoSkipComposeOnExplicitForeignKey feature). Callable
+     * instantiation/patch data is opaque pre-build and therefore not
+     * introspected.
+     *
+     * Patch data (state/setField/patchData) takes precedence over
+     * instantiation data, mirroring the build-time merge order.
+     *
+     * @internal
+     *
+     * @return array<string, mixed>
+     */
+    public function getPinnedFields(): array
+    {
+        $pinned = [];
+        if (is_array($this->dataFromInstantiation)) {
+            foreach ($this->dataFromInstantiation as $key => $value) {
+                if (is_string($key)) {
+                    $pinned[$key] = $value;
+                }
+            }
+        }
+
+        // sequence() / sequenceField() pins are explicit caller state too. A
+        // field only counts as pinned when EVERY produced row sets it to a
+        // non-null value (present in every sequence state / every cycle
+        // value) — otherwise some row would still need the parent composed.
+        // Callable states are opaque pre-build and conservatively ignored.
+        return $this->dataFromPatch
+            + $this->pinnedSequenceFields()
+            + $pinned;
+    }
+
+    /**
+     * Fields pinned to a non-null value for *every* produced row by
+     * `sequence()` / `sequenceField()` (and therefore safe to treat as
+     * already satisfying a required parent).
+     *
+     * @return array<string, mixed>
+     */
+    private function pinnedSequenceFields(): array
+    {
+        $pinned = [];
+
+        if ($this->sequenceData !== []) {
+            $perStateArrays = [];
+            foreach ($this->sequenceData as $state) {
+                if ($state instanceof EntityInterface) {
+                    $perStateArrays[] = $state->toArray();
+                } elseif (is_array($state)) {
+                    $perStateArrays[] = $state;
+                } else {
+                    // A callable state is opaque pre-build: cannot guarantee
+                    // any field is pinned for that row — bail out entirely.
+                    $perStateArrays = [];
+
+                    break;
+                }
+            }
+            if ($perStateArrays !== []) {
+                $common = $perStateArrays[0];
+                foreach ($perStateArrays as $stateArray) {
+                    foreach ($common as $field => $_) {
+                        if (
+                            !array_key_exists($field, $stateArray)
+                            || $stateArray[$field] === null
+                        ) {
+                            unset($common[$field]);
+                        }
+                    }
+                }
+                foreach ($common as $field => $value) {
+                    if (is_string($field)) {
+                        $pinned[$field] = $value;
+                    }
+                }
+            }
+        }
+
+        foreach ($this->fieldSequences as $field => $values) {
+            if ($values === []) {
+                continue;
+            }
+            $allNonNull = true;
+            foreach ($values as $value) {
+                if ($value === null) {
+                    $allNonNull = false;
+
+                    break;
+                }
+            }
+            if ($allNonNull) {
+                $pinned[$field] = $values[0];
+            }
+        }
+
+        return $pinned;
     }
 
     /**

--- a/tests/Factory/AllowedFkAddressFactory.php
+++ b/tests/Factory/AllowedFkAddressFactory.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace CakephpFixtureFactories\Test\Factory;
+
+use CakephpFixtureFactories\Factory\BaseFactory;
+use CakephpFixtureFactories\Generator\GeneratorInterface;
+
+/**
+ * Like {@see SmellyAddressFactory} (returns the `city_id` FK from
+ * `definition()`), but explicitly declares that column intentional via
+ * {@see BaseFactory::allowedForeignKeysInDefinition()}. Models the supported
+ * exception for non-managed condition-join columns.
+ *
+ * @extends BaseFactory<\TestApp\Model\Entity\Address>
+ */
+class AllowedFkAddressFactory extends BaseFactory
+{
+    protected function getRootTableRegistryName(): string
+    {
+        return 'Addresses';
+    }
+
+    public function definition(GeneratorInterface $generator): array
+    {
+        return [
+            'street' => $generator->streetAddress(),
+            'city_id' => $generator->numberBetween(1, 100),
+        ];
+    }
+
+    protected function allowedForeignKeysInDefinition(): array
+    {
+        return ['city_id'];
+    }
+}

--- a/tests/Factory/RequiredParentsAuthorFactory.php
+++ b/tests/Factory/RequiredParentsAuthorFactory.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link          https://webrider.de/
+ * @since         1.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace CakephpFixtureFactories\Test\Factory;
+
+use CakephpFixtureFactories\Factory\BaseFactory;
+use CakephpFixtureFactories\Generator\GeneratorInterface;
+
+/**
+ * A bare Authors factory with NO `configure()` defaults and NO `forFoo()`
+ * helpers, so `withRequiredParents()` is exercised in isolation. The Authors
+ * table has a NOT NULL `address_id` (Address belongsTo — required) and a
+ * nullable `business_address_id` (BusinessAddress belongsTo — optional).
+ *
+ * @extends BaseFactory<\TestApp\Model\Entity\Author>
+ */
+class RequiredParentsAuthorFactory extends BaseFactory
+{
+    protected function getRootTableRegistryName(): string
+    {
+        return 'Authors';
+    }
+
+    public function definition(GeneratorInterface $generator): array
+    {
+        return [
+            'name' => $generator->name(),
+        ];
+    }
+}

--- a/tests/Factory/RequiredParentsOverrideAuthorFactory.php
+++ b/tests/Factory/RequiredParentsOverrideAuthorFactory.php
@@ -15,7 +15,7 @@ namespace CakephpFixtureFactories\Test\Factory;
 
 /**
  * Opts the (otherwise nullable, thus not auto-resolved) `BusinessAddress`
- * belongsTo into `withRequiredParents()` via the override hook, demonstrating
+ * belongsTo into `withRequiredParents()` via the additive hook, demonstrating
  * the supported, non-guessing escape hatch for associations automatic
  * detection deliberately refuses (composite / custom-join / nullable).
  *
@@ -24,10 +24,10 @@ namespace CakephpFixtureFactories\Test\Factory;
 class RequiredParentsOverrideAuthorFactory extends RequiredParentsAuthorFactory
 {
     /**
-     * @return array<int, string>|null
+     * @return array<int, string>
      */
-    protected function requiredParentAssociations(): ?array
+    protected function requiredParentAssociations(): array
     {
-        return ['Address', 'BusinessAddress'];
+        return ['BusinessAddress'];
     }
 }

--- a/tests/Factory/RequiredParentsOverrideAuthorFactory.php
+++ b/tests/Factory/RequiredParentsOverrideAuthorFactory.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link          https://webrider.de/
+ * @since         1.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace CakephpFixtureFactories\Test\Factory;
+
+/**
+ * Opts the (otherwise nullable, thus not auto-resolved) `BusinessAddress`
+ * belongsTo into `withRequiredParents()` via the override hook, demonstrating
+ * the supported, non-guessing escape hatch for associations automatic
+ * detection deliberately refuses (composite / custom-join / nullable).
+ *
+ * @extends \CakephpFixtureFactories\Test\Factory\RequiredParentsAuthorFactory
+ */
+class RequiredParentsOverrideAuthorFactory extends RequiredParentsAuthorFactory
+{
+    /**
+     * @return array<int, string>|null
+     */
+    protected function requiredParentAssociations(): ?array
+    {
+        return ['Address', 'BusinessAddress'];
+    }
+}

--- a/tests/TestCase/Factory/BaseFactoryForeignKeyDetectionTest.php
+++ b/tests/TestCase/Factory/BaseFactoryForeignKeyDetectionTest.php
@@ -20,6 +20,7 @@ use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use CakephpFixtureFactories\Factory\BaseFactory;
 use CakephpFixtureFactories\Test\Factory\AddressFactory;
+use CakephpFixtureFactories\Test\Factory\AllowedFkAddressFactory;
 use CakephpFixtureFactories\Test\Factory\CityFactory;
 use CakephpFixtureFactories\Test\Factory\SmellyAddressFactory;
 use TestApp\Model\Table\CitiesTable;
@@ -125,6 +126,25 @@ class BaseFactoryForeignKeyDetectionTest extends TestCase
         SmellyAddressFactory::new()->build();
 
         $this->assertSame([], $this->capturedErrors);
+    }
+
+    /**
+     * A factory may declare a definition() column intentional via
+     * `allowedForeignKeysInDefinition()` — reserved for non-managed
+     * condition-join columns. The detector must not flag a listed column,
+     * while `strictDefinition` stays globally on for every other factory.
+     */
+    public function testAllowedForeignKeysInDefinitionExemptsListedColumn(): void
+    {
+        AllowedFkAddressFactory::new()->build();
+
+        $this->assertSame([], $this->capturedErrors, 'A column listed in allowedForeignKeysInDefinition() must not be flagged.');
+
+        // The exemption is per-factory: an un-listed smelly factory on the
+        // same column is still flagged.
+        SmellyAddressFactory::new()->build();
+        $this->assertCount(1, $this->capturedErrors);
+        $this->assertStringContainsString('"city_id"', $this->capturedErrors[0]['message']);
     }
 
     /**

--- a/tests/TestCase/Factory/BaseFactoryWithRequiredParentsTest.php
+++ b/tests/TestCase/Factory/BaseFactoryWithRequiredParentsTest.php
@@ -406,9 +406,10 @@ class BaseFactoryWithRequiredParentsTest extends TestCase
     }
 
     /**
-     * The override hook is authoritative: it opts the (otherwise nullable,
-     * not auto-resolved) BusinessAddress into composition AND keeps Address.
-     * This is the supported, non-guessing escape hatch for composite /
+     * The hook is additive: it opts the (otherwise nullable, not
+     * auto-resolved) BusinessAddress into composition while the ordinary
+     * required Address still comes from automatic detection. This is the
+     * supported, non-guessing escape hatch for composite /
      * custom-join associations automatic detection refuses to build.
      */
     public function testOverrideHookOptsInExtraAssociation(): void
@@ -420,7 +421,7 @@ class BaseFactoryWithRequiredParentsTest extends TestCase
         $this->assertNotNull($author->address_id, 'Address still composed.');
         $this->assertNotNull(
             $author->business_address_id,
-            'Override hook opted BusinessAddress in even though its FK is nullable.',
+            'Hook opted BusinessAddress in even though its FK is nullable.',
         );
     }
 

--- a/tests/TestCase/Factory/BaseFactoryWithRequiredParentsTest.php
+++ b/tests/TestCase/Factory/BaseFactoryWithRequiredParentsTest.php
@@ -27,8 +27,10 @@ use CakephpFixtureFactories\Test\Factory\CountryFactory;
 use CakephpFixtureFactories\Test\Factory\RequiredParentsAuthorFactory;
 use CakephpFixtureFactories\Test\Factory\RequiredParentsOverrideAuthorFactory;
 use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
+use InvalidArgumentException;
 use ReflectionMethod;
 use TestApp\Test\Factory\AuthorFactory;
+use Throwable;
 
 /**
  * Behavioural tests for `BaseFactory::withRequiredParents()` — the ergonomic
@@ -613,5 +615,175 @@ class BaseFactoryWithRequiredParentsTest extends TestCase
 
         $this->assertNotNull($country->id);
         $this->assertSame(1, CountryFactory::query()->count());
+    }
+
+    /**
+     * `maxDepth: 1` composes only the root's *direct* required parents — the
+     * grandparent chain is intentionally not recursed into. The composed row
+     * may then be un-persistable (its own NOT NULL FK is unsatisfied); that is
+     * the caller's responsibility, exactly like `$except`.
+     */
+    public function testMaxDepthOneComposesOnlyDirectParentNotGrandparent(): void
+    {
+        $author = RequiredParentsAuthorFactory::new()
+            ->withRequiredParents(maxDepth: 1)
+            ->build();
+
+        $this->assertNotEmpty(
+            $author->address,
+            'maxDepth:1 still composes the direct required parent Address.',
+        );
+        $this->assertEmpty(
+            $author->address->city,
+            'maxDepth:1 must NOT recurse into the grandparent City.',
+        );
+    }
+
+    /**
+     * `maxDepth: 2` composes the root's parents and their parents, but stops
+     * before the third level. Here: Address + City, but not Country.
+     */
+    public function testMaxDepthTwoComposesTwoLevels(): void
+    {
+        $author = RequiredParentsAuthorFactory::new()
+            ->withRequiredParents(maxDepth: 2)
+            ->build();
+
+        $this->assertNotEmpty($author->address, 'Level 1 (Address) composed.');
+        $this->assertNotEmpty($author->address->city, 'Level 2 (City) composed.');
+        $this->assertEmpty(
+            $author->address->city->country,
+            'maxDepth:2 must NOT recurse into the third level (Country).',
+        );
+    }
+
+    /**
+     * Explicit `maxDepth: null` is the unbounded default: the whole NOT NULL
+     * chain is composed, identical to calling `withRequiredParents()`.
+     */
+    public function testMaxDepthNullComposesWholeChain(): void
+    {
+        $author = RequiredParentsAuthorFactory::new()
+            ->withRequiredParents(maxDepth: null)
+            ->build();
+
+        $this->assertNotEmpty($author->address, 'Address composed.');
+        $this->assertNotEmpty($author->address->city, 'City composed.');
+        $this->assertNotEmpty(
+            $author->address->city->country,
+            'maxDepth:null composes the whole chain down to Country.',
+        );
+    }
+
+    /**
+     * `maxDepth: 0` (or negative) is a confusing footgun — "compose zero
+     * required parents" is just not calling the method. Reject it loudly at
+     * call time instead of silently composing nothing.
+     */
+    public function testMaxDepthZeroThrowsInvalidArgument(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        RequiredParentsAuthorFactory::new()->withRequiredParents(maxDepth: 0);
+    }
+
+    /**
+     * A negative cap is equally nonsensical and rejected the same way.
+     */
+    public function testMaxDepthNegativeThrowsInvalidArgument(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        RequiredParentsAuthorFactory::new()->withRequiredParents(maxDepth: -1);
+    }
+
+    /**
+     * The documented `maxDepth` trap: capping below the real required depth
+     * produces a row whose own NOT NULL FK is unsatisfied, so `->save()`
+     * fails. This is the caller's responsibility (same contract as `$except`),
+     * and — being side-effect free — nothing leaks: no Author/Address row is
+     * written when the persist aborts.
+     */
+    public function testMaxDepthBelowRequiredDepthProducesUnpersistableRow(): void
+    {
+        $threw = false;
+        try {
+            RequiredParentsAuthorFactory::new()
+                ->withRequiredParents(maxDepth: 1)
+                ->save();
+        } catch (Throwable $e) {
+            $threw = true;
+        }
+
+        $this->assertTrue(
+            $threw,
+            'maxDepth:1 leaves Address.city_id (NOT NULL) unsatisfied, so save() must fail.',
+        );
+        $this->assertSame(0, AddressFactory::query()->count(), 'No Address leaked.');
+        $this->assertSame(
+            0,
+            RequiredParentsAuthorFactory::query()->count(),
+            'No Author leaked — composition is atomic.',
+        );
+    }
+
+    /**
+     * Opt-in `strict: true`: when `maxDepth` actually truncates the required
+     * chain — a composed boundary parent still has its own unsatisfied
+     * required belongsTo — fail loudly at call time with an actionable
+     * message instead of silently producing an un-persistable row.
+     */
+    public function testStrictThrowsWhenMaxDepthDropsANeededParent(): void
+    {
+        $this->expectException(FixtureFactoryException::class);
+        $this->expectExceptionMessage('maxDepth');
+
+        RequiredParentsAuthorFactory::new()
+            ->withRequiredParents(maxDepth: 1, strict: true);
+    }
+
+    /**
+     * `strict: true` is a no-op when the cap is deep enough to satisfy the
+     * whole required chain — no exception, full chain composed.
+     */
+    public function testStrictDoesNotThrowWhenCapCoversTheChain(): void
+    {
+        $author = RequiredParentsAuthorFactory::new()
+            ->withRequiredParents(maxDepth: 3, strict: true)
+            ->build();
+
+        $this->assertNotEmpty($author->address->city->country);
+    }
+
+    /**
+     * `strict: true` with no cap (full chain) never throws — there is no
+     * truncation to be strict about.
+     */
+    public function testStrictWithoutMaxDepthIsHarmless(): void
+    {
+        $author = RequiredParentsAuthorFactory::new()
+            ->withRequiredParents(strict: true)
+            ->save();
+
+        $this->assertNotNull($author->id);
+    }
+
+    /**
+     * `recycle()` cannot rescue a capped branch: recycle only substitutes
+     * *composed* belongsTo branches, and `maxDepth` stops the recycled
+     * table's branch from being composed at all. So `maxDepth` + a recycle
+     * for a beyond-cap table is genuinely un-persistable, and `strict`
+     * correctly reports it rather than being silenced by the recycle.
+     */
+    public function testStrictStillThrowsWhenRecycleCannotReachACappedBranch(): void
+    {
+        $country = CountryFactory::new()->save();
+
+        $this->expectException(FixtureFactoryException::class);
+        $this->expectExceptionMessage('maxDepth');
+
+        RequiredParentsAuthorFactory::new()
+            ->recycle($country)
+            ->withRequiredParents(maxDepth: 2, strict: true);
     }
 }

--- a/tests/TestCase/Factory/BaseFactoryWithRequiredParentsTest.php
+++ b/tests/TestCase/Factory/BaseFactoryWithRequiredParentsTest.php
@@ -1,0 +1,616 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link https://webrider.de/
+ * @since 2.0.0
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace CakephpFixtureFactories\Test\TestCase\Factory;
+
+use Cake\Core\Configure;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use CakephpFixtureFactories\Error\FixtureFactoryException;
+use CakephpFixtureFactories\Factory\BaseFactory;
+use CakephpFixtureFactories\ORM\FactoryTableRegistry;
+use CakephpFixtureFactories\Test\Factory\AddressFactory;
+use CakephpFixtureFactories\Test\Factory\CityFactory;
+use CakephpFixtureFactories\Test\Factory\CountryFactory;
+use CakephpFixtureFactories\Test\Factory\RequiredParentsAuthorFactory;
+use CakephpFixtureFactories\Test\Factory\RequiredParentsOverrideAuthorFactory;
+use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
+use ReflectionMethod;
+use TestApp\Test\Factory\AuthorFactory;
+
+/**
+ * Behavioural tests for `BaseFactory::withRequiredParents()` — the ergonomic
+ * counterpart to the FK-in-definition() detector (`strictDefinition`).
+ *
+ * It composes every belongsTo whose single scalar FK column is NOT NULL,
+ * recursively, so a built row satisfies its NOT NULL FK constraints without
+ * hand-written `->with()` boilerplate. Composite-key / `foreignKey => false`
+ * associations are never auto-resolved (PR #85 brittle cases) — only the
+ * override hook can opt them in.
+ */
+class BaseFactoryWithRequiredParentsTest extends TestCase
+{
+    use TruncateDirtyTables;
+
+    protected function tearDown(): void
+    {
+        // Tests that augment a factory's root table with extra associations
+        // (cycle / custom-join / shared-PK cases) must not leak them into the
+        // next test: clear BOTH the app locator and the fixture-factories one
+        // (the factory resolves its table through the latter).
+        TableRegistry::getTableLocator()->clear();
+        FactoryTableRegistry::getTableLocator()->clear();
+        parent::tearDown();
+    }
+
+    /**
+     * The Authors table requires `address_id` (NOT NULL belongsTo Address),
+     * which in turn requires `city_id` (NOT NULL belongsTo City), which
+     * requires `country_id` (NOT NULL belongsTo Country). One call composes
+     * the whole NOT NULL chain so the row persists.
+     */
+    public function testComposesRequiredBelongsToChain(): void
+    {
+        $author = RequiredParentsAuthorFactory::new()
+            ->withRequiredParents()
+            ->save();
+
+        $this->assertNotNull($author->id);
+        $this->assertNotNull($author->address_id, 'Required Address must be composed.');
+        $this->assertSame(1, AddressFactory::query()->count());
+        $this->assertSame(1, CityFactory::query()->count(), 'Address.city_id chain must be satisfied.');
+        $this->assertSame(1, CountryFactory::query()->count(), 'City.country_id chain must be satisfied.');
+    }
+
+    /**
+     * `business_address_id` is nullable, so BusinessAddress is NOT a required
+     * parent and must not be silently fabricated.
+     */
+    public function testNullableForeignKeyIsNotComposed(): void
+    {
+        $author = RequiredParentsAuthorFactory::new()
+            ->withRequiredParents()
+            ->save();
+
+        $this->assertNull(
+            $author->business_address_id,
+            'Nullable business_address_id must not be auto-composed.',
+        );
+        // One Address only — for the required `address_id`, not BusinessAddress.
+        $this->assertSame(1, AddressFactory::query()->count());
+    }
+
+    /**
+     * `withRequiredParents()` returns a clone and never mutates the receiver.
+     */
+    public function testReturnsCloneAndIsImmutable(): void
+    {
+        $base = RequiredParentsAuthorFactory::new();
+        $withParents = $base->withRequiredParents();
+
+        $this->assertNotSame($base, $withParents);
+    }
+
+    /**
+     * An alias in `$except` is skipped: the caller pins that FK literally for
+     * a column-scope assertion. Here Address is excepted and the FK supplied
+     * explicitly; the deeper chain is therefore not built at all.
+     */
+    public function testExceptSkipsNamedAssociation(): void
+    {
+        $address = AddressFactory::new()->save();
+        $cityCountBefore = CityFactory::query()->count();
+
+        $author = RequiredParentsAuthorFactory::new(['address_id' => $address->id])
+            ->withRequiredParents(['Address'])
+            ->save();
+
+        $this->assertSame($address->id, $author->address_id);
+        // Excepting Address means no extra Address/City/Country chain is built
+        // beyond the single Address (with its own required City+Country) above.
+        $this->assertSame(1, AddressFactory::query()->count());
+        $this->assertSame($cityCountBefore, CityFactory::query()->count());
+    }
+
+    /**
+     * Side-effect free: composing required parents writes NOTHING to the
+     * database until the root factory is persisted. `->build()` stays purely
+     * in-memory (this is the core `with*()` contract — eagerly persisting at
+     * chain time would break atomicity and leak rows).
+     */
+    public function testWithRequiredParentsIsSideEffectFreeUntilPersist(): void
+    {
+        $author = RequiredParentsAuthorFactory::new()
+            ->withRequiredParents()
+            ->build();
+
+        $this->assertTrue($author->isNew(), 'build() must not persist.');
+        $this->assertSame(0, AddressFactory::query()->count(), 'No Address row written by build().');
+        $this->assertSame(0, CountryFactory::query()->count(), 'No Country row written by build().');
+    }
+
+    /**
+     * Default (no `recycle()`): each produced row in a counted batch gets its
+     * own full required parent chain — correct for independent fixtures.
+     */
+    public function testCountedBatchBuildsADistinctChainPerRowByDefault(): void
+    {
+        $authors = RequiredParentsAuthorFactory::new()
+            ->count(3)
+            ->withRequiredParents()
+            ->saveMany();
+
+        $this->assertCount(3, $authors);
+        $ids = array_map(fn ($a): int => $a->address_id, $authors);
+        $this->assertCount(3, array_unique($ids), 'A distinct Address per row.');
+        $this->assertSame(3, AddressFactory::query()->count());
+        $this->assertSame(3, CityFactory::query()->count());
+        $this->assertSame(3, CountryFactory::query()->count());
+    }
+
+    /**
+     * `withRequiredParents()` composes cleanly with the established
+     * `recycle()` pattern: build a shared parent yourself and every produced
+     * row's required chain reuses it. This is the supported way to dedup a
+     * batch — the method never persists on its own, so it stays atomic.
+     */
+    public function testComposesWithRecycleToShareOneParentAcrossBatch(): void
+    {
+        $country = CountryFactory::new()->save();
+
+        $authors = RequiredParentsAuthorFactory::new()
+            ->count(5)
+            ->withRequiredParents()
+            ->recycle($country)
+            ->saveMany();
+
+        $this->assertCount(5, $authors);
+        $this->assertSame(
+            1,
+            CountryFactory::query()->count(),
+            'Every row\'s required chain reuses the single recycled Country.',
+        );
+        // Addresses/Cities still fan out per row (only Country was recycled).
+        $this->assertSame(5, AddressFactory::query()->count());
+    }
+
+    /**
+     * An explicit `->with('Address', $entity)` already satisfies the alias, so
+     * `withRequiredParents()` must NOT double-compose it — the explicit entity
+     * wins and only one Address exists.
+     */
+    public function testExplicitWithIsNotDoubleComposed(): void
+    {
+        $address = AddressFactory::new()->save();
+        $cityCountBefore = CityFactory::query()->count();
+
+        $author = RequiredParentsAuthorFactory::new()
+            ->with('Address', $address)
+            ->withRequiredParents()
+            ->save();
+
+        $this->assertSame($address->id, $author->address_id, 'Explicit Address wins.');
+        $this->assertSame(1, AddressFactory::query()->count(), 'No second Address composed.');
+        $this->assertSame(
+            $cityCountBefore,
+            CityFactory::query()->count(),
+            'Explicit Address already had its chain — none re-built.',
+        );
+    }
+
+    /**
+     * A required parent composed as a bare FACTORY (explicitly or via a
+     * configure() default) must be recursively enriched, not skipped: its own
+     * required grandchildren (here `Address.city_id` → City → Country) have to
+     * be satisfied or the save fails on the NOT NULL the API is meant to
+     * prevent. The caller's Address factory is kept (not replaced).
+     */
+    public function testComposedParentFactoryIsRecursivelyEnriched(): void
+    {
+        $author = RequiredParentsAuthorFactory::new()
+            ->with('Address', AddressFactory::new()->setField('street', 'Pinned Street'))
+            ->withRequiredParents()
+            ->save();
+
+        $this->assertNotNull($author->address_id, 'Address composed.');
+        $address = AddressFactory::query()->firstOrFail();
+        $this->assertSame('Pinned Street', $address->get('street'), "Caller's Address factory kept.");
+        $this->assertNotNull(
+            $address->get('city_id'),
+            'Grandchild Address.city_id satisfied — composed factory was enriched, not skipped.',
+        );
+        $this->assertSame(1, CityFactory::query()->count());
+        $this->assertSame(1, CountryFactory::query()->count());
+    }
+
+    /**
+     * Order independence with NO orphan: an explicit `->with()` placed AFTER
+     * `withRequiredParents()` wins, and — because composition is side-effect
+     * free until persist — the auto chain leaves no stray pre-built Address
+     * row behind. Exactly one Address (the explicit one) exists.
+     */
+    public function testExplicitWithAfterWithRequiredParentsLeavesNoOrphan(): void
+    {
+        $address = AddressFactory::new()->save();
+
+        $author = RequiredParentsAuthorFactory::new()
+            ->withRequiredParents()
+            ->with('Address', $address)
+            ->save();
+
+        $this->assertSame($address->id, $author->address_id, 'Explicit Address wins.');
+        $this->assertSame(
+            1,
+            AddressFactory::query()->count(),
+            'No orphaned auto-built Address — composition is side-effect free.',
+        );
+    }
+
+    /**
+     * Composes cleanly with `autoSkipComposeOnExplicitForeignKey`: pinning the
+     * FK at the call site auto-skips the composed parent, so the explicit
+     * value survives and no throw-away parent row is created. Uses
+     * `TestApp\Test\Factory\AuthorFactory` (no configure() defaults) so the
+     * only composition is from `withRequiredParents()`.
+     */
+    public function testInteractionWithAutoSkipComposeOnExplicitForeignKey(): void
+    {
+        $this->assertTrue((bool)Configure::read('FixtureFactories.autoSkipComposeOnExplicitForeignKey', true));
+        $address = AddressFactory::new()->save();
+        $addressCountBefore = AddressFactory::query()->count();
+
+        $author = AuthorFactory::new(['address_id' => $address->id])
+            ->withRequiredParents()
+            ->save();
+
+        $this->assertSame($address->id, $author->address_id, 'Pinned FK survives.');
+        $this->assertSame(
+            $addressCountBefore,
+            AddressFactory::query()->count(),
+            'No throw-away Address row created when the FK is pinned.',
+        );
+    }
+
+    /**
+     * Consistency with the opt-out flag: when
+     * `autoSkipComposeOnExplicitForeignKey` is OFF, the library's legacy
+     * contract is "composed parent overrides the explicit FK". So
+     * `withRequiredParents()` must still compose the parent (a fresh Address
+     * is created and wins), matching the rest of the library rather than
+     * silently dropping the alias.
+     */
+    public function testPinnedForeignKeyStillComposesWhenAutoSkipDisabled(): void
+    {
+        Configure::write('FixtureFactories.autoSkipComposeOnExplicitForeignKey', false);
+        $address = AddressFactory::new()->save();
+        $addressCountBefore = AddressFactory::query()->count();
+
+        $author = AuthorFactory::new(['address_id' => $address->id])
+            ->withRequiredParents()
+            ->save();
+
+        $this->assertNotNull($author->address_id);
+        $this->assertSame(
+            $addressCountBefore + 1,
+            AddressFactory::query()->count(),
+            'Opt-out mode: the composed parent is created (legacy override behavior).',
+        );
+    }
+
+    /**
+     * A non-null FK on a `Factory::new($entity)` payload that is a HIDDEN
+     * entity property must still be detected as pinned (probed via has()/get(),
+     * not toArray() which drops hidden fields), so no throw-away parent is
+     * composed over it.
+     */
+    public function testHiddenEntityForeignKeyIsTreatedAsPinned(): void
+    {
+        $address = AddressFactory::new()->save();
+        $author = AuthorFactory::new()->getTable()->newEntity(
+            ['name' => 'Hidden FK', 'address_id' => $address->id],
+            ['accessibleFields' => ['*' => true]],
+        );
+        $author->setHidden(['address_id'], true);
+        $addressCountBefore = AddressFactory::query()->count();
+
+        $built = AuthorFactory::new($author)
+            ->withRequiredParents()
+            ->save();
+
+        $this->assertSame($address->id, $built->address_id, 'Hidden entity FK survives.');
+        $this->assertSame(
+            $addressCountBefore,
+            AddressFactory::query()->count(),
+            'No throw-away Address for a hidden but set FK.',
+        );
+    }
+
+    /**
+     * A FK pinned for *every* produced row via `sequenceField()` is explicit
+     * caller state and must be honored: the parent is not auto-composed and
+     * the sequenced value survives ("explicit FK wins" for counted builds).
+     */
+    public function testSequencePinnedForeignKeyIsHonored(): void
+    {
+        $a1 = AddressFactory::new()->save();
+        $a2 = AddressFactory::new()->save();
+        $addressCountBefore = AddressFactory::query()->count();
+
+        $authors = AuthorFactory::new()
+            ->count(2)
+            ->sequenceField('address_id', $a1->id, $a2->id)
+            ->withRequiredParents()
+            ->saveMany();
+
+        $this->assertSame([$a1->id, $a2->id], [$authors[0]->address_id, $authors[1]->address_id]);
+        $this->assertSame(
+            $addressCountBefore,
+            AddressFactory::query()->count(),
+            'No throw-away Address created when the FK is sequence-pinned for every row.',
+        );
+    }
+
+    /**
+     * Cycle detection is path-scoped, not global: two distinct sibling
+     * branches that each reach the SAME physical table (Address and
+     * BusinessAddress both → addresses) is a DAG, not a cycle, and must NOT
+     * raise the cycle exception.
+     */
+    public function testSiblingBranchesToSameTableAreNotAFalseCycle(): void
+    {
+        $author = RequiredParentsOverrideAuthorFactory::new()
+            ->withRequiredParents()
+            ->save();
+
+        $this->assertNotNull($author->address_id);
+        $this->assertNotNull($author->business_address_id);
+    }
+
+    /**
+     * A non-null belongsTo FK supplied via ENTITY instantiation
+     * (`Factory::new($entity)`) already satisfies that parent: the resolver
+     * must treat it as pinned and not auto-compose a throw-away parent that
+     * would overwrite the caller-provided value.
+     */
+    public function testEntityInstantiatedForeignKeyIsTreatedAsPinned(): void
+    {
+        $address = AddressFactory::new()->save();
+        $author = AuthorFactory::new()->getTable()->newEntity(
+            ['name' => 'Pinned', 'address_id' => $address->id],
+            ['accessibleFields' => ['*' => true]],
+        );
+        $addressCountBefore = AddressFactory::query()->count();
+
+        $built = AuthorFactory::new($author)
+            ->withRequiredParents()
+            ->save();
+
+        $this->assertSame($address->id, $built->address_id, 'Entity-supplied FK survives.');
+        $this->assertSame(
+            $addressCountBefore,
+            AddressFactory::query()->count(),
+            'No throw-away Address created for an entity-pinned FK.',
+        );
+    }
+
+    /**
+     * The override hook is authoritative: it opts the (otherwise nullable,
+     * not auto-resolved) BusinessAddress into composition AND keeps Address.
+     * This is the supported, non-guessing escape hatch for composite /
+     * custom-join associations automatic detection refuses to build.
+     */
+    public function testOverrideHookOptsInExtraAssociation(): void
+    {
+        $author = RequiredParentsOverrideAuthorFactory::new()
+            ->withRequiredParents()
+            ->save();
+
+        $this->assertNotNull($author->address_id, 'Address still composed.');
+        $this->assertNotNull(
+            $author->business_address_id,
+            'Override hook opted BusinessAddress in even though its FK is nullable.',
+        );
+    }
+
+    /**
+     * A `foreignKey => false` custom-condition belongsTo (the classic uuid
+     * join — a PR #85 brittle case) must NEVER be auto-resolved, even though
+     * it is technically a belongsTo. Only the override hook can opt it in.
+     */
+    public function testForeignKeyFalseCustomJoinIsNotAutoResolved(): void
+    {
+        $factory = RequiredParentsAuthorFactory::new();
+        $factory->getTable()->belongsTo('GhostCountry', [
+            'className' => 'Countries',
+            'foreignKey' => false,
+            'conditions' => ['Authors.name = GhostCountry.name'],
+        ]);
+
+        $author = $factory
+            ->withRequiredParents()
+            ->save();
+
+        $this->assertNotNull($author->id, 'Build still succeeds.');
+        // Only the legitimate required chain built a Country (via City);
+        // the foreignKey=>false GhostCountry must NOT have added another.
+        $this->assertSame(
+            1,
+            CountryFactory::query()->count(),
+            'foreignKey => false belongsTo must not be auto-resolved.',
+        );
+    }
+
+    /**
+     * Recycle dedup within a single recursive chain: a SINGLE build composes
+     * exactly one of each required ancestor along its chain (Author -> Address
+     * -> City -> Country = one row each), never fanning out.
+     *
+     * Note the well-defined boundary: two *distinct-alias* belongsTo that both
+     * target the same table (Address + BusinessAddress) each build their own
+     * independent chain — that is per-alias intent, not a shared ancestor.
+     * Cross-row dedup for a counted batch is covered separately.
+     */
+    public function testSingleBuildComposesOneOfEachAlongTheChain(): void
+    {
+        $author = RequiredParentsOverrideAuthorFactory::new()
+            ->withRequiredParents()
+            ->save();
+
+        $this->assertNotNull($author->address_id);
+        $this->assertNotNull($author->business_address_id);
+        // Two distinct aliases (Address, BusinessAddress) → two independent
+        // chains; each chain itself is built exactly once (no fan-out within).
+        $this->assertNotSame(
+            $author->address_id,
+            $author->business_address_id,
+            'Distinct aliases keep their own parent — per-alias intent preserved.',
+        );
+        $this->assertSame(2, AddressFactory::query()->count(), 'One Address per distinct alias.');
+        $this->assertSame(2, CityFactory::query()->count(), 'One City per chain — no fan-out within a chain.');
+        $this->assertSame(2, CountryFactory::query()->count(), 'One Country per chain.');
+    }
+
+    /**
+     * A *null* value pinned on a required FK does NOT satisfy a NOT NULL
+     * constraint, so the parent must still be composed (matches the non-null
+     * semantics of autoSkipComposeOnExplicitForeignKey). Without this, the
+     * build would fail on the NOT NULL constraint.
+     */
+    public function testNullPinnedForeignKeyStillComposesParent(): void
+    {
+        $author = RequiredParentsAuthorFactory::new(['address_id' => null])
+            ->withRequiredParents()
+            ->save();
+
+        $this->assertNotNull(
+            $author->address_id,
+            'A null-pinned required FK must still get a composed parent.',
+        );
+        $this->assertSame(1, AddressFactory::query()->count());
+    }
+
+    /**
+     * A required (NOT NULL) belongsTo cycle is mathematically unsatisfiable by
+     * auto-composition. It must fail loudly with an actionable message — not
+     * recurse forever, and not silently produce a factory that later dies on a
+     * confusing NOT NULL violation. (`SelfRef` reuses the NOT NULL `address_id`
+     * column but targets Authors itself — an A -> A cycle.)
+     */
+    public function testCyclicRequiredParentGraphThrowsActionableException(): void
+    {
+        $factory = RequiredParentsAuthorFactory::new();
+        $factory->getTable()->belongsTo('SelfRef', [
+            'className' => 'Authors',
+            'foreignKey' => 'address_id',
+        ]);
+
+        $this->expectException(FixtureFactoryException::class);
+        $this->expectExceptionMessage('NOT NULL) belongsTo cycle');
+
+        $factory->withRequiredParents();
+    }
+
+    /**
+     * The actionable escape hatch works: pinning the cyclic FK at the call
+     * site and excluding the cyclic alias via `$except` breaks the cycle so
+     * the row becomes persistable.
+     */
+    public function testExceptBreaksAnOtherwiseUnsatisfiableCycle(): void
+    {
+        $address = AddressFactory::new()->save();
+
+        $factory = RequiredParentsAuthorFactory::new(['address_id' => $address->id]);
+        $factory->getTable()->belongsTo('SelfRef', [
+            'className' => 'Authors',
+            'foreignKey' => 'address_id',
+        ]);
+
+        // SelfRef + Address both ride address_id; pin it and except both.
+        $author = $factory
+            ->withRequiredParents(['SelfRef', 'Address'])
+            ->save();
+
+        $this->assertSame($address->id, $author->address_id);
+    }
+
+    /**
+     * Honor an explicitly-composed terminating parent that breaks an
+     * otherwise self-referential required cycle: when `->with('SelfRef',
+     * $entity)` supplies the cycle's terminating row, `withRequiredParents()`
+     * must NOT throw the cycle exception (the explicit entity wins). The
+     * cycle check runs only for aliases it would actually recurse into.
+     */
+    public function testExplicitEntityBreaksCycleInsteadOfThrowing(): void
+    {
+        $terminator = AuthorFactory::new()->withRequiredParents()->save();
+
+        $factory = RequiredParentsAuthorFactory::new();
+        $factory->getTable()->belongsTo('SelfRef', [
+            'className' => 'Authors',
+            'foreignKey' => 'address_id',
+        ]);
+
+        // SelfRef satisfied by a concrete entity (cycle broken). No exception
+        // must be raised while composing the chain.
+        $enriched = $factory
+            ->with('SelfRef', $terminator)
+            ->withRequiredParents(['Address']);
+
+        $this->assertInstanceOf(RequiredParentsAuthorFactory::class, $enriched);
+    }
+
+    /**
+     * A shared-primary-key 1:1 belongsTo (the FK column IS the table's primary
+     * key, e.g. `child.id` → `parent.id`) is a legitimate single scalar NOT
+     * NULL belongsTo and MUST be auto-resolved — it must not be excluded just
+     * because the column is also the primary key.
+     */
+    public function testSharedPrimaryKeyBelongsToIsResolved(): void
+    {
+        $factory = RequiredParentsAuthorFactory::new();
+        // Authors.id is the PK; declare a belongsTo whose FK is that PK.
+        $factory->getTable()->belongsTo('PkParent', [
+            'className' => 'Addresses',
+            'foreignKey' => 'id',
+        ]);
+
+        $resolver = new ReflectionMethod(
+            BaseFactory::class,
+            'resolveRequiredParentAliases',
+        );
+
+        $aliases = $resolver->invoke($factory, []);
+
+        $this->assertContains(
+            'PkParent',
+            $aliases,
+            'A shared-primary-key belongsTo must not be excluded from auto-resolution.',
+        );
+    }
+
+    /**
+     * A factory whose root table has no required (NOT NULL single-scalar-FK)
+     * belongsTo is a clean no-op — Countries has no belongsTo at all.
+     */
+    public function testNoRequiredParentsIsNoOp(): void
+    {
+        $country = CountryFactory::new()
+            ->withRequiredParents()
+            ->save();
+
+        $this->assertNotNull($country->id);
+        $this->assertSame(1, CountryFactory::query()->count());
+    }
+}


### PR DESCRIPTION
## Summary

Adds `BaseFactory::withRequiredParents()` — the ergonomic counterpart to `FixtureFactories.strictDefinition`.

`strictDefinition` (rightly) forbids foreign-key columns in `definition()`, but then every factory for a table with NOT NULL belongsTo FKs becomes unusable without manual association composition at each call site. This is the missing other half: a factory composes exactly the parents its schema requires, in one call, with optional shared-ancestor reuse via `recycle()`.

## Design

- **Auto-introspection.** Resolves the root table's belongsTo associations whose single scalar FK column is NOT NULL, and composes one parent each. Built on the existing FK-column enumeration already used by the strictDefinition detector and the explicit-FK auto-skip — no new schema-walking primitive.
- **Explicit shared-ancestor reuse via `recycle()`.** Shared ancestors are not deduplicated by default; branches compose independently. When a graph should reuse one pre-existing ancestor across branches or rows, `recycle()` provides that explicitly.
- **Additive hook for the hard cases.** Composite keys and `foreignKey => false` custom-join associations are deliberately NOT auto-resolved (the same class of edge case that made the earlier join-introspection attempt brittle). A factory can add those explicitly via `requiredParentAssociations()`, so the detector never silently mis-resolves them.
- **Composes cleanly with the explicit-FK auto-skip.** When a caller pins an FK, the corresponding composed parent is skipped — no double-compose — so `withRequiredParents()` stays churn-free at call sites that pin a literal FK for a column-scope assertion. The `except` argument covers the explicit case.
- Framed in the docs as the *pragmatic default*: data a test actually asserts on should still be composed explicitly with the directional helpers; `withRequiredParents()` is for "I just need a valid row".

## Files

- `src/Factory/BaseFactory.php`, `src/Factory/DataCompiler.php` — the feature.
- `tests/TestCase/Factory/BaseFactoryWithRequiredParentsTest.php` plus two test factory doubles — covers auto-resolution, nullable-FK exclusion, composite/custom-join requiring the additive hook, the `except` path, explicit shared-ancestor reuse via `recycle()`, interaction with an explicit association, and interaction with the explicit-FK auto-skip.
- `docs/guide/required-parents.md` (new), cross-linked from `docs/guide/foreign-keys-in-definition.md`, wired into the docs sidebar.

## Verification

- Full library suite on sqlite: 712 tests, 2484 assertions, green (11 skipped — DB-specific, unchanged from `main`).
- `cs-check`: clean.
- `stan`: not run locally — `composer stan` fails in a bare clone at its DB bootstrap (`test_suite_light` migration trigger) **identically on clean `main`**, i.e. a pre-existing local-environment limitation, not introduced here. CI runs stan in the proper environment.

This is a feature proposal for maintainer review; design points (recycle default, hook shape, framing) are open to adjustment.