### PR TITLE
Warn when eager primary connection setup silently fails

### DIFF
--- a/src/TestSuite/FactoryTransactionStrategy.php
+++ b/src/TestSuite/FactoryTransactionStrategy.php
@@ -113,8 +113,25 @@ class FactoryTransactionStrategy implements FixtureStrategyInterface
         try {
             /** @var \Cake\Database\Connection $primary */
             $primary = ConnectionManager::get($this->primaryConnection);
-        } catch (Throwable) {
-            return; // unconfigured / unknown connection name — silent skip.
+        } catch (Throwable $e) {
+            // The eager guarantee silently disappears when the configured
+            // primary connection name doesn't resolve (typo in a subclass,
+            // missing test connection config, etc.). Tests still PASS for
+            // factory-only writes (the lazy path inside doPersist still
+            // wraps them), but mixed-style tests start leaking direct
+            // $table->save() rows — exactly the bug the eager default was
+            // reintroduced to fix. Surface a warning so the regression is
+            // visible at runtime instead of silently disappearing.
+            trigger_error(sprintf(
+                "FactoryTransactionStrategy: eager begin disabled — primary connection '%s' "
+                . 'is not configured (%s). Direct $table->save() / raw inserts inside tests '
+                . 'will NOT be rolled back at teardown. Set $primaryConnection on a subclass '
+                . "to your real test connection, or set it to '' to silence this warning.",
+                $this->primaryConnection,
+                $e->getMessage(),
+            ), E_USER_WARNING);
+
+            return;
         }
         $this->ensureTransaction($primary);
     }

--- a/tests/TestCase/TestSuite/FactoryTransactionStrategyTest.php
+++ b/tests/TestCase/TestSuite/FactoryTransactionStrategyTest.php
@@ -221,6 +221,45 @@ class FactoryTransactionStrategyTest extends TestCase
     }
 
     /**
+     * If `$primaryConnection` is set to an unconfigured/typo'd name (the
+     * typical bug: a subclass declares 'test_min' instead of 'test'), the
+     * eager guarantee silently disappeared. Now emit an `E_USER_WARNING` so
+     * the regression surfaces at runtime — mixed-style tests (Factory +
+     * direct `$table->save()`) would otherwise start leaking direct-save rows.
+     */
+    public function testBadPrimaryConnectionEmitsUserWarning(): void
+    {
+        $strategy = new class () extends FactoryTransactionStrategy {
+            protected string $primaryConnection = 'definitely_not_a_real_connection_name';
+        };
+
+        $captured = [];
+        set_error_handler(
+            function (int $level, string $message) use (&$captured): bool {
+                if ($level === E_USER_WARNING) {
+                    $captured[] = $message;
+
+                    return true;
+                }
+
+                return false;
+            },
+            E_USER_WARNING,
+        );
+
+        try {
+            $strategy->setupTest([]);
+        } finally {
+            restore_error_handler();
+            $strategy->teardownTest();
+        }
+
+        $this->assertNotEmpty($captured, 'Bad $primaryConnection must trigger an E_USER_WARNING.');
+        $this->assertStringContainsString('definitely_not_a_real_connection_name', $captured[0]);
+        $this->assertStringContainsString('eager begin disabled', $captured[0]);
+    }
+
+    /**
      * Test that teardown without any persists works fine
      *
      * @return void


### PR DESCRIPTION
## Problem

`FactoryTransactionStrategy::setupTest()` (lines 113–118 pre-fix):

```php
try {
    $primary = ConnectionManager::get($this->primaryConnection);
} catch (Throwable) {
    return; // unconfigured / unknown connection name — silent skip.
}
```

A subclass with `protected string $primaryConnection = 'test_min';` typo'd from `'test_main'` produced no warning, no log, no failure. The documented eager guarantee (`docs/guide/setup.md:142` — "direct `$table->save()` is also rolled back") silently disappeared. Factory-only tests still passed (lazy `ensureTransaction` covers them inside `doPersist`), but mixed-style tests started leaking direct-save rows — the exact bug the eager default was reintroduced to fix in v2 (`docs/guide/upgrading.md:22`).

## Fix

`E_USER_WARNING` on the silent skip:

> `FactoryTransactionStrategy: eager begin disabled — primary connection 'test_min' is not configured (…). Direct $table->save() / raw inserts inside tests will NOT be rolled back at teardown. Set $primaryConnection on a subclass to your real test connection, or set it to '' to silence this warning.`

The existing opt-out (`$primaryConnection = ''`, used by `LazyFactoryTransactionStrategy`) is unchanged — it short-circuits before the try block.

## Verification

- New `testBadPrimaryConnectionEmitsUserWarning` (RED→GREEN) capturing the warning via `set_error_handler`.
- Full suite: **739 tests, 2550 assertions, 0 failures, 0 deprecations** (11 pre-existing sqlite skips).
- phpstan clean, phpcs clean.

Targets `main`. Fifth of the remaining-P2 sweep.
