### PR TITLE
recycle() polish: reject same-source duplicates + doc clarifications

### DIFF
--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -2507,10 +2507,25 @@ abstract class BaseFactory
      * Addresses), recycle substitutes both. Use `with('Alias', $entity)`
      * directly for per-alias control.
      *
+     * Only **belongsTo** branches are substituted. A composed `hasOne` /
+     * `hasMany` / `belongsToMany` child is NOT replaced with a recycled
+     * entity — its identity is the *factory's* build (the recycle map only
+     * propagates *into* it so its own belongsTo branches can substitute).
+     * If you need a specific child entity, attach it explicitly with
+     * `with('Alias', $entity)` instead.
+     *
+     * Within a single call, two entities for the same source table are
+     * rejected (`InvalidArgumentException`) — that shape is almost always a
+     * typo for "I want one of these but I'm not sure which". Across multiple
+     * `recycle()` calls, last wins (a chained `->recycle($a)->recycle($b)` on
+     * the same source is treated as an intentional update).
+     *
      * @param \Cake\Datasource\EntityInterface ...$entities One or more
      *     already-built entities to reuse, keyed internally by source table.
      *
-     * @throws \InvalidArgumentException If an entity has no source table set.
+     * @throws \InvalidArgumentException If an entity has no source table set,
+     *     is unsaved, or collides with another entity for the same source
+     *     table in the same call.
      *
      * @return static
      */
@@ -2521,6 +2536,7 @@ abstract class BaseFactory
         }
 
         $factory = clone $this;
+        $seenInCall = [];
         foreach ($entities as $entity) {
             $source = $entity->getSource();
             if ($source === '') {
@@ -2541,6 +2557,22 @@ abstract class BaseFactory
             // Normalize the factory-internal `__ff_<hash>` suffix so the map
             // keys match association target aliases on the lookup side.
             $key = DataCompiler::normalizeTableAlias($source);
+
+            // Within a SINGLE call, reject duplicate-source entities — the
+            // result would silently keep only the last one, almost always a
+            // typo for "I want one of these but I'm not sure which".
+            // Across SEPARATE recycle() calls last-wins is still allowed
+            // (intentional update of the recycle map for that table).
+            if (isset($seenInCall[$key])) {
+                throw new InvalidArgumentException(sprintf(
+                    'recycle() received two entities for the same source table `%s` in one call — '
+                    . 'the second would silently drop the first. Pick one, or chain a second '
+                    . '`->recycle($other)` call if you intentionally want to overwrite the map.',
+                    $key,
+                ));
+            }
+            $seenInCall[$key] = true;
+
             $factory->recycledEntities[$key] = $entity;
         }
 

--- a/tests/TestCase/Factory/BaseFactoryRecycleTest.php
+++ b/tests/TestCase/Factory/BaseFactoryRecycleTest.php
@@ -324,4 +324,38 @@ class BaseFactoryRecycleTest extends TestCase
 
         CityFactory::new()->recycle($detached);
     }
+
+    /**
+     * Two entities for the same source table in ONE recycle() call would
+     * silently keep only the last — almost always a typo. Reject loudly.
+     * (Across separate `->recycle()->recycle()` calls last-wins still works;
+     * see {@see self::testSeparateRecycleCallsOnSameSourceLastWins}.)
+     */
+    public function testRecycleRejectsTwoEntitiesForSameSourceInOneCall(): void
+    {
+        $a = CityFactory::new()->save();
+        $b = CityFactory::new()->save();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/same source table/');
+
+        AddressFactory::new()->recycle($a, $b);
+    }
+
+    /**
+     * Two separate `->recycle()` calls on the same source table is an
+     * intentional update of the recycle map — last wins is preserved.
+     */
+    public function testSeparateRecycleCallsOnSameSourceLastWins(): void
+    {
+        $first = CityFactory::new(['name' => 'first'])->save();
+        $second = CityFactory::new(['name' => 'second'])->save();
+
+        $address = AddressFactory::new()
+            ->recycle($first)
+            ->recycle($second)
+            ->save();
+
+        $this->assertSame($second->id, $address->city_id);
+    }
 }


### PR DESCRIPTION
## recycle() polish

Two related changes addressing audit 3 P2-1 and recycle docblock gaps:

### 1. Reject same-source duplicates in a single `recycle()` call

`recycle($a, $b)` for the same source table silently dropped `$a` ("last wins"), almost always a typo for "I want one of these but I'm not sure which". Now throws `InvalidArgumentException`:

> `recycle() received two entities for the same source table 'addresses' in one call — the second would silently drop the first. Pick one, or chain a second ->recycle($other) call if you intentionally want to overwrite the map.`

Across **separate** `->recycle($a)->recycle($b)` calls last-wins is preserved (it's an intentional update of the map — covered by `testSeparateRecycleCallsOnSameSourceLastWins`).

### 2. Docblock clarifications

Explicit statement that **only `belongsTo`** branches are substituted; a composed `hasOne` / `hasMany` / `belongsToMany` child keeps its factory-built identity (the recycle map only propagates *into* it so its own belongsTo branches can substitute). Plus the one-call vs separate-call duplicate handling above.

### Hashmany propagation coverage

The audit also flagged missing `hasMany` / BTM recycle test coverage. I drafted a test but the TestApp schema's back-link strip (`removeAssociationForToOneFactory`) and hasMany's hard-wired back-FK conflict with the specific scenario — coverage for that would need either a new schema or a more constructed test fixture. Out of scope for this focused PR; can be a follow-up.

## Verification

- 2 new tests in `BaseFactoryRecycleTest`:
  - `testRecycleRejectsTwoEntitiesForSameSourceInOneCall`
  - `testSeparateRecycleCallsOnSameSourceLastWins`
- Full suite: **740 tests, 2550 assertions, 0 failures, 0 deprecations** (11 pre-existing sqlite skips).
- phpstan clean, phpcs clean.

Targets `main`. Sixth and final of the remaining-P2 sweep.
