### PR TITLE
Composition guards: has() pivot BTM-only + for()/has() target type-check

### DIFF
--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -21,6 +21,7 @@ use Cake\Datasource\EntityInterface;
 use Cake\Event\EventManagerInterface;
 use Cake\I18n\I18n;
 use Cake\ORM\Association\BelongsTo;
+use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\Table;
 use CakephpFixtureFactories\Error\FixtureFactoryException;
@@ -2324,7 +2325,7 @@ abstract class BaseFactory
         if ($alias === null) {
             $alias = $this->resolveDirectionalAssociation($factory, true);
         } else {
-            $this->guardAliasDirection($alias, true);
+            $this->guardAliasDirection($alias, true, $factory);
         }
 
         return $this->with($alias, $factory);
@@ -2351,6 +2352,8 @@ abstract class BaseFactory
      * @param string|null $alias Explicit association alias on the source table; auto-resolved when null.
      * @param array<string, mixed> $pivot Pivot data for belongsToMany joins.
      *
+     * @throws \RuntimeException
+     *
      * @return static
      */
     public function has(BaseFactory $factory, ?string $alias = null, array $pivot = []): static
@@ -2362,9 +2365,25 @@ abstract class BaseFactory
         if ($alias === null) {
             $alias = $this->resolveDirectionalAssociation($factory, false);
         } else {
-            $this->guardAliasDirection($alias, false);
+            $this->guardAliasDirection($alias, false, $factory);
         }
         if ($pivot !== []) {
+            // Pivot data only has a place to land on belongsToMany joins
+            // (Cake writes it into `_joinData` on the junction row). For
+            // hasOne / hasMany the marshaller has no junction to populate,
+            // so the data was silently dropped on save. Reject loudly.
+            $association = $this->getTable()->getAssociation($alias);
+            if (!$association instanceof BelongsToMany) {
+                throw new RuntimeException(sprintf(
+                    "%s::has() pivot data is only meaningful for belongsToMany; alias '%s' "
+                    . 'is a `%s` association on `%s`. Drop the pivot argument, '
+                    . 'or use the alias that points to a belongsToMany junction.',
+                    self::shortName(static::class),
+                    $alias,
+                    strtolower(self::shortName($association::class)),
+                    $this->getTable()->getRegistryAlias(),
+                ));
+            }
             // Patch `_joinData` into every built child so Cake's belongsToMany
             // marshaller writes the pivot columns onto the join row. The
             // previous `mergeAssociated(['_joinData' => $pivot])` only set
@@ -2387,10 +2406,13 @@ abstract class BaseFactory
      *
      * @param string $alias Association alias on this factory's source table.
      * @param bool $belongsTo `true` when called from `for()`, `false` from `has()`.
+     * @param \CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface>|null $factory
+     *     Associated factory whose target table should match the alias's
+     *     target. When `null`, only the direction guard runs.
      *
      * @throws \RuntimeException When the alias is unknown or resolves to the wrong cardinality.
      */
-    private function guardAliasDirection(string $alias, bool $belongsTo): void
+    private function guardAliasDirection(string $alias, bool $belongsTo, ?BaseFactory $factory = null): void
     {
         $caller = $belongsTo ? 'for' : 'has';
         $callerShort = self::shortName(static::class);
@@ -2416,24 +2438,46 @@ abstract class BaseFactory
         }
 
         $isBelongsTo = $association instanceof BelongsTo;
-        if ($belongsTo === $isBelongsTo) {
-            return;
+        if ($belongsTo !== $isBelongsTo) {
+            $expected = $belongsTo ? 'belongsTo' : 'has* (hasOne, hasMany, belongsToMany)';
+            $actual = $isBelongsTo ? 'belongsTo' : 'has*';
+
+            throw new RuntimeException(sprintf(
+                "%s::%s() with alias '%s' refers to a %s association — expected %s. "
+                . "Use the matching directional helper, or `with('%s', ...)` if you "
+                . 'want the lower-level form.',
+                $callerShort,
+                $caller,
+                $alias,
+                $actual,
+                $expected,
+                $alias,
+            ));
         }
 
-        $expected = $belongsTo ? 'belongsTo' : 'has* (hasOne, hasMany, belongsToMany)';
-        $actual = $isBelongsTo ? 'belongsTo' : 'has*';
-
-        throw new RuntimeException(sprintf(
-            "%s::%s() with alias '%s' refers to a %s association — expected %s. "
-            . "Use the matching directional helper, or `with('%s', ...)` if you "
-            . 'want the lower-level form.',
-            $callerShort,
-            $caller,
-            $alias,
-            $actual,
-            $expected,
-            $alias,
-        ));
+        // Target-match guard: a `Foo::for(BarFactory, 'Address')` whose Bar
+        // factory does NOT target the Address alias's table is a mis-wire
+        // that the auto-resolve path would have caught — match it here too,
+        // mirroring the disjuncts in resolveDirectionalAssociation().
+        if ($factory !== null) {
+            $factoryRoot = $factory->getRootTableRegistryName();
+            $targets = $association->getClassName() === $factoryRoot
+                || $association->getTarget()->getRegistryAlias() === $factoryRoot
+                || $association->getName() === $factoryRoot;
+            if (!$targets) {
+                throw new RuntimeException(sprintf(
+                    "%s::%s() alias '%s' targets `%s`, but `%s` builds `%s`. "
+                    . 'Pass a factory whose root table matches the alias target, '
+                    . 'or drop the alias argument to let auto-resolution catch it.',
+                    $callerShort,
+                    $caller,
+                    $alias,
+                    $association->getTarget()->getRegistryAlias(),
+                    $factory::class,
+                    $factoryRoot,
+                ));
+            }
+        }
     }
 
     /**

--- a/tests/TestCase/Factory/BaseFactoryForHasAliasTest.php
+++ b/tests/TestCase/Factory/BaseFactoryForHasAliasTest.php
@@ -144,4 +144,55 @@ class BaseFactoryForHasAliasTest extends TestCase
             ->has(AddressFactory::new(), 'Address')
             ->save();
     }
+
+    /**
+     * Passing `$pivot` to a hasOne / hasMany alias is meaningless — Cake's
+     * non-junction marshaller has no `_joinData` slot to write, so the pivot
+     * silently drops on save. Reject loudly with a clear "BelongsToMany
+     * only" message instead.
+     */
+    public function testHasRejectsPivotForNonBelongsToManyAlias(): void
+    {
+        // CountriesTable: hasMany Cities. `_joinData` has no meaning here.
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/pivot.*belongsToMany|_joinData/i');
+
+        CountryFactory::new()
+            ->has(CityFactory::new(), 'Cities', ['featured' => true]);
+    }
+
+    /**
+     * The explicit-alias form must also type-check the passed factory's
+     * target table against the alias's target. Without this guard,
+     * `Author::for(City, 'Address')` silently builds a City entity into
+     * the Address slot, mis-wiring at save time.
+     */
+    public function testForRejectsFactoryWhoseTargetDoesNotMatchTheAlias(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches(
+            "/alias 'Address' targets.*CityFactory.*builds.*Cities/i",
+        );
+
+        // Author's `Address` alias targets `Addresses`; passing CityFactory
+        // is a categorical mismatch that auto-resolution would catch but the
+        // explicit alias path currently lets slide.
+        AuthorFactory::new()->for(CityFactory::new(), 'Address');
+    }
+
+    /**
+     * Same guard on `has()`: a child factory whose target doesn't match the
+     * alias's target table is a mis-wiring.
+     */
+    public function testHasRejectsFactoryWhoseTargetDoesNotMatchTheAlias(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches(
+            "/alias 'Cities' targets.*CountryFactory.*builds.*Countries/i",
+        );
+
+        // Country's `Cities` alias targets `Cities`; passing CountryFactory
+        // is a mis-wire that has() should reject.
+        CountryFactory::new()->has(CountryFactory::new(), 'Cities');
+    }
 }


