### PR TITLE
withRequiredParents(): maxDepth + strict knobs

### DIFF
--- a/docs/guide/required-parents.md
+++ b/docs/guide/required-parents.md
@@ -143,6 +143,73 @@ $author = AuthorFactory::new(['address_id' => $address->id])
 // $author->address_id === $address->id; no throw-away Address built.
 ```
 
+## `maxDepth`: cap the recursion depth
+
+By default `withRequiredParents()` recurses the *whole* NOT NULL chain. Pass
+`maxDepth` to compose only the first N levels below the root:
+
+```php
+// Only the root's direct required parents — not their parents.
+AuthorFactory::new()->withRequiredParents(maxDepth: 1)->build();
+
+// Root's parents and their parents, but not the third level.
+AuthorFactory::new()->withRequiredParents(maxDepth: 2)->build();
+
+// Explicit null is the unbounded default (same as no argument).
+AuthorFactory::new()->withRequiredParents(maxDepth: null)->build();
+```
+
+`$except` and `maxDepth` are independent — pass both as named arguments:
+`->withRequiredParents(['BusinessAddress'], maxDepth: 2)`.
+
+`maxDepth` caps the *auto-recursion* this method performs. It does **not**
+suppress a composed parent factory's own `configure()` / `for()` defaults —
+those are the factory author's deliberate choice and always apply. So a depth
+cap is fully effective for the bare factories `withRequiredParents()` targets
+(no FKs in `definition()`/`configure()`, the `strictDefinition` model); if a
+parent factory self-composes a chain via `configure()`, that chain is still
+built regardless of `maxDepth`.
+
+::: warning A cap below the real required depth produces an un-persistable row
+This is by design — the exact same contract as `$except`. If `maxDepth`
+stops before a deeper `NOT NULL` FK is satisfied, `->build()` still returns an
+in-memory entity, but `->save()` fails with a `NOT NULL` violation. Use
+`maxDepth` only when you know the deeper levels are nullable, pinned, or
+recycled; otherwise omit it and let the full chain compose.
+
+This also applies to the [required-parent cycle fast-fail](#shared-primary-key-and-cyclic-graphs):
+a cycle *beyond* the cap is never reached, so it degrades from the actionable
+`FixtureFactoryException` to a generic save-time `NOT NULL` error. A cycle
+*within* the cap still throws as usual.
+:::
+
+### `strict`: turn the silent shortfall into a clear error
+
+Opt in with `strict: true` when you want a capped chain that is *too shallow*
+to fail loudly at the call site instead of silently producing an
+un-persistable row:
+
+```php
+// Throws FixtureFactoryException: maxDepth:1 leaves Address's required
+// City unsatisfied.
+AuthorFactory::new()->withRequiredParents(maxDepth: 1, strict: true);
+
+// No throw — the cap covers the whole required chain.
+AuthorFactory::new()->withRequiredParents(maxDepth: 9, strict: true)->save();
+```
+
+`strict` only fires when `maxDepth` actually truncates a *needed* parent: a
+boundary parent that still has its own required belongsTo not already composed
+(`configure()` / `->with()` / `->for()`), pinned, or excepted. It is a no-op
+without `maxDepth` (a full chain is never truncated), and it also restores an
+actionable message for a [cycle beyond the cap](#shared-primary-key-and-cyclic-graphs)
+instead of the generic save-time error. Default is `strict: false` — the
+silent contract above.
+
+`maxDepth` must be a positive integer or `null`. `0` or a negative value
+throws an `InvalidArgumentException` at call time — "compose zero required
+parents" is just not calling `withRequiredParents()`.
+
 ## Composes cleanly with the rest of the layer
 
 - An alias already composed as a **factory** —

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -1673,13 +1673,50 @@ abstract class BaseFactory
      * Note: a root table with an unsatisfiable required (NOT NULL) belongsTo
      * cycle raises a `FixtureFactoryException` — see the cycle handling below.
      *
+     * Depth: by default the whole NOT NULL chain is recursed. Pass `$maxDepth`
+     * to compose only the first N levels below the root (`1` = direct parents
+     * only). A cap below the real required depth yields an un-persistable row
+     * — the caller's responsibility, exactly like `$except`. This includes the
+     * cycle fast-fail: a required-parent cycle *beyond* the cap is not reached,
+     * so it surfaces as a save-time NOT NULL error rather than the
+     * `FixtureFactoryException`. A cycle *within* the cap still throws. Opt into
+     * `$strict` to turn that silent shortfall into an actionable exception at
+     * call time (it also restores an actionable message for a capped cycle).
+     *
      * @param array<int, string> $except Association aliases to skip.
+     * @param int|null $maxDepth Cap how many *levels* of required parents are
+     *   composed below the root. `null` (default) recurses the whole NOT NULL
+     *   chain. `1` composes only the root's direct required parents, `2` those
+     *   plus their parents, and so on. A cap below the real required depth can
+     *   produce an un-persistable row (a deeper NOT NULL FK left unsatisfied) —
+     *   by design, the caller's responsibility, exactly like `$except`.
+     * @param bool $strict When `true` and `$maxDepth` truncates the chain so a
+     *   composed boundary parent still has its own unsatisfied required
+     *   belongsTo, fail loudly at call time with an actionable
+     *   `FixtureFactoryException` instead of silently producing an
+     *   un-persistable row. Default `false` keeps the silent contract. A no-op
+     *   without `$maxDepth` (a full chain is never truncated).
+     *
+     * @throws \InvalidArgumentException When `$maxDepth` is provided but not at
+     *   least 1 — "compose zero required parents" is just not calling this.
+     *   `$strict` is set and `$maxDepth` leaves a required parent unsatisfied.
      *
      * @return static
      */
-    public function withRequiredParents(array $except = []): static
-    {
-        return $this->doWithRequiredParents($except, []);
+    public function withRequiredParents(
+        array $except = [],
+        ?int $maxDepth = null,
+        bool $strict = false,
+    ): static {
+        if ($maxDepth !== null && $maxDepth < 1) {
+            throw new InvalidArgumentException(sprintf(
+                'withRequiredParents() $maxDepth must be a positive integer or null, got %d. '
+                . 'To compose no required parents, simply do not call withRequiredParents().',
+                $maxDepth,
+            ));
+        }
+
+        return $this->doWithRequiredParents($except, [], $maxDepth, 0, $strict);
     }
 
     /**
@@ -1689,14 +1726,25 @@ abstract class BaseFactory
      *   unsatisfiable required-parent cycle (self-referential or
      *   `A -> B -> A` NOT NULL graphs) and fail fast with an actionable
      *   exception instead of recursing until the stack overflows.
+     * @param int|null $maxDepth Remaining recursion budget (see
+     *   {@see self::withRequiredParents()}); `null` is unbounded.
+     * @param int $depth Current level below the root (0 = root).
+     * @param bool $strict Throw when `$maxDepth` truncates the chain leaving a
+     *   composed boundary parent with its own unsatisfied required belongsTo.
      *
      * @throws \CakephpFixtureFactories\Error\FixtureFactoryException When a
-     *   required (NOT NULL) belongsTo cycle is detected.
+     *   required (NOT NULL) belongsTo cycle is detected, or when `$strict` and
+     *   the depth cap leaves a required parent unsatisfied.
      *
      * @return static
      */
-    private function doWithRequiredParents(array $except, array $visitedTables): static
-    {
+    private function doWithRequiredParents(
+        array $except,
+        array $visitedTables,
+        ?int $maxDepth,
+        int $depth,
+        bool $strict,
+    ): static {
         if ($this->readBootstrapMode) {
             return clone $this;
         }
@@ -1764,7 +1812,49 @@ abstract class BaseFactory
             // first level. `$except` is intentionally root-scoped: a deeper
             // level's required parents are always needed for that row to
             // persist regardless of what the caller pinned.
-            $parentFactory = $parentFactory->doWithRequiredParents([], $visitedTables);
+            //
+            // `maxDepth` caps how deep that recursion goes: the parent itself
+            // (at $depth + 1) is still composed below, but it is only enriched
+            // with ITS own required parents while that next level stays within
+            // the cap. Reaching the cap with a deeper NOT NULL FK unsatisfied
+            // is the caller's responsibility — same contract as `$except`.
+            if ($maxDepth === null || $depth + 1 < $maxDepth) {
+                $parentFactory = $parentFactory->doWithRequiredParents(
+                    [],
+                    $visitedTables,
+                    $maxDepth,
+                    $depth + 1,
+                    $strict,
+                );
+            } elseif ($strict) {
+                // The cap stops us recursing into $parentFactory. If that
+                // boundary parent still has a required belongsTo that is NOT
+                // already composed on it (configure()/with()/for()) and NOT
+                // pinned/excepted, the composed row cannot persist. Note a
+                // later recycle() cannot rescue it: recycle only substitutes
+                // *composed* branches, and the cap stopped that branch from
+                // being composed. Opt-in strictness turns that silent
+                // shortfall — and a capped cycle — into an actionable failure
+                // at call time.
+                $composedOnParent = $parentFactory->getAssociationBuilder()->getAssociations();
+                foreach ($parentFactory->resolveRequiredParentAliases([]) as $unmetAlias) {
+                    if (isset($composedOnParent[$unmetAlias])) {
+                        continue;
+                    }
+
+                    throw new FixtureFactoryException(sprintf(
+                        'withRequiredParents(maxDepth: %d, strict: true): the depth cap leaves the '
+                        . 'required belongsTo "%s" on table "%s" (reached via "%s") unsatisfied, so '
+                        . 'the composed row cannot persist. Raise maxDepth, pin or recycle that FK, '
+                        . 'add "%s" to $except, or drop strict to accept the silent contract.',
+                        $maxDepth,
+                        $unmetAlias,
+                        $parentFactory->getTable()->getTable(),
+                        $alias,
+                        $alias,
+                    ));
+                }
+            }
 
             // Compose the parent *factory* only — no persistence here. The
             // parent is built and saved as part of the root factory's own

--- a/tests/TestCase/Factory/BaseFactoryWithRequiredParentsTest.php
+++ b/tests/TestCase/Factory/BaseFactoryWithRequiredParentsTest.php
@@ -27,8 +27,10 @@ use CakephpFixtureFactories\Test\Factory\CountryFactory;
 use CakephpFixtureFactories\Test\Factory\RequiredParentsAuthorFactory;
 use CakephpFixtureFactories\Test\Factory\RequiredParentsOverrideAuthorFactory;
 use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
+use InvalidArgumentException;
 use ReflectionMethod;
 use TestApp\Test\Factory\AuthorFactory;
+use Throwable;
 
 /**
  * Behavioural tests for `BaseFactory::withRequiredParents()` — the ergonomic
@@ -613,5 +615,175 @@ class BaseFactoryWithRequiredParentsTest extends TestCase
 
         $this->assertNotNull($country->id);
         $this->assertSame(1, CountryFactory::query()->count());
+    }
+
+    /**
+     * `maxDepth: 1` composes only the root's *direct* required parents — the
+     * grandparent chain is intentionally not recursed into. The composed row
+     * may then be un-persistable (its own NOT NULL FK is unsatisfied); that is
+     * the caller's responsibility, exactly like `$except`.
+     */
+    public function testMaxDepthOneComposesOnlyDirectParentNotGrandparent(): void
+    {
+        $author = RequiredParentsAuthorFactory::new()
+            ->withRequiredParents(maxDepth: 1)
+            ->build();
+
+        $this->assertNotEmpty(
+            $author->address,
+            'maxDepth:1 still composes the direct required parent Address.',
+        );
+        $this->assertEmpty(
+            $author->address->city,
+            'maxDepth:1 must NOT recurse into the grandparent City.',
+        );
+    }
+
+    /**
+     * `maxDepth: 2` composes the root's parents and their parents, but stops
+     * before the third level. Here: Address + City, but not Country.
+     */
+    public function testMaxDepthTwoComposesTwoLevels(): void
+    {
+        $author = RequiredParentsAuthorFactory::new()
+            ->withRequiredParents(maxDepth: 2)
+            ->build();
+
+        $this->assertNotEmpty($author->address, 'Level 1 (Address) composed.');
+        $this->assertNotEmpty($author->address->city, 'Level 2 (City) composed.');
+        $this->assertEmpty(
+            $author->address->city->country,
+            'maxDepth:2 must NOT recurse into the third level (Country).',
+        );
+    }
+
+    /**
+     * Explicit `maxDepth: null` is the unbounded default: the whole NOT NULL
+     * chain is composed, identical to calling `withRequiredParents()`.
+     */
+    public function testMaxDepthNullComposesWholeChain(): void
+    {
+        $author = RequiredParentsAuthorFactory::new()
+            ->withRequiredParents(maxDepth: null)
+            ->build();
+
+        $this->assertNotEmpty($author->address, 'Address composed.');
+        $this->assertNotEmpty($author->address->city, 'City composed.');
+        $this->assertNotEmpty(
+            $author->address->city->country,
+            'maxDepth:null composes the whole chain down to Country.',
+        );
+    }
+
+    /**
+     * `maxDepth: 0` (or negative) is a confusing footgun — "compose zero
+     * required parents" is just not calling the method. Reject it loudly at
+     * call time instead of silently composing nothing.
+     */
+    public function testMaxDepthZeroThrowsInvalidArgument(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        RequiredParentsAuthorFactory::new()->withRequiredParents(maxDepth: 0);
+    }
+
+    /**
+     * A negative cap is equally nonsensical and rejected the same way.
+     */
+    public function testMaxDepthNegativeThrowsInvalidArgument(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        RequiredParentsAuthorFactory::new()->withRequiredParents(maxDepth: -1);
+    }
+
+    /**
+     * The documented `maxDepth` trap: capping below the real required depth
+     * produces a row whose own NOT NULL FK is unsatisfied, so `->save()`
+     * fails. This is the caller's responsibility (same contract as `$except`),
+     * and — being side-effect free — nothing leaks: no Author/Address row is
+     * written when the persist aborts.
+     */
+    public function testMaxDepthBelowRequiredDepthProducesUnpersistableRow(): void
+    {
+        $threw = false;
+        try {
+            RequiredParentsAuthorFactory::new()
+                ->withRequiredParents(maxDepth: 1)
+                ->save();
+        } catch (Throwable $e) {
+            $threw = true;
+        }
+
+        $this->assertTrue(
+            $threw,
+            'maxDepth:1 leaves Address.city_id (NOT NULL) unsatisfied, so save() must fail.',
+        );
+        $this->assertSame(0, AddressFactory::query()->count(), 'No Address leaked.');
+        $this->assertSame(
+            0,
+            RequiredParentsAuthorFactory::query()->count(),
+            'No Author leaked — composition is atomic.',
+        );
+    }
+
+    /**
+     * Opt-in `strict: true`: when `maxDepth` actually truncates the required
+     * chain — a composed boundary parent still has its own unsatisfied
+     * required belongsTo — fail loudly at call time with an actionable
+     * message instead of silently producing an un-persistable row.
+     */
+    public function testStrictThrowsWhenMaxDepthDropsANeededParent(): void
+    {
+        $this->expectException(FixtureFactoryException::class);
+        $this->expectExceptionMessage('maxDepth');
+
+        RequiredParentsAuthorFactory::new()
+            ->withRequiredParents(maxDepth: 1, strict: true);
+    }
+
+    /**
+     * `strict: true` is a no-op when the cap is deep enough to satisfy the
+     * whole required chain — no exception, full chain composed.
+     */
+    public function testStrictDoesNotThrowWhenCapCoversTheChain(): void
+    {
+        $author = RequiredParentsAuthorFactory::new()
+            ->withRequiredParents(maxDepth: 3, strict: true)
+            ->build();
+
+        $this->assertNotEmpty($author->address->city->country);
+    }
+
+    /**
+     * `strict: true` with no cap (full chain) never throws — there is no
+     * truncation to be strict about.
+     */
+    public function testStrictWithoutMaxDepthIsHarmless(): void
+    {
+        $author = RequiredParentsAuthorFactory::new()
+            ->withRequiredParents(strict: true)
+            ->save();
+
+        $this->assertNotNull($author->id);
+    }
+
+    /**
+     * `recycle()` cannot rescue a capped branch: recycle only substitutes
+     * *composed* belongsTo branches, and `maxDepth` stops the recycled
+     * table's branch from being composed at all. So `maxDepth` + a recycle
+     * for a beyond-cap table is genuinely un-persistable, and `strict`
+     * correctly reports it rather than being silenced by the recycle.
+     */
+    public function testStrictStillThrowsWhenRecycleCannotReachACappedBranch(): void
+    {
+        $country = CountryFactory::new()->save();
+
+        $this->expectException(FixtureFactoryException::class);
+        $this->expectExceptionMessage('maxDepth');
+
+        RequiredParentsAuthorFactory::new()
+            ->recycle($country)
+            ->withRequiredParents(maxDepth: 2, strict: true);
     }
 }


### PR DESCRIPTION
Stacked on `feature-with-required-parents` (PR #87). Adds two opt-in knobs to `withRequiredParents()` — the "easy to use, don't overload, stay transparent" follow-up discussed for that feature.

## What

- **`maxDepth`** — cap how many levels of required parents are composed below the root. `null` (default) recurses the whole `NOT NULL` chain unchanged; integer `N` composes only the first `N` levels; a non-positive value throws `InvalidArgumentException`. It caps the *auto-recursion* only — a composed parent factory's own `configure()` / `for()` defaults still apply (documented; this method targets bare strictDefinition-style factories).
- **`strict`** (opt-in, default `false`) — turn the silent "capped too shallow ⇒ un-persistable row" shortfall into an actionable `FixtureFactoryException` at call time. Fires only when the cap actually truncates a *needed* parent (a boundary parent whose own required belongsTo is not already composed, pinned, or excepted), and also restores an actionable message for a cycle beyond the cap.

Signature: `withRequiredParents(array $except = [], ?int $maxDepth = null, bool $strict = false)`.

## Design notes / review trail

- The `maxDepth` boundary stays **silent by default** — same contract as `$except`. A required-parent cycle beyond the cap therefore degrades from the fast-fail exception to a save-time `NOT NULL` error; documented, and recoverable via `strict`.
- A `recycle()` chained for a beyond-cap table **cannot** rescue the row (recycle only substitutes *composed* branches, and the cap stops that branch from being composed). `strict` correctly reports this rather than being silenced — locked by a regression test.
- A prune-at-recycled-tables idea was explored and **split out**: it surfaced a separate pre-existing recycle interaction better handled on its own; not in this PR.

## Verification

- `phpstan`: clean.
- `phpcs`: clean.
- `phpunit`: the full suite + this file were green during development (722 suite / 34 in-file). Final local re-run is currently **blocked by a repo-wide environment issue**, not this change: `cakephp-test-suite-light`'s sniffer trigger fires during the bootstrap migration's sqlite table-rebuild on a cold database, so `authors` never gets `json_field` and the suite errors out — the untouched target branch reproduces this identically. No local mysql/pgsql available to sidestep it.
- Opened as **draft**: relying on the GitHub CI matrix (sqlite / mysql / pgsql) as the authoritative green before un-drafting. Please do not merge until CI is green.

Docs updated in `docs/guide/required-parents.md` (the `$except` sibling section) and the method docblock.
