### PR TITLE
Docs: upgrade notes for the sequence() and has() breaking changes

### DIFF
--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -23,6 +23,27 @@ If you're still on `1.3.x`, upgrade to `1.4.x` first, then move to v2.
 - **DummyGenerator backend now requires `johnykvsky/dummygenerator:^0.2.1`** (was `^0.1.0 || ^0.2.0`). v0.1.x is removed entirely — the deprecation notice the adapter used to emit on every test boot is gone, the legacy `DefinitionContainerBuilder` code path with it. The v2 adapter only constructs `DummyGenerator::create()` and calls `withDefinition(RandomizerInterface::class, new XoshiroRandomizer($seed))` directly. Tied to that: v2 now forwards the `optional()` float weight to `boolean()` directly (added in v0.2.1), so weights below 0.005 — e.g. `optional(0.001)` for 0.1% chance — fire at the requested rate instead of silently rounding to 0%. Projects on `^0.2.0` need to bump to `^0.2.1` (a patch release); projects still on `^0.1.x` need to upgrade to `^0.2.1`.
 - **`enumElement()` alias is removed.** The Faker-specific name was a back-compat alias for `enumCase()`; both adapters now expose only `enumCase()` (returns the case) and `enumValue()` (returns the backed-enum scalar). The `trigger_error(E_USER_DEPRECATED)` the dummy adapter used to emit on every `enumElement()` call under `debug = true` is gone with it. Callers that still use `enumElement(EnumClass::class)` should rename to `enumCase(EnumClass::class)` — the bundled rector config does not rewrite this rename, so it's a manual one-line change per call site.
 - **Foreign-key columns in `definition()` now emit `E_USER_DEPRECATED`.** Any factory whose `definition()` returns a column belonging to a belongsTo association (e.g. returning `author_id` from `definition()`) triggers a deprecation that names the column, the association alias, and the migration path. The smell either creates dangling ids (no parent composed) or silently overrides the composed parent's id with a random value — both shapes mask the real source of the FK. See the [Foreign keys in definition()](foreign-keys-in-definition.md) guide for the full rationale and a migration cookbook. The detector is on by default; opt out transitionally with `Configure::write('FixtureFactories.strictDefinition', false)` while you migrate. The opt-out is removed in the next major release, when the deprecation graduates to a hard exception.
+- **`sequence()` callables now receive a single `Sequence` context object (BREAKING, no fallback).** The old positional `fn ($factory, $generator, int $index)` form no longer works — it fails with a `Sequence` vs `BaseFactory` type error. Rewrite the closure to take one `Sequence $s` and read what you need off it (`$s->index` 0-based, `$s->position` 1-based, `$s->total`, `$s->isFirst()`, `$s->isLast()`, `$s->generator`, `$s->factory`):
+
+  ```diff
+  -use CakephpFixtureFactories\Factory\Sequence;
+  -
+   ArticleFactory::new()->count(5)
+  -    ->sequence(fn ($factory, $generator, $index) => ['rank' => $index])
+  +    ->sequence(fn (Sequence $s) => ['rank' => $s->index])
+       ->saveMany();
+  ```
+
+  The Rector config does **not** rewrite this — it's a manual change per call site. See [Examples](examples.md) for the full `Sequence` surface.
+- **`has()`'s second argument is now `?string $alias`; pivot data moves to the third position (BREAKING).** `for()` and `has()` gained an optional `$alias` to disambiguate multiple associations targeting the same table. For `has()` this shifts the pivot array: `->has($factory, ['featured' => true])` no longer compiles (the array is bound to `?string $alias`). Pass the alias (or `null`) first, or use a named argument:
+
+  ```diff
+  - CountryFactory::new()->has(CityFactory::new(), ['is_capital' => true])
+  + CountryFactory::new()->has(CityFactory::new(), null, ['is_capital' => true])
+  + // or: ->has(CityFactory::new(), pivotData: ['is_capital' => true])
+  ```
+
+  `for()` is unaffected (it took no pivot arg); passing `$alias` is purely additive there. With `$alias = null` both helpers behave exactly as before (auto-resolve by table). See [Associations](associations.md#disambiguating-for-and-has).
 
 For the v2 step, the package ships a Rector config to help with the mechanical API rename work:
 


### PR DESCRIPTION
## Why

Two BREAKING changes shipped to `main` with no migration note in the upgrade guide — the project requires user-facing breaks to ship docs alongside.

- **`sequence()` single-arg `Sequence` switch** — the old `fn ($factory, $generator, $index)` form now fails with a `Sequence` vs `BaseFactory` type error. No fallback, not Rector-rewritten.
- **`has()` pivot-position shift** — `has()`'s 2nd arg is now `?string $alias`; `->has($f, ['featured' => true])` no longer compiles (the array binds to `$alias`).

Neither had an entry in `docs/guide/upgrading.md`'s "Behavior changes since 1.4.x" list; a user upgrading hits a confusing TypeError/mis-bind with nowhere to look.

## What

Adds two bullets (matching the existing style) with before/after `diff` snippets and cross-links to the Examples / Associations pages. Verified the cross-doc anchors resolve (`associations.md#disambiguating-for-and-has`).

Docs-only; no code change. Targets `main`.