### PR DESCRIPTION
## Two related explicit-alias guards on `for()` / `has()`

### 1. `has()` pivot data is meaningless on non-`BelongsToMany`

`has($factory, $alias, $pivot)` unconditionally called `$factory->state(['_joinData' => $pivot])`. For `hasOne` / `hasMany` aliases there's no junction to write to, so `_joinData` lands as a stray field on the child entity and **drops silently** on save.

Now `has()` resolves the alias's association and throws when `$pivot !== []` and the association is not `BelongsToMany`:

> `AuthorFactory::has() pivot data is only meaningful for belongsToMany; alias 'Cities' is a `hasmany` association on `Countries`. Drop the pivot argument, or use the alias that points to a belongsToMany junction.`

### 2. `for()` / `has()` explicit-alias did not type-check the passed factory's target

`guardAliasDirection` checked cardinality (belongsTo vs has*) only — it did **not** verify that the passed factory's root table matches the alias's target. So `AuthorFactory::new()->for(CityFactory::new(), 'Address')` was accepted: City entity built into the Address slot → mis-wiring at save time. The auto-resolve path doesn't have this hole; only the explicit-alias path did.

Now `guardAliasDirection` also rejects target mismatches, mirroring the same disjuncts (`getClassName` / `getTarget()->getRegistryAlias()` / `getName()`) the auto-resolve uses:

> `AuthorFactory::for() alias 'Address' targets `Address`, but `CakephpFixtureFactories\Test\Factory\CityFactory` builds `Cities`. Pass a factory whose root table matches the alias target, or drop the alias argument to let auto-resolution catch it.`

## Verification

3 RED→GREEN tests in `BaseFactoryForHasAliasTest`:
- `testHasRejectsPivotForNonBelongsToManyAlias`
- `testForRejectsFactoryWhoseTargetDoesNotMatchTheAlias`
- `testHasRejectsFactoryWhoseTargetDoesNotMatchTheAlias`

- Full suite: **737 tests, 2544 assertions, 0 failures, 0 deprecations** (11 pre-existing sqlite skips).
- phpstan clean, phpcs clean, codex clean.

Targets `main`. Third of the remaining-P2 sweep (after #95 / #96).
