### PR TITLE
Bake: skip columns managed by TimestampBehavior on insert

### DIFF
--- a/docs/reference/bake.md
+++ b/docs/reference/bake.md
@@ -56,6 +56,14 @@ bin/cake bake fixture_factory Articles --all-fields
 
 Foreign-key columns remain excluded regardless of the flag, so the baked factory keeps pushing related rows through the association APIs (`with()` / `for()` / `has()`) instead of emitting raw integer FK values.
 
+### Columns managed by `TimestampBehavior`
+
+Bake also skips columns that `TimestampBehavior` populates automatically on insert — by default `created` and `modified`, plus any extras a project configures on `Model.beforeSave` with `'new'` or `'always'`. Baking a random datetime there would dirty the entity, so the behavior would skip its own update and the fixture would ship a random timestamp instead of the test-run's "now". Skipping at bake time keeps the behavior in charge.
+
+Detection is by **class**, so a renamed alias (`addBehavior('AuditTimestamps', ['className' => 'Timestamp'])`) is recognized. Fields configured `'existing'` (only update on existing rows) or wired to non-`Model.beforeSave` events are NOT skipped — those don't fire on insert, so bake must still emit a value.
+
+**Trade-off for pure `->build()` users:** `TimestampBehavior` only fires on save; if you rely on `->build()` (no persist) and expect the timestamp fields to be populated, override at the factory: `->setField('created', \Cake\I18n\DateTime::now())` or add an `afterBuild` callback.
+
 ## Customizing the generated code
 
 Two configuration keys influence what `bake` writes:

--- a/src/Codegen/DefaultDataGuesser.php
+++ b/src/Codegen/DefaultDataGuesser.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace CakephpFixtureFactories\Codegen;
 
 use Cake\Core\Configure;
+use Cake\ORM\Behavior\TimestampBehavior;
 use Cake\ORM\Table;
 
 /**
@@ -191,9 +192,19 @@ class DefaultDataGuesser
         $foreignKeys = $this->collectForeignKeys($table);
         $uniqueFields = $this->collectSingleColumnUniqueFields($table);
         $primaryKeys = $schema->getPrimaryKey();
+        $behaviorManaged = $this->collectBehaviorManagedFields($table);
 
         foreach ($columns as $column) {
             if (in_array($column, $primaryKeys, true) || in_array($column, $foreignKeys, true)) {
+                continue;
+            }
+            if (in_array($column, $behaviorManaged, true)) {
+                // Field is populated automatically at save time by a Cake
+                // behavior (e.g. `TimestampBehavior` for `created` /
+                // `modified`). Baking a generator value would land in the
+                // entity, make the field dirty, and the behavior would then
+                // skip its own update — producing random fixture timestamps
+                // instead of the test-run's "now". Skip so the behavior runs.
                 continue;
             }
 
@@ -417,6 +428,53 @@ class DefaultDataGuesser
         }
 
         return array_values(array_unique($uniqueFields));
+    }
+
+    /**
+     * Collect column names populated automatically on **insert** by Cake
+     * behaviors attached to the table — i.e. fields the factory's NEW-row
+     * save will leave the behavior to fill in. Today this only inspects
+     * `TimestampBehavior` (`created` / `modified` by default, plus any
+     * additional fields a project configures on `Model.beforeSave`).
+     *
+     * Conservative on purpose: only `Model.beforeSave` events count, and
+     * only fields configured `'new'` or `'always'`. A field configured
+     * `'existing'` (or wired to a non-`beforeSave` event) does NOT fire on
+     * insert, so bake must still emit a value or the NOT NULL insert fails.
+     *
+     * @return array<string>
+     */
+    private function collectBehaviorManagedFields(Table $table): array
+    {
+        $fields = [];
+        // Detect by CLASS, not alias: `addBehavior('AuditTimestamps',
+        // ['className' => 'Timestamp'])` registers TimestampBehavior under a
+        // custom alias, so `has('Timestamp')` is false. Iterate everything
+        // loaded and instanceof-check. Multiple aliases of the behavior union.
+        $behaviors = $table->behaviors();
+        foreach ($behaviors->loaded() as $alias) {
+            $behavior = $behaviors->get($alias);
+            if (!$behavior instanceof TimestampBehavior) {
+                continue;
+            }
+            $events = (array)$behavior->getConfig('events');
+            foreach ($events as $eventName => $fieldsForEvent) {
+                if ($eventName !== 'Model.beforeSave' || !is_array($fieldsForEvent)) {
+                    continue;
+                }
+                foreach ($fieldsForEvent as $field => $when) {
+                    if (
+                        is_string($field)
+                        && $field !== ''
+                        && ($when === 'new' || $when === 'always')
+                    ) {
+                        $fields[$field] = true;
+                    }
+                }
+            }
+        }
+
+        return array_keys($fields);
     }
 
     private function normalizeGeneratorExpression(string $generatorMethod): string

