### PR TITLE
Composition: merge marshaller options across duplicate to-many alias adds

### DIFF
--- a/src/Factory/AssociationBuilder.php
+++ b/src/Factory/AssociationBuilder.php
@@ -48,6 +48,31 @@ class AssociationBuilder
     private array $associations = [];
 
     /**
+     * History of every factory ever added under each alias — the
+     * `$associations` map keeps only the last (for back-compat with
+     * `getAssociations()`), but the marshaller config in `getAssociated()`
+     * needs to MERGE across all of them so a `->with('Alias', F1)` followed
+     * by a `->with('Alias', F2)` doesn't silently drop F1's nested
+     * marshaller config (associated branches, accessibleFields, etc.).
+     *
+     * The merge is to-many only. For to-one aliases the merge would
+     * contradict DataCompiler::mergeWithToOne()'s last-wins semantics, so
+     * getAssociated() reverts to single-entry behavior in that case.
+     *
+     * Known edge (not handled): configure()-default → user-explicit override
+     * for the SAME alias does not distinguish "default" from "user" entries
+     * here, so the marshaller config for that alias may carry the default's
+     * nested config even though the user explicitly replaced it. The data
+     * path is unaffected (DataCompiler overrides defaults correctly); only
+     * marshaller accessibleFields keys may include extras for the dropped
+     * default branch. A future refinement could mirror DataCompiler's
+     * default-vs-user separation here.
+     *
+     * @var array<string, array<int, \CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface>>>
+     */
+    private array $associationHistory = [];
+
+    /**
      * @var array<string, mixed>
      */
     private array $manualAssociations = [];
@@ -319,8 +344,15 @@ class AssociationBuilder
         }
         if (count($explode) === 0) {
             unset($this->associations[$baseAssociationName]);
+            // Keep history aligned: otherwise getAssociated() would
+            // resurrect the dropped alias's marshaller config from history.
+            unset($this->associationHistory[$baseAssociationName]);
         } else {
             $this->associations[$baseAssociationName] = $this->associations[$baseAssociationName]->without(implode('.', $explode));
+            // Same trim on the history so partial-drop semantics carry too.
+            foreach ($this->associationHistory[$baseAssociationName] ?? [] as $i => $entry) {
+                $this->associationHistory[$baseAssociationName][$i] = $entry->without(implode('.', $explode));
+            }
         }
     }
 
