### PR TITLE
Fix: recycle() silently rebuilds a mid-chain required parent

### DIFF
--- a/docs/guide/required-parents.md
+++ b/docs/guide/required-parents.md
@@ -87,8 +87,11 @@ Without `recycle()`, each produced row gets its own full required chain, which
 is the correct default for independent fixtures. Note the cost is the *whole
 transitive chain* per row: `->count(50)` on a root three levels deep inserts
 50 × every level, not 50 rows. `recycle()` the shared table(s) when that matters
-— a recycled entity is substituted at every depth of the chain by table name,
-for the whole batch.
+— a recycled entity is substituted at **every depth** of the chain by table
+name, for the whole batch. This includes *mid-chain* parents, not just the
+leaf: recycling an intermediate required parent reuses it everywhere, because
+`withRequiredParents()`' auto-composition is treated as a default (not as
+explicit per-branch `with()` intent) and so never blocks recycle substitution.
 
 Two **distinct-alias** belongsTo that happen to target the same table (e.g.
 `Address` and `BusinessAddress`, both → `addresses`) each get their own parent

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -1780,8 +1780,16 @@ abstract class BaseFactory
                     continue;
                 }
                 $parentFactory = $existing;
+                // The caller composed this branch themselves (explicit
+                // ->with()/->for(), or a configure() default). Leave its
+                // classification untouched so recycle() keeps its documented
+                // "explicit per-branch intent wins" semantics.
+                $autoResolved = false;
             } else {
                 $parentFactory = $factory->getAssociationBuilder()->getAssociatedFactory($alias);
+                // We synthesized this parent solely to satisfy a NOT NULL FK:
+                // auto-scaffolding, not per-branch user intent.
+                $autoResolved = true;
             }
 
             // Only now — for an alias we would actually recurse into — reject
@@ -1845,8 +1853,10 @@ abstract class BaseFactory
                     throw new FixtureFactoryException(sprintf(
                         'withRequiredParents(maxDepth: %d, strict: true): the depth cap leaves the '
                         . 'required belongsTo "%s" on table "%s" (reached via "%s") unsatisfied, so '
-                        . 'the composed row cannot persist. Raise maxDepth, pin or recycle that FK, '
-                        . 'add "%s" to $except, or drop strict to accept the silent contract.',
+                        . 'the composed row cannot persist. Raise maxDepth, pin that FK, '
+                        . 'add "%s" to $except, or drop strict to accept the silent contract. '
+                        . '(recycle() cannot help here: the cap stopped this branch from being '
+                        . 'composed, and recycle only substitutes composed branches.)',
                         $maxDepth,
                         $unmetAlias,
                         $parentFactory->getTable()->getTable(),
@@ -1861,6 +1871,18 @@ abstract class BaseFactory
             // persist unit, so this stays side-effect free and atomic, and a
             // caller's recycle() still dedups the chain across a batch.
             $factory = $factory->with($alias, $parentFactory);
+
+            // An auto-resolved parent is scaffolding, not per-branch user
+            // intent. `with()` lands it in the explicit-association bucket
+            // (after configure() was already snapshotted), which would flip
+            // hasUserSetAssociations() and make recycle() refuse to substitute
+            // this node — silently rebuilding a mid-chain parent the caller
+            // recycle()d. Demote it to a configure()-style default so recycle
+            // substitution works at every depth, while a caller-composed
+            // branch keeps its intent.
+            if ($autoResolved) {
+                $factory->getDataCompiler()->demoteAssociationToDefault($alias);
+            }
         }
 
         return $factory;

--- a/src/Factory/DataCompiler.php
+++ b/src/Factory/DataCompiler.php
@@ -1103,6 +1103,38 @@ class DataCompiler
     }
 
     /**
+     * Reclassify a single association from an explicit user `with()`
+     * (`$dataFromAssociations`) to a `configure()`-style default
+     * (`$dataFromDefaultAssociations`).
+     *
+     * `withRequiredParents()` composes the required chain by calling
+     * `with()` *after* `configure()` has been snapshotted, so its
+     * auto-resolved parents would otherwise look like per-branch user intent
+     * and flip {@see self::hasUserSetAssociations()} — which makes
+     * {@see self::mergeWithToOne()} refuse to substitute a `recycle()`d row
+     * for that node. Auto-composition is not user intent, so demote it: the
+     * parent is still built, but recycle substitution works at every depth of
+     * the chain, exactly like a `configure()` default.
+     *
+     * No-op when the alias is not currently an explicit association.
+     *
+     * @internal
+     *
+     * @param string $associationName Association alias to reclassify.
+     *
+     * @return void
+     */
+    public function demoteAssociationToDefault(string $associationName): void
+    {
+        if (!isset($this->dataFromAssociations[$associationName])) {
+            return;
+        }
+
+        $this->dataFromDefaultAssociations[$associationName] = $this->dataFromAssociations[$associationName];
+        unset($this->dataFromAssociations[$associationName]);
+    }
+
+    /**
      * Whether the user (post-`configure()`) added any association overrides
      * via `with()` / `for()` / `has()` on this factory.
      *

--- a/tests/TestCase/Factory/BaseFactoryWithRequiredParentsTest.php
+++ b/tests/TestCase/Factory/BaseFactoryWithRequiredParentsTest.php
@@ -786,4 +786,38 @@ class BaseFactoryWithRequiredParentsTest extends TestCase
             ->recycle($country)
             ->withRequiredParents(maxDepth: 2, strict: true);
     }
+
+    /**
+     * Recycling a *mid-chain* required parent (not just the leaf) must reuse
+     * it, not silently rebuild it. `withRequiredParents()` auto-composes the
+     * chain; that auto-composition must not count as user `with()` intent and
+     * defeat recycle substitution for an intermediate node.
+     */
+    public function testRecyclingAMidChainParentReusesItAcrossBatch(): void
+    {
+        // A persisted City (with its own required Country) to share.
+        $city = CityFactory::new()->withRequiredParents()->save();
+        $this->assertSame(1, CityFactory::query()->count());
+        $this->assertSame(1, CountryFactory::query()->count());
+
+        $authors = RequiredParentsAuthorFactory::new()
+            ->count(4)
+            ->withRequiredParents()
+            ->recycle($city)
+            ->saveMany();
+
+        $this->assertCount(4, $authors);
+        $this->assertSame(
+            1,
+            CityFactory::query()->count(),
+            'The recycled mid-chain City must be reused by every row, not rebuilt.',
+        );
+        $this->assertSame(
+            1,
+            CountryFactory::query()->count(),
+            'No extra Country built behind a duplicated City.',
+        );
+        // Addresses still fan out (Address was not recycled).
+        $this->assertSame(4, AddressFactory::query()->count());
+    }
 }


