### PR TITLE
Fix two transaction-lifecycle P1s: rollback cascade + cross-connection finalize

### DIFF
--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -764,10 +764,15 @@ abstract class BaseFactory
      */
     private function finalizePersistedEntities(array $entities, Table $table): void
     {
-        if (!$table->getConnection()->inTransaction()) {
-            return;
-        }
-
+        // Compensate Cake 5.4+ deferred clean()/setNew(false) under outer
+        // transactions. The check used to short-circuit when the table's
+        // OWN connection was not in transaction, but for associated entities
+        // under a multi-connection cascade the save runs on the *parent's*
+        // connection — the child's connection may legitimately be idle.
+        // Skipping compensation there left the entity isNew()===true and
+        // silently broke `Table::delete()` / identity-based lookups. The
+        // operations below are idempotent (no harm to clean an already-clean
+        // entity or setNew(false) one that already is), so run unconditionally.
         $alias = $table->getAlias();
         foreach ($entities as $entity) {
             $entity->clean();

--- a/src/TestSuite/FactoryTransactionStrategy.php
+++ b/src/TestSuite/FactoryTransactionStrategy.php
@@ -10,6 +10,7 @@ use Cake\TestSuite\Fixture\FixtureStrategyInterface;
 use CakephpFixtureFactories\Error\PersistenceException;
 use CakephpFixtureFactories\Factory\BaseFactory;
 use CakephpFixtureFactories\Generator\CakeGeneratorFactory;
+use RuntimeException;
 use Throwable;
 
 /**
@@ -123,18 +124,18 @@ class FactoryTransactionStrategy implements FixtureStrategyInterface
      */
     public function teardownTest(): void
     {
-        // Rollback all active transactions
-        $this->releaseTransactions();
-
-        // Clear active instance
-        self::$activeInstance = null;
-
-        // Clear tracked tables
-        FactoryTableTracker::getInstance()->clear();
-
-        // Reset generator unique state for next test
-        CakeGeneratorFactory::clearInstances();
-        BaseFactory::resetDefaultGenerator();
+        // try/finally so a rollback failure inside releaseTransactions()
+        // (now aggregated and rethrown) still clears the active instance
+        // and the table tracker — otherwise the next test inherits dead
+        // bookkeeping pointing at a half-released strategy.
+        try {
+            $this->releaseTransactions();
+        } finally {
+            self::$activeInstance = null;
+            FactoryTableTracker::getInstance()->clear();
+            CakeGeneratorFactory::clearInstances();
+            BaseFactory::resetDefaultGenerator();
+        }
     }
 
     /**
@@ -151,12 +152,32 @@ class FactoryTransactionStrategy implements FixtureStrategyInterface
      */
     public function releaseTransactions(): void
     {
-        foreach ($this->connections as $connection) {
-            if ($connection->inTransaction()) {
+        // Per-connection isolation: if rollback throws on connection N
+        // (broken socket, killed backend, server-side timeout), connections
+        // N+1.. still get rolled back, and `$this->connections` resets
+        // *regardless*. The previous abort-on-first-failure semantics left
+        // open transactions on every subsequent connection AND left this
+        // strategy's bookkeeping pointing at dead connections — leaking the
+        // active instance and silently corrupting the next test.
+        $errors = [];
+        foreach ($this->connections as $name => $connection) {
+            if (!$connection->inTransaction()) {
+                continue;
+            }
+            try {
                 $connection->rollback(true);
+            } catch (Throwable $e) {
+                $errors[] = sprintf("'%s': %s", $name, $e->getMessage());
             }
         }
         $this->connections = [];
+
+        if ($errors !== []) {
+            throw new RuntimeException(
+                'releaseTransactions: rollback failed on ' . implode('; ', $errors)
+                . '. Strategy state has been reset; subsequent tests may still need attention.',
+            );
+        }
     }
 
     /**

--- a/tests/TestCase/TestSuite/FactoryTransactionStrategyTest.php
+++ b/tests/TestCase/TestSuite/FactoryTransactionStrategyTest.php
@@ -6,6 +6,7 @@ namespace CakephpFixtureFactories\Test\TestCase\TestSuite;
 
 use Cake\Core\Configure;
 use Cake\Database\Connection;
+use Cake\ORM\Entity;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use CakephpFixtureFactories\Error\PersistenceException;
@@ -20,7 +21,10 @@ use CakephpFixtureFactories\TestSuite\FactoryTransactionStrategy;
 use CakephpFixtureFactories\TestSuite\LazyFactoryTransactionStrategy;
 use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use ReflectionMethod;
+use ReflectionProperty;
 use RuntimeException;
+use Throwable;
 
 /**
  * Test that the FactoryTransactionStrategy properly manages transactions
@@ -443,5 +447,75 @@ class FactoryTransactionStrategyTest extends TestCase
         } catch (PersistenceException $exception) {
             $this->assertSame('no transaction', $exception->getPrevious()?->getMessage());
         }
+    }
+
+    /**
+     * Bug fix: if `rollback(true)` throws on connection N (broken socket,
+     * killed backend, server-side timeout), the loop must NOT abort —
+     * subsequent connections would never be rolled back and `$connections`
+     * would never reset, leaking the active instance into the next test.
+     * Per-connection isolation + unconditional reset + aggregated rethrow.
+     */
+    #[AllowMockObjectsWithoutExpectations]
+    public function testReleaseTransactionsResetsStateEvenIfOneRollbackThrows(): void
+    {
+        $bad = $this->createMock(Connection::class);
+        $bad->method('inTransaction')->willReturn(true);
+        $bad->method('rollback')->willThrowException(new RuntimeException('rollback boom'));
+
+        $good = $this->createMock(Connection::class);
+        $good->method('inTransaction')->willReturn(true);
+        $good->expects($this->once())->method('rollback')->with(true);
+
+        $strategy = new FactoryTransactionStrategy();
+        $connections = new ReflectionProperty($strategy, 'connections');
+        $connections->setValue($strategy, ['bad' => $bad, 'good' => $good]);
+
+        $caught = null;
+        try {
+            $strategy->releaseTransactions();
+        } catch (Throwable $e) {
+            $caught = $e;
+        }
+
+        $this->assertNotNull($caught, 'A rollback failure must still surface to the caller.');
+        $this->assertStringContainsString('bad', $caught->getMessage());
+        $this->assertSame(
+            [],
+            $connections->getValue($strategy),
+            'Connections array must reset regardless of rollback exception — otherwise the strategy leaks into the next test.',
+        );
+    }
+
+    /**
+     * Bug fix: `finalizePersistedEntities()` previously short-circuited when
+     * the table's *own* connection was not in transaction. For associated
+     * entities under a multi-connection cascade the save runs on the
+     * **parent's** connection, not the child's — and the child's connection
+     * may legitimately not be in transaction. Skipping compensation there left
+     * the entity reporting `isNew() === true`, which silently breaks
+     * `Table::delete()` and any other identity-based lookup. The compensation
+     * is idempotent, so it must run unconditionally.
+     */
+    #[AllowMockObjectsWithoutExpectations]
+    public function testFinalizeCompensatesWhenTableConnectionIsNotInTransaction(): void
+    {
+        $entity = new Entity(['x' => 1]);
+        $this->assertTrue($entity->isNew(), 'fresh entity is new before finalize');
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('inTransaction')->willReturn(false);
+        $table = $this->createMock(Table::class);
+        $table->method('getConnection')->willReturn($connection);
+        $table->method('getAlias')->willReturn('SomeAlias');
+
+        $method = new ReflectionMethod(BaseFactory::class, 'finalizePersistedEntities');
+        $method->invoke(AuthorFactory::new(), [$entity], $table);
+
+        $this->assertFalse(
+            $entity->isNew(),
+            'Compensation must run regardless of the table connection state.',
+        );
+        $this->assertSame('SomeAlias', $entity->getSource());
     }
 }


### PR DESCRIPTION
Addresses both P1 findings from the latest persistence-lifecycle audit. One focused PR, two contained changes, two new regression tests.

## P1-1 — `releaseTransactions()` aborts on the first failing rollback; never resets state

`src/TestSuite/FactoryTransactionStrategy.php:152-160` (pre-fix):

```php
foreach ($this->connections as $connection) {
    if ($connection->inTransaction()) {
        $connection->rollback(true);   // can throw, aborts the loop
    }
}
$this->connections = [];               // skipped if rollback throws
```

If `rollback(true)` throws on connection N (broken socket, killed backend, server-side timeout), N+1..end are **never** rolled back, **and** `$this->connections = []` is unreachable. `teardownTest()` then never clears `$activeInstance` / the table tracker / the generator. Subsequent tests start with the strategy pointing at dead connections and leftover open transactions on every other backend — cross-test data leak with no test-output signal.

**Fix:** per-connection isolation + unconditional reset + aggregated rethrow. `teardownTest()` now also wraps `releaseTransactions()` in `try/finally` so `$activeInstance` / the tracker / the generator clear even when the rethrow fires.

## P1-2 — `finalizePersistedEntities()` consults the wrong connection for associated entities

`src/Factory/BaseFactory.php:765` (pre-fix):

```php
if (!$table->getConnection()->inTransaction()) {
    return;
}
```

For ASSOCIATED entities under a cascade, the save runs on the **parent's** connection (`saveAssociated()` walks the parent's tree), but this caller (`replayAssociatedAfterSaveForEntity()`, line 853) passes the **child's** table. In a multi-connection setup where the child's connection is legitimately idle, the guard short-circuits and the child entity stays `isNew() === true` → `Table::delete($child)` no-ops, identity-based lookups break — the exact CakePHP-5.4 deferred-bookkeeping symptom the comment above the method warns about, just for the wrong reason.

**Fix:** the three operations (`clean()`, `setNew(false)`, `setSource()`) are all idempotent. Drop the guard and run unconditionally.

## Verification

Two new RED→GREEN tests in `FactoryTransactionStrategyTest`:
- `testReleaseTransactionsResetsStateEvenIfOneRollbackThrows` — injects a mock connection whose `rollback(true)` throws; asserts the other connection's rollback still runs, `$connections` is reset, and the aggregated error surfaces.
- `testFinalizeCompensatesWhenTableConnectionIsNotInTransaction` — reflection call into the private method with a mock table whose connection is not in transaction; asserts the entity is finalized regardless.

- Full suite: **728 tests, 2525 assertions, 0 failures, 0 deprecations** (11 pre-existing sqlite skips).
- phpstan clean, phpcs clean, codex clean.

Targets `main`. Addresses the two P1s from the persistence-lifecycle audit; the related P2/P3 from that audit (eager-setup silent degradation, `$persistDepth` static reset) are not in this PR's scope.
