### PR TITLE
Fix: FK-column cache never invalidated on runtime association changes

### DIFF
--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -1421,7 +1421,44 @@ abstract class BaseFactory
      */
     public static function collectForeignKeyColumns(Table $table): array
     {
-        $cacheKey = $table->getRegistryAlias();
+        // The registry alias alone is NOT a sufficient cache key: it is a
+        // hash of table + connection + behaviors + events and does NOT change
+        // when a belongsTo is added/removed/replaced on the table at runtime.
+        // Fold a lightweight signature of the belongsTo set (alias + foreign
+        // key) into the key so a runtime association change recomputes the
+        // map instead of serving a stale one to the detector and the
+        // build-time auto-skip. Building the signature is cheap (no schema /
+        // condition introspection — that stays behind the cache).
+        $belongsToSignature = [];
+        foreach ($table->associations() as $association) {
+            if (!$association instanceof BelongsTo) {
+                continue;
+            }
+            $part = $association->getAlias()
+                . ':' . implode(',', (array)$association->getForeignKey());
+            // For a foreignKey => false custom join the protected columns are
+            // recovered from `conditions`, not the (absent) foreign key — so
+            // the key must also track the conditions, or replacing the same
+            // alias with a different join keeps a stale map. Array conditions
+            // are folded in; opaque Closure/expression conditions recover no
+            // columns anyway, so they need no signature contribution.
+            if ($association->getForeignKey() === false) {
+                $conditions = $association->getConditions();
+                if (is_array($conditions)) {
+                    try {
+                        $part .= ':' . md5(serialize($conditions));
+                    } catch (Throwable) {
+                        // Unserializable (e.g. a Closure inside the array):
+                        // force a cache miss rather than risk a stale hit.
+                        $part .= ':' . uniqid('', true);
+                    }
+                }
+            }
+            $belongsToSignature[] = $part;
+        }
+        sort($belongsToSignature);
+        $cacheKey = $table->getRegistryAlias()
+            . '#' . md5(implode('|', $belongsToSignature));
         if (isset(self::$fkColumnsByRegistry[$cacheKey])) {
             return self::$fkColumnsByRegistry[$cacheKey];
         }

--- a/tests/TestCase/Factory/BaseFactoryForeignKeyDetectionTest.php
+++ b/tests/TestCase/Factory/BaseFactoryForeignKeyDetectionTest.php
@@ -250,4 +250,35 @@ class BaseFactoryForeignKeyDetectionTest extends TestCase
         $this->assertArrayNotHasKey(0, $map);
         $this->assertSame([], $map, 'Filter-only and Closure conditions must contribute no columns.');
     }
+
+    /**
+     * The FK-column map is cached per table, but the cache key must reflect
+     * the table's belongsTo set: a belongsTo added (or changed) at runtime
+     * after the first call has to be picked up, otherwise the detector and
+     * the build-time auto-skip both consult a stale map. Without this the
+     * only escape is the process-wide reset() — fragile and order-dependent.
+     */
+    public function testForeignKeyColumnCacheReflectsRuntimeAssociationChanges(): void
+    {
+        $table = new Table(['table' => 'cities', 'alias' => 'FkCacheProbe']);
+        $table->belongsTo('Countries', ['foreignKey' => 'country_id']);
+
+        $first = BaseFactory::collectForeignKeyColumns($table);
+        $this->assertSame(['country_id' => 'Countries'], $first);
+
+        // A belongsTo registered AFTER the cached call must be reflected
+        // (no manual resetForeignKeyInDefinitionDetector() in between).
+        $table->belongsTo('LateRegion', [
+            'className' => 'Countries',
+            'foreignKey' => 'late_region_id',
+        ]);
+        $second = BaseFactory::collectForeignKeyColumns($table);
+
+        $this->assertArrayHasKey(
+            'late_region_id',
+            $second,
+            'FK-column cache must invalidate when the belongsTo set changes at runtime.',
+        );
+        $this->assertSame('LateRegion', $second['late_region_id']);
+    }
 }

--- a/tests/TestCase/Factory/BaseFactoryWithRequiredParentsTest.php
+++ b/tests/TestCase/Factory/BaseFactoryWithRequiredParentsTest.php
@@ -441,9 +441,21 @@ class BaseFactoryWithRequiredParentsTest extends TestCase
             'conditions' => ['Authors.name = GhostCountry.name'],
         ]);
 
-        $author = $factory
-            ->withRequiredParents()
-            ->save();
+        // This test exercises withRequiredParents()'s handling of a
+        // foreignKey => false join, not the FK-in-definition() detector. The
+        // contrived `Authors.name = GhostCountry.name` join makes `name`
+        // (a real definition() data field) double as the recovered join
+        // column, so strictDefinition would correctly — but irrelevantly —
+        // flag it here. Isolate from the detector.
+        $strict = Configure::read('FixtureFactories.strictDefinition');
+        Configure::write('FixtureFactories.strictDefinition', false);
+        try {
+            $author = $factory
+                ->withRequiredParents()
+                ->save();
+        } finally {
+            Configure::write('FixtureFactories.strictDefinition', $strict);
+        }
 
         $this->assertNotNull($author->id, 'Build still succeeds.');
         // Only the legitimate required chain built a Country (via City);


### PR DESCRIPTION
## Problem

`BaseFactory::collectForeignKeyColumns()` cached the FK → alias map keyed **only** on `$table->getRegistryAlias()`. That alias is a hash of table + connection + behaviors + events — it does **not** change when a `belongsTo` is added, removed, or replaced on the table at runtime. So the cached map went stale and was served to **both** consumers: the FK-in-`definition()` detector (`strictDefinition`) and the build-time auto-skip in `DataCompiler`.

The only mitigation was the process-wide `resetForeignKeyInDefinitionDetector()`, called from a single test class — fragile, order-dependent, and not available in production.

## Fix

Fold a lightweight signature of the belongsTo set into the cache key:
- `alias + foreignKey` for ordinary associations, plus
- the serialized `conditions` for `foreignKey => false` custom joins (their columns are recovered from conditions, so a conditions change must invalidate too — caught a residual hole in review).

A runtime association change now recomputes; the expensive schema / condition extraction stays behind the cache for the steady state.

## Notable

Fixing detection **unmasked** a real-but-irrelevant deprecation in `testForeignKeyFalseCustomJoinIsNotAutoResolved`: its contrived `Authors.name = GhostCountry.name` join makes `name` (a genuine `definition()` data field) double as the recovered join column, so `strictDefinition` correctly flagged it. That test exercises `withRequiredParents()`, not the detector, so it now isolates from `strictDefinition` (with `try/finally`). This is the bug working-as-intended once the stale cache no longer hides it.

## Verification

- New regression test `testForeignKeyColumnCacheReflectsRuntimeAssociationChanges` (RED before, GREEN after).
- Full suite: **725 tests, 2515 assertions, 0 failures, 0 deprecations** (11 pre-existing sqlite skips).
- phpstan clean, phpcs clean, codex clean (its P2 — conditions in the key — is addressed).

Targets `main`. Addresses the deferred P2 (process-wide FK-cache invalidation) from the recent deep-dive.