### PR DESCRIPTION
## Problem

Recycling a **mid-chain** required parent silently produced duplicate rows.

`withRequiredParents()` composes the required `NOT NULL` chain by calling `with()` — but that runs *after* `configure()` has been snapshotted into the default-association bucket, so every auto-resolved parent landed in the *explicit* bucket and flipped `hasUserSetAssociations()`. `DataCompiler::mergeWithToOne()`'s recycle guard (`!$factory->hasUserSetAssociations()`) then refused to substitute a `recycle()`d row for that node, **silently rebuilding** the recycled mid-chain parent and its sub-chain. No error, structurally valid, semantically wrong data.

Only recycling a chain **leaf** (e.g. `Country`) worked, because a leaf has no parents to enrich. The guide (`required-parents.md`) explicitly promised *"substituted at every depth of the chain"* — which was false for any non-leaf.

Reproduction (now a regression test):

```php
$city = CityFactory::new()->withRequiredParents()->save(); // 1 City, 1 Country
RequiredParentsAuthorFactory::new()->count(4)
    ->withRequiredParents()->recycle($city)->saveMany();
// before: 5 Cities (1 recycled + 4 rebuilt). after: 1 City, 1 Country.
```

## Fix

Auto-resolved parents are scaffolding, not per-branch user intent. After `withRequiredParents()` attaches an auto-resolved parent, demote it from the explicit bucket to a `configure()`-style default (new internal `DataCompiler::demoteAssociationToDefault()`), so recycle substitution works at **every depth** — while a caller-composed branch (explicit `->with()`/`->for()`, or an entity) keeps its intent and still blocks recycle as documented.

Also:
- The `strict`-mode exception no longer suggests `recycle()` for a *capped* (uncomposed) branch, where recycle genuinely cannot help — it explains why.
- `required-parents.md` documents that mid-chain recycle works (was the false claim; the fix makes it true).

## Verification

- Full suite green (724 tests, 2512 assertions, 0 failures; 11 pre-existing sqlite skips).
- New regression test `testRecyclingAMidChainParentReusesItAcrossBatch`; existing leaf-recycle, `maxDepth`/`strict`, and `BaseFactoryRecycleTest` all still green.
- phpstan clean, phpcs clean.

Targets `main` (the `withRequiredParents` + `maxDepth`/`strict` stack is already merged there).
