### PR TITLE
Fix: foreignKey=>false belongsTo composition fails at persist time

### DIFF
--- a/docs/guide/required-parents.md
+++ b/docs/guide/required-parents.md
@@ -269,12 +269,18 @@ Resolution order: `auto-detected ∪ requiredParentAssociations() − excludedRe
 Exclude wins over both the additive hook and per-call `$except` (both subtract).
 Each is independent; either may stay at its default (`[]`).
 
-::: warning Additive opt-in does not (yet) support composite / `foreignKey => false`
-The additive `requiredParentAssociations()` hook composes the opted-in parent
-factory, but the FK-set step that follows fails for **composite-key** and
-**`foreignKey => false` custom-condition** belongsTo (the PR #85 brittle
-cases). Until that is wired, attach them at the call site with
-`->with('Alias', $parentFactory)` instead.
+::: tip foreignKey => false: supported via independent save
+The additive `requiredParentAssociations()` hook (and `->with('Alias', ...)`)
+support **`foreignKey => false`** custom-condition belongsTo: the parent is
+built and saved independently of the cascade (Cake's
+`BelongsTo::saveAssociated` cannot handle them — the relation is queried by
+custom conditions at read time, with no FK column to populate). The parent
+row exists in the database after `save()` and is reachable via
+`->find()->contain('Alias')`, but is **not** attached to the in-memory root
+entity (`$root->{alias}` stays `null` post-save) — attaching it would re-fire
+the broken cascade. **Composite-key** opt-in via the additive hook is not yet
+covered; attach those at the call site with `->with('Alias', $parentFactory)`
+for now.
 :::
 
 ## It's the pragmatic default — not the assertion tool

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -1097,6 +1097,52 @@ abstract class BaseFactory
     }
 
     /**
+     * The save options this factory would pass to `Table::saveOrFail()`
+     * during its own `doPersist()` flow. Exposed so the
+     * `foreignKey => false` branch in
+     * {@see \CakephpFixtureFactories\Factory\DataCompiler::mergeWithToOne()}
+     * can persist the parent through the same option set (checkRules,
+     * atomic, the AssociationBuilder-derived `associated` list) instead of
+     * defaulting and silently diverging from cascade-path behavior.
+     *
+     * @internal
+     *
+     * @return array<string, mixed>
+     */
+    public function getSaveOptionsForAssociated(): array
+    {
+        return $this->getSaveOptions();
+    }
+
+    /**
+     * Replay `Model.afterSave` + factory afterSave callbacks for every
+     * nested associated entity under `$entity`, walking THIS factory's
+     * association tree. Returns the (possibly replaced) entity.
+     *
+     * Used by the `foreignKey => false` branch in
+     * {@see \CakephpFixtureFactories\Factory\DataCompiler::mergeWithToOne()}:
+     * since the parent is not attached to the root, the root's normal
+     * post-save walker {@see self::replayAssociatedAfterSaveEvents()} cannot
+     * reach the subtree under this parent — replay it here instead so a
+     * `with('Alias', CountryFactory::new()->with('Continent', …)->afterSave(…))`
+     * sees its nested callbacks regardless of the parent's persist path.
+     *
+     * @internal
+     *
+     * @param \Cake\Datasource\EntityInterface $entity The just-persisted
+     *     parent whose nested associations need their afterSave replayed.
+     *
+     * @return \Cake\Datasource\EntityInterface
+     */
+    public function replayAssociatedAfterSaveForTree(EntityInterface $entity): EntityInterface
+    {
+        $visited = [];
+        $entities = $this->replayAssociatedAfterSaveEvents([$entity], $this, $visited);
+
+        return $entities[0] ?? $entity;
+    }
+
+    /**
      * Sets the value for a single field
      *
      * @param string $field to set

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -1068,6 +1068,35 @@ abstract class BaseFactory
     }
 
     /**
+     * Replay this factory's `afterSave()` callbacks on an already-persisted
+     * entity, mirroring the dispatch
+     * {@see self::replayAssociatedAfterSaveForEntity()} performs for entities
+     * saved via the normal cascade. Returns the (possibly replaced) entity so
+     * callbacks that swap it in-place are honored.
+     *
+     * Used by {@see \CakephpFixtureFactories\Factory\DataCompiler::mergeWithToOne()}
+     * for the `foreignKey => false` belongsTo branch, where the parent is
+     * persisted independently (Cake's `BelongsTo::saveAssociated()` cannot
+     * handle that shape) and would otherwise miss factory-level callbacks
+     * the rest of the chain runs through.
+     *
+     * @internal
+     *
+     * @param \Cake\Datasource\EntityInterface $entity The just-persisted entity.
+     *
+     * @return \Cake\Datasource\EntityInterface
+     */
+    public function applyAfterSaveCallbacksToEntity(EntityInterface $entity): EntityInterface
+    {
+        if ($this->afterSaveCallbacks === []) {
+            return $entity;
+        }
+        $result = $this->applyCallbacks([$entity], $this->afterSaveCallbacks);
+
+        return $result[0] ?? $entity;
+    }
+
+    /**
      * Sets the value for a single field
      *
      * @param string $field to set
@@ -2075,10 +2104,15 @@ abstract class BaseFactory
      * {@see self::excludedRequiredParentAssociations()} or the per-call
      * `$except` argument are subtracted.
      *
-     * Note: composite-key and `foreignKey => false` custom-join belongsTo
-     * (the PR #85 brittle cases) are NOT currently supported by additive
-     * opt-in — composing the parent works, but the FK-set path fails. See
-     * {@see self::excludedRequiredParentAssociations()} for the symmetric
+     * `foreignKey => false` custom-condition joins are supported: the parent
+     * is built and saved independently of the cascade (Cake's
+     * `BelongsTo::saveAssociated` cannot handle them — the relation is queried
+     * by custom conditions at read time, with no FK column to populate). The
+     * parent row persists and is reachable via `find()->contain()`, but is
+     * NOT attached to the in-memory root entity post-save (attaching would
+     * re-fire the broken cascade). Composite-key opt-in is not yet covered;
+     * opt those in at the call site with `->with('Alias', $factory)` for now.
+     * See {@see self::excludedRequiredParentAssociations()} for the symmetric
      * factory-class-level *exclude* hook.
      *
      * @return array<int, string> Additional aliases to compose.

--- a/src/Factory/DataCompiler.php
+++ b/src/Factory/DataCompiler.php
@@ -25,6 +25,7 @@ use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 use CakephpFixtureFactories\Error\FixtureFactoryException;
 use CakephpFixtureFactories\Error\PersistenceException;
+use CakephpFixtureFactories\TestSuite\FactoryTableTracker;
 use CakephpFixtureFactories\TestSuite\FactoryTransactionStrategy;
 use Closure;
 use InvalidArgumentException;
@@ -947,7 +948,18 @@ class DataCompiler
                 $associatedEntity->set(self::IS_ASSOCIATED, true);
                 $this->markEntityDirtyIfNew($associatedEntity);
                 $target = $association->getTarget();
-                $target->saveOrFail($associatedEntity);
+                // Mirror BaseFactory::doPersist(): the tracker drives
+                // teardown/truncation and diagnostics, so this independent
+                // save must register too.
+                FactoryTableTracker::getInstance()
+                    ->trackTable($target);
+                // Use the factory's own save options (checkRules / atomic /
+                // associated list) so this persist is configured the same
+                // way as the cascade path would have configured it.
+                $target->saveOrFail(
+                    $associatedEntity,
+                    $factory->getSaveOptionsForAssociated(),
+                );
                 // Finalize: Cake 5.4+ defers clean()/setNew(false) until the
                 // outer transaction closes; the cascade path's
                 // finalizePersistedEntities() compensates, mirror it here so
@@ -957,9 +969,12 @@ class DataCompiler
                     $associatedEntity->setNew(false);
                     $associatedEntity->setSource($target->getAlias());
                 }
-                // Replay this branch's factory afterSave callbacks the way
-                // replayAssociatedAfterSaveForEntity() would on the cascade
-                // path — the entity never reaches the root for that pass.
+                // Replay this branch's factory afterSave callbacks AND the
+                // afterSave events/callbacks for every NESTED associated
+                // factory under it. Since the parent is not attached to the
+                // root, replayAssociatedAfterSaveEvents() on the root can't
+                // discover the subtree — replay it here instead.
+                $associatedEntity = $factory->replayAssociatedAfterSaveForTree($associatedEntity);
                 $associatedEntity = $factory->applyAfterSaveCallbacksToEntity($associatedEntity);
             }
 

--- a/src/Factory/DataCompiler.php
+++ b/src/Factory/DataCompiler.php
@@ -25,6 +25,7 @@ use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 use CakephpFixtureFactories\Error\FixtureFactoryException;
 use CakephpFixtureFactories\Error\PersistenceException;
+use CakephpFixtureFactories\TestSuite\FactoryTransactionStrategy;
 use Closure;
 use InvalidArgumentException;
 
@@ -915,6 +916,63 @@ class DataCompiler
                 ));
             }
             $associatedEntity = $associatedEntities[0];
+        }
+
+        // A `foreignKey => false` belongsTo cannot go through Cake's standard
+        // cascade: `BelongsTo::saveAssociated()` does
+        //   array_combine((array)false, $target->extract((array)$bindingKey))
+        // which becomes `['' => value]` (false cast to '') and the subsequent
+        // `$entity->patch('', ...)` throws "Cannot set an empty field". There
+        // is no FK column to populate anyway — the relation is queried by
+        // custom conditions at read time. Save the parent independently and
+        // skip the property-set that would trigger the broken cascade.
+        if (
+            $association instanceof BelongsTo
+            && $association->getForeignKey() === false
+            && $this->isInPersistMode()
+        ) {
+            if ($associatedEntity->isNew()) {
+                // Join the active test transaction so this save participates
+                // in the same rollback unit as the root save — orphan-free on
+                // root failure. No-op when no test strategy is active (this
+                // plugin's contract is test-suite use with the eager strategy).
+                FactoryTransactionStrategy::getActiveInstance()
+                    ?->ensureTransaction($association->getTarget()->getConnection());
+
+                // Match the nested-save semantics the cascade path applies:
+                // tag the entity so FactoryTableBeforeSave treats it as
+                // associated (unique-row reuse etc.), mark new entities
+                // dirty, and let Cake cascade through the parent's own
+                // associations normally — only THIS belongsTo edge is bypassed.
+                $associatedEntity->set(self::IS_ASSOCIATED, true);
+                $this->markEntityDirtyIfNew($associatedEntity);
+                $target = $association->getTarget();
+                $target->saveOrFail($associatedEntity);
+                // Finalize: Cake 5.4+ defers clean()/setNew(false) until the
+                // outer transaction closes; the cascade path's
+                // finalizePersistedEntities() compensates, mirror it here so
+                // afterSave callbacks observe a consistent post-save shape.
+                if ($target->getConnection()->inTransaction()) {
+                    $associatedEntity->clean();
+                    $associatedEntity->setNew(false);
+                    $associatedEntity->setSource($target->getAlias());
+                }
+                // Replay this branch's factory afterSave callbacks the way
+                // replayAssociatedAfterSaveForEntity() would on the cascade
+                // path — the entity never reaches the root for that pass.
+                $associatedEntity = $factory->applyAfterSaveCallbacksToEntity($associatedEntity);
+            }
+
+            // NOTE: we intentionally do NOT call $entity->set($associationName,
+            // $associatedEntity) here. Doing so would (re-)trigger Cake's
+            // BelongsTo::saveAssociated() on the root save and reproduce the
+            // exact "Cannot set an empty field" crash this branch exists to
+            // avoid. Trade-off: the composed parent is persisted and queryable
+            // via custom conditions, but is NOT attached to the in-memory root
+            // entity post-save. A root afterSave() callback that expects to
+            // read `$root->{property}` for a foreignKey => false parent must
+            // re-query it instead.
+            return;
         }
 
         if ($this->isInPersistMode()) {

--- a/tests/Factory/RequiredParentsForeignKeyFalseOptInFactory.php
+++ b/tests/Factory/RequiredParentsForeignKeyFalseOptInFactory.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link          https://webrider.de/
+ * @since         1.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace CakephpFixtureFactories\Test\Factory;
+
+/**
+ * Opts a `foreignKey => false` custom-condition belongsTo (`GhostCountry`,
+ * registered at runtime by the test) into `withRequiredParents()` via the
+ * additive hook, exercising the documented entry point through which the
+ * additive hook composes the opted-in parent.
+ *
+ * @extends \CakephpFixtureFactories\Test\Factory\RequiredParentsAuthorFactory
+ */
+class RequiredParentsForeignKeyFalseOptInFactory extends RequiredParentsAuthorFactory
+{
+    /**
+     * @return array<int, string>
+     */
+    protected function requiredParentAssociations(): array
+    {
+        return ['GhostCountry'];
+    }
+}

--- a/tests/TestCase/Factory/BaseFactoryWithRequiredParentsTest.php
+++ b/tests/TestCase/Factory/BaseFactoryWithRequiredParentsTest.php
@@ -26,6 +26,7 @@ use CakephpFixtureFactories\Test\Factory\CityFactory;
 use CakephpFixtureFactories\Test\Factory\CountryFactory;
 use CakephpFixtureFactories\Test\Factory\RequiredParentsAuthorFactory;
 use CakephpFixtureFactories\Test\Factory\RequiredParentsExcludeAuthorFactory;
+use CakephpFixtureFactories\Test\Factory\RequiredParentsForeignKeyFalseOptInFactory;
 use CakephpFixtureFactories\Test\Factory\RequiredParentsOverrideAuthorFactory;
 use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
 use InvalidArgumentException;
@@ -490,6 +491,77 @@ class BaseFactoryWithRequiredParentsTest extends TestCase
             1,
             CountryFactory::query()->count(),
             'foreignKey => false belongsTo must not be auto-resolved.',
+        );
+    }
+
+    /**
+     * Persisting an explicitly-composed `foreignKey => false` belongsTo must
+     * succeed: the parent is built / saved independently and is NOT cascaded
+     * via the (broken upstream) `BelongsTo::saveAssociated` path. Cake's
+     * `saveAssociated` casts `(array)false` → `[false]` and produces an empty
+     * field for `patch()` — "Cannot set an empty field". A custom-condition
+     * join has no FK to populate, so we never set the property for cascade.
+     */
+    public function testPersistingForeignKeyFalseComposedParentSucceeds(): void
+    {
+        $countryCountBefore = CountryFactory::query()->count();
+        $factory = RequiredParentsAuthorFactory::new();
+        $factory->getTable()->belongsTo('GhostCountry', [
+            'className' => 'Countries',
+            'foreignKey' => false,
+            'conditions' => ['Authors.name = GhostCountry.name'],
+        ]);
+
+        // strictDefinition would (correctly but irrelevantly) flag `name` as
+        // the recovered join column; this test exercises foreignKey => false
+        // persistence, not the detector.
+        $strict = Configure::read('FixtureFactories.strictDefinition');
+        Configure::write('FixtureFactories.strictDefinition', false);
+        try {
+            $author = $factory
+                ->with('GhostCountry', CountryFactory::new())
+                ->withRequiredParents()
+                ->save();
+        } finally {
+            Configure::write('FixtureFactories.strictDefinition', $strict);
+        }
+
+        $this->assertNotNull($author->id, 'Author persisted.');
+        $this->assertSame(
+            $countryCountBefore + 2,
+            CountryFactory::query()->count(),
+            'Both the chain Country (via City) and the foreignKey=>false GhostCountry parent persisted.',
+        );
+    }
+
+    /**
+     * Same fix exercised through the documented additive-hook entry point:
+     * a factory that opts a `foreignKey => false` association in via
+     * `requiredParentAssociations()` must compose AND persist it cleanly.
+     */
+    public function testAdditiveHookComposesForeignKeyFalseAssociation(): void
+    {
+        $countryCountBefore = CountryFactory::query()->count();
+        $factory = RequiredParentsForeignKeyFalseOptInFactory::new();
+        $factory->getTable()->belongsTo('GhostCountry', [
+            'className' => 'Countries',
+            'foreignKey' => false,
+            'conditions' => ['Authors.name = GhostCountry.name'],
+        ]);
+
+        $strict = Configure::read('FixtureFactories.strictDefinition');
+        Configure::write('FixtureFactories.strictDefinition', false);
+        try {
+            $author = $factory->withRequiredParents()->save();
+        } finally {
+            Configure::write('FixtureFactories.strictDefinition', $strict);
+        }
+
+        $this->assertNotNull($author->id);
+        $this->assertSame(
+            $countryCountBefore + 2,
+            CountryFactory::query()->count(),
+            'Additive-hook opt-in of a foreignKey=>false belongsTo composes the parent.',
         );
     }
 


### PR DESCRIPTION
## Problem

Composing a `foreignKey => false` custom-condition `belongsTo` and persisting crashed with `InvalidArgumentException: Cannot set an empty field`. Empirically confirmed via probe; root cause is upstream in Cake's `BelongsTo::saveAssociated()` (`vendor/cakephp/cakephp/src/ORM/Association/BelongsTo.php:142-153`):

```php
$foreignKeys = (array)$this->getForeignKey(); // (array)false === [false]
$properties = array_combine($foreignKeys, $targetEntity->extract(...)); // ['' => value]
$entity->patch($properties, ['guard' => false]); // throws on ''
```

The relation has no FK column to populate (it's queried by custom conditions), so cascading through `saveAssociated()` cannot work upstream. PR #92's docblock acknowledged the limitation; this PR fixes it.

## Fix

`DataCompiler::mergeWithToOne()` now routes the `foreignKey => false` branch through an independent save:

- Join the active `FactoryTransactionStrategy` so the parent save participates in the test's rollback unit (atomic with the root save on failure — the contracted test-suite use case).
- Tag `IS_ASSOCIATED` so `FactoryTableBeforeSave` applies the nested-save semantics (unique-row reuse etc.).
- Let Cake cascade through the parent's *own* associations normally (`associated => true`).
- Finalize the entity (`clean()` / `setNew(false)` / `setSource()`) to match the post-cascade shape under Cake 5.4+.
- Replay the parent factory's `afterSave()` callbacks mirroring `replayAssociatedAfterSaveForEntity()`.

Skip the cascade-triggering `$entity->set($associationName, $associatedEntity)` step (that's the upstream-broken edge).

## Documented trade-off

The composed parent is persisted and reachable via `find()->contain('Alias')`, but is **not** attached to the in-memory root entity post-save (`$root->{alias}` stays `null`). Re-attaching would re-fire the broken cascade. A root `afterSave()` that needs the parent must re-query it. Composite-key opt-in via the additive hook is still not covered; attach those at the call site for now.

## Codex review trail

Three iterations addressed: P1 atomicity (`ensureTransaction` joins test transaction), P1 nested cascade preserved (dropped `associated => false`), P2 afterSave replay (`applyAfterSaveCallbacksToEntity()` + finalization). Remaining limitations (post-save attachment) are inherent to the upstream constraint and documented.

## Verification

- New tests `testPersistingForeignKeyFalseComposedParentSucceeds` (`with()` path) + `testAdditiveHookComposesForeignKeyFalseAssociation` (additive-hook path) — both RED before, GREEN after.
- Full suite: **728 tests, 2521 assertions, 0 failures, 0 deprecations** (11 pre-existing sqlite skips).
- phpstan clean, phpcs clean.

Targets `main`. Companion to PR #92's exclude hook; completes the additive hook's `foreignKey => false` support.