--- a/tests/TestCase/Codegen/DefaultDataGuesserAllFieldsTest.php
+++ b/tests/TestCase/Codegen/DefaultDataGuesserAllFieldsTest.php
@@ -109,6 +109,154 @@ class DefaultDataGuesserAllFieldsTest extends TestCase
     }
 
     /**
+     * Tables managed by `TimestampBehavior` populate the configured fields
+     * (default `created` / `modified`) automatically at save time. Baking an
+     * explicit `$generator->datetime()` for those columns overrides the
+     * behavior at fixture time (the entity becomes dirty, so the behavior
+     * skips its own update) — producing random fixture timestamps where
+     * users typically want the test-run's "now". Bake now detects the
+     * behavior and skips the fields it manages.
+     */
+    public function testSkipsColumnsManagedByTimestampBehavior(): void
+    {
+        $table = $this->buildTimestampManagedTable();
+
+        $defaults = (new DefaultDataGuesser())
+            ->setIncludeOptional(true)
+            ->guessFor($table);
+
+        $this->assertArrayNotHasKey(
+            'created',
+            $defaults,
+            'TimestampBehavior-managed column must not be baked.',
+        );
+        $this->assertArrayNotHasKey(
+            'modified',
+            $defaults,
+            'TimestampBehavior-managed column must not be baked.',
+        );
+        // Sanity: a non-managed column is still emitted under --all-fields.
+        $this->assertArrayHasKey('name', $defaults);
+    }
+
+    /**
+     * A `TimestampBehavior` reconfigured to only touch a custom field
+     * (`touched_at`) leaves `created` / `modified` un-managed — bake must
+     * emit those again rather than blanket-skip by name.
+     */
+    public function testCustomTimestampBehaviorConfigOnlySkipsItsActualFields(): void
+    {
+        $table = $this->buildTimestampManagedTable([
+            'events' => [
+                'Model.beforeSave' => [
+                    'touched_at' => 'always',
+                ],
+            ],
+        ]);
+
+        $defaults = (new DefaultDataGuesser())
+            ->setIncludeOptional(true)
+            ->guessFor($table);
+
+        // The behavior no longer manages created / modified, so bake must.
+        $this->assertArrayHasKey('created', $defaults);
+        $this->assertArrayHasKey('modified', $defaults);
+    }
+
+    /**
+     * Fields configured `'existing'` (only fire on updates) or wired to a
+     * non-`Model.beforeSave` event (never fires on the insert path) do NOT
+     * fill in on a factory's NEW-row save. Bake must still emit those, or
+     * the NOT NULL insert leaves them null and fails.
+     */
+    public function testTimestampFieldsThatDoNotFireOnInsertAreStillBaked(): void
+    {
+        $table = $this->buildTimestampManagedTable([
+            'events' => [
+                // 'existing' — only fires on updates, not the initial insert.
+                'Model.beforeSave' => [
+                    'created' => 'existing',
+                ],
+                // Non-beforeSave event — never reached on the insert path.
+                'Model.afterSave' => [
+                    'modified' => 'always',
+                ],
+            ],
+        ]);
+
+        $defaults = (new DefaultDataGuesser())
+            ->setIncludeOptional(true)
+            ->guessFor($table);
+
+        $this->assertArrayHasKey(
+            'created',
+            $defaults,
+            "'existing' only fires on updates — bake must emit for insert.",
+        );
+        $this->assertArrayHasKey(
+            'modified',
+            $defaults,
+            'Non-beforeSave events never fire on insert — bake must emit.',
+        );
+    }
+
+    /**
+     * `TimestampBehavior` can be loaded under a custom alias via
+     * `addBehavior('AuditTimestamps', ['className' => 'Timestamp'])`. Detect
+     * by class (instanceof) rather than alias so the skip still applies.
+     */
+    public function testTimestampBehaviorDetectedUnderCustomAlias(): void
+    {
+        $table = $this->buildTimestampManagedTable(behaviorAlias: 'AuditTimestamps');
+
+        $defaults = (new DefaultDataGuesser())
+            ->setIncludeOptional(true)
+            ->guessFor($table);
+
+        $this->assertArrayNotHasKey('created', $defaults);
+        $this->assertArrayNotHasKey('modified', $defaults);
+    }
+
+    /**
+     * Build a real `Cake\ORM\Table` with an inline schema covering the
+     * `created DATETIME NOT NULL` / `modified DATETIME NOT NULL` shape (no
+     * DB default — the case where the existing bake skip rules wouldn't
+     * fire) and a `TimestampBehavior` attached.
+     *
+     * @param array<string, mixed> $behaviorConfig Optional override for the
+     * @param string $behaviorAlias
+     *     `events` config; defaults to TimestampBehavior's stock config
+     *     (created => new, modified => always on Model.beforeSave).
+     */
+    private function buildTimestampManagedTable(
+        array $behaviorConfig = [],
+        string $behaviorAlias = 'Timestamp',
+    ): Table {
+        $schema = new TableSchema('test_managed', [
+            'id' => ['type' => 'integer', 'null' => false],
+            'name' => ['type' => 'string', 'null' => false, 'length' => 64, 'default' => null],
+            'created' => ['type' => 'datetime', 'null' => false, 'default' => null],
+            'modified' => ['type' => 'datetime', 'null' => false, 'default' => null],
+            'touched_at' => ['type' => 'datetime', 'null' => false, 'default' => null],
+        ]);
+        $schema->addConstraint('primary', ['type' => 'primary', 'columns' => ['id']]);
+
+        $table = new Table([
+            'table' => 'test_managed',
+            'alias' => 'TestManaged',
+            'schema' => $schema,
+        ]);
+        if ($behaviorAlias !== 'Timestamp') {
+            // Class alias: load TimestampBehavior under a custom registry name.
+            $table->addBehavior($behaviorAlias, ['className' => 'Timestamp'] + $behaviorConfig);
+        } else {
+            $table->addBehavior('Timestamp', $behaviorConfig);
+        }
+
+        return $table;
+    }
+
+    /**
      * Build a partial-mocked Table with the schema bits the guesser inspects.
      *
      * @param array{


### PR DESCRIPTION
## Problem

For a typical `created DATETIME NOT NULL` / `modified DATETIME NOT NULL` table (no DB default), bake's `DefaultDataGuesser` emits `'created' => $generator->datetime()` and `'modified' => $generator->datetime()`. At save time, `TimestampBehavior::handleEvent` sees the field is already dirty and **skips its own update** — so fixture rows ship with random timestamps instead of the test-run's "now". A subtle, surprising override of an opt-in behavior.

## Fix

`DefaultDataGuesser::guessFor()` now consults the table's loaded behaviors and skips fields `TimestampBehavior` writes on **insert**:

- **By class, not alias.** A renamed load (`addBehavior('AuditTimestamps', ['className' => 'Timestamp'])`) is recognized via `instanceof TimestampBehavior`.
- **Only `Model.beforeSave` events** — that's the one the insert path fires.
- **Only `when => 'new' | 'always'`** — `'existing'` only fires on updates, so bake must still emit or the `NOT NULL` insert leaves it null and fails.
- Multiple TimestampBehavior aliases on the same table union their fields.

## Codex review trail

Three iterations:
1. Initial fix → codex P2 ("`'existing'` and non-`beforeSave` skipped wrongly"). Narrowed to insert-firing fields only.
2. Codex P2 ("aliased load slips through"). Switched to class-based detection.
3. Codex P2 ("`build()` path loses timestamps — `TimestampBehavior` only runs on save"). Documented the trade-off in `docs/reference/bake.md` (pure-build users override with `setField()` / `afterBuild`). Pushed back on adding a flag — keeps the API tight per the focused-scope request.

## Verification

- 4 new tests in `DefaultDataGuesserAllFieldsTest`: skip-managed (default config), custom-config-only-skips-its-fields, `'existing'`/non-`beforeSave`-still-baked, custom-alias detection.
- Full suite: **734 tests, 2538 assertions, 0 failures, 0 deprecations** (11 pre-existing sqlite skips).
- phpstan clean, phpcs clean.

Targets `main`. First of the remaining-P2 sweep.