@@ -331,7 +363,34 @@ class AssociationBuilder
     {
         $result = [];
         foreach ($this->associations as $name => $associatedFactory) {
-            $result[$name] = $associatedFactory->getMarshallerOptions();
+            // Merge across history ONLY for to-many branches, mirroring
+            // DataCompiler::mergeWithToMany() which iterates every appended
+            // factory. For to-one (belongsTo / hasOne) branches
+            // DataCompiler::mergeWithToOne() uses the LAST factory (`$data[
+            // $count - 1]`), so the marshaller config must do the same —
+            // otherwise stale nested config from a replaced F1 leaks into
+            // patchEntity() for the F2-only branch.
+            try {
+                $association = $this->getAssociation($name);
+                $isToOne = $this->associationIsToOne($association);
+            } catch (Throwable) {
+                // Association lookup failed (e.g. a manually-added alias
+                // not declared on the table); fall back to last-wins to
+                // preserve previous behavior in that edge.
+                $isToOne = true;
+            }
+
+            if ($isToOne) {
+                $result[$name] = $associatedFactory->getMarshallerOptions();
+
+                continue;
+            }
+
+            $merged = [];
+            foreach ($this->associationHistory[$name] ?? [$associatedFactory] as $entry) {
+                $merged = array_replace_recursive($merged, $entry->getMarshallerOptions());
+            }
+            $result[$name] = $merged;
         }
 
         return array_replace_recursive($result, $this->manualAssociations);
@@ -356,6 +415,7 @@ class AssociationBuilder
     public function addAssociation(string $associationName, BaseFactory $factory): void
     {
         $this->associations[$associationName] = $factory;
+        $this->associationHistory[$associationName][] = $factory;
     }
 
     /**
@@ -367,6 +427,13 @@ class AssociationBuilder
     {
         foreach ($this->associations as $associationName => $associatedFactory) {
             $this->associations[$associationName] = $callback($associatedFactory);
+        }
+        // Apply the same transform to the parallel history so getAssociated()
+        // doesn't drift from the canonical associations map.
+        foreach ($this->associationHistory as $associationName => $entries) {
+            foreach ($entries as $i => $entry) {
+                $this->associationHistory[$associationName][$i] = $callback($entry);
+            }
         }
     }
 

--- a/tests/TestCase/Factory/BaseFactoryAssociationsTest.php
+++ b/tests/TestCase/Factory/BaseFactoryAssociationsTest.php
@@ -754,4 +754,79 @@ class BaseFactoryAssociationsTest extends TestCase
 
         $this->assertSame($name, $country->cities[0]->name);
     }
+
+    /**
+     * Two `->with('SameAlias', F)` calls on a to-many branch BOTH contribute
+     * entities (DataCompiler appends), but `AssociationBuilder::$associations`
+     * only kept the LAST factory — so `getMarshallerOptions()->associated`
+     * silently dropped nested-marshaller config (e.g. nested `with()` /
+     * `accessibleFields`) from the first branch. The marshaller-routed outer
+     * patch (DataCompiler.php:449) then ran without that config.
+     *
+     * Fix: marshaller options must merge across every factory ever added
+     * under a given alias.
+     */
+    public function testGetMarshallerOptionsMergesAssociatedConfigAcrossDuplicateAliases(): void
+    {
+        // Two with('Authors', ...) on an Article: F1 nests a non-back-link
+        // BusinessAddress, F2 is bare. Merged 'associated' must keep F1's
+        // BusinessAddress config — without the fix only F2 (last-wins) was
+        // reflected in marshaller options. (BusinessAddress is chosen because
+        // it is NOT the back-link Authors->Articles, which would otherwise be
+        // stripped by removeAssociationForToOneFactory.)
+        $factory = ArticleFactory::new()
+            ->with('Authors', AuthorFactory::new()->with('BusinessAddress', AddressFactory::new()))
+            ->with('Authors', AuthorFactory::new());
+
+        $options = $factory->getMarshallerOptions();
+
+        $this->assertArrayHasKey('associated', $options);
+        $this->assertArrayHasKey('Authors', $options['associated']);
+        $authorsOptions = $options['associated']['Authors'];
+        $this->assertArrayHasKey('associated', $authorsOptions);
+        $this->assertArrayHasKey(
+            'BusinessAddress',
+            $authorsOptions['associated'],
+            "Nested 'BusinessAddress' from the first with('Authors', …) must survive a second with('Authors', …).",
+        );
+    }
+
+    /**
+     * For TO-ONE branches (belongsTo / hasOne), DataCompiler's
+     * mergeWithToOne picks the LAST factory only — `$data[$count - 1]`. The
+     * marshaller config must follow the same "last wins" precedence, NOT
+     * union across history; otherwise stale config from a replaced F1
+     * leaks into patchEntity() and accepts/persists fields F2 explicitly
+     * dropped.
+     */
+    public function testGetMarshallerOptionsKeepsLastWinsForDuplicateToOneAliases(): void
+    {
+        // Bare F2 establishes the "what F2 alone produces" baseline (it
+        // includes configure-default associations, that's fine — we just
+        // want to confirm F1's extras did NOT leak into the merged result).
+        $f2 = AddressFactory::new();
+        $f2Baseline = $f2->getMarshallerOptions();
+
+        // F1 has a marker option F2 does not — `setMarshallerOptions()`
+        // adds a synthetic key so we can detect leakage cleanly.
+        $f1 = AddressFactory::new()->setMarshallerOptions(['_leak_probe' => true]);
+
+        $factory = AuthorFactory::new()
+            ->with('Address', $f1)
+            ->with('Address', $f2);
+
+        $options = $factory->getMarshallerOptions();
+
+        $this->assertSame(
+            $f2Baseline,
+            $options['associated']['Address'],
+            'Duplicate belongsTo alias is last-wins: F1 was replaced, so the merged '
+            . 'marshaller config must equal F2 standalone — not a union that leaks F1.',
+        );
+        $this->assertArrayNotHasKey(
+            '_leak_probe',
+            $options['associated']['Address'],
+            'F1 leak probe must not surface on the merged Address options.',
+        );
+    }
 }


### PR DESCRIPTION
## Problem

`AssociationBuilder::$associations` is a last-wins map per alias, but `DataCompiler::$dataFromAssociations` **appends** factories per alias. So `->with('Alias', F1)->with('Alias', F2)` on a to-many branch builds entities from BOTH, yet the marshaller options at `getMarshallerOptions()->associated` only saw F2's — the marshaller-routed outer patch (`DataCompiler.php:449`) lost F1's nested config (`associated` branches, `accessibleFields`, etc.) and silently dropped its deep patching path.

## Fix

Parallel `$associationHistory` tracking every factory ever added under each alias. `getAssociated()` now:

- **to-many alias:** merges `getMarshallerOptions()` across all history entries (`array_replace_recursive` so later entries override scalars while unioning the nested `'associated'` branches),
- **to-one alias:** keeps the existing last-wins (mirrors `DataCompiler::mergeWithToOne()` which uses `$data[$count - 1]`).

`dropAssociation()` / `mapAssociations()` track the history in lockstep so removals and transforms don't drift from the canonical map.

## Codex review trail

Three iterations:
1. First pass: merged across all aliases unconditionally.
2. Codex P2: "to-one duplicates need last-wins" — added the cardinality split.
3. Codex P1: "configure→user override for same alias would still leak default's marshaller config." Documented this as a known limitation in the property docblock: data path is unaffected (DataCompiler overrides correctly), only marshaller `accessibleFields` keys may carry extras for the dropped default branch. A future refinement could mirror DataCompiler's default-vs-user separation in AssociationBuilder, but that's a broader design change than this focused fix.

## Verification

2 RED→GREEN tests in `BaseFactoryAssociationsTest`:
- `testGetMarshallerOptionsMergesAssociatedConfigAcrossDuplicateAliases` (to-many merge)
- `testGetMarshallerOptionsKeepsLastWinsForDuplicateToOneAliases` (to-one last-wins)

- Full suite: **740 tests, 2553 assertions, 0 failures, 0 deprecations** (11 pre-existing sqlite skips).
- phpstan clean, phpcs clean.

Targets `main`. Fourth of the remaining-P2 sweep.

> Note: an earlier `fix-association-storage-drift` branch was pushed with an outdated diff (against an older `main` snapshot). This `-v2` branch is the rebased correct version; the stale one can be deleted.
