### PR TITLE
P3 sweep: six small correctness fixes + tests + docs

### DIFF
--- a/docs/guide/associations.md
+++ b/docs/guide/associations.md
@@ -44,6 +44,8 @@ $article = ArticleFactory::new()->count(5)->with('Authors[3].Address.City.Countr
 ```
 will create 5 articles, having themselves each 3 different associated authors, all located in Kenya.
 
+The bracket count is also honored when the second argument is a factory instance — e.g. `->with('Cities[3]', CityFactory::new()->forCountries())` builds 3 cities. If the passed factory already has its own `->count(n)`, the bracket count wins (so the bracket syntax is the single source of truth for cardinality on that line).
+
 It is also possible to specify the fields of a toMany associated model.
 For example, if we wish to create a random country with two cities having known names:
 

--- a/docs/guide/queries.md
+++ b/docs/guide/queries.md
@@ -75,6 +75,9 @@ class ArticlesControllerTest extends AppTestCase
 - `assertEntityExists(EntityInterface $entity, ?string $factoryClass = null, ?string $message = null)` — the entity is still in the database (by primary key).
 - `assertEntityMissing(EntityInterface $entity, ?string $factoryClass = null, ?string $message = null)` — the entity is no longer in the database.
 
+> [!IMPORTANT]
+> `assertEntityMissing()` refuses entities that were never persisted — both the "no primary key" case and the application-assigned-PK case (UUID / string IDs) where the entity carries a PK at build time but was never written. The guard checks `isNew()` first and the PK as a fallback. Save the entity (then delete it) before asserting it is missing.
+
 The optional `$factoryClass` argument on the entity assertions scopes the lookup to that factory's table. Use it when several factory variants share a bare table alias on different connections — without it, the entity's `getSource()` is consulted, which may resolve to whichever factory variant most-recently registered with the locator.
 
 `$criteria` is passed straight to `Factory::query()->where(...)`, so the same operator forms work — e.g. `['title LIKE' => '%Cake%']`, `['status IN' => ['draft', 'published']]`, `['author_id' => $author->id]`.

--- a/docs/guide/scenarios.md
+++ b/docs/guide/scenarios.md
@@ -127,7 +127,7 @@ class FeedTest extends TestCase
 
 ### API
 
-- `addToPool(string $pool, EntityInterface|array $entities)` — register one or more entities under a named pool; repeated calls append.
+- `addToPool(string $pool, EntityInterface|array $entities)` — register one or more entities under a named pool; repeated calls append. Empty pool names are refused with a clear error (an empty key on the read side produced a useless message before).
 - `getPool(string $pool): array<EntityInterface>` — return every entity in a pool.
 - `getRandom(string $pool): EntityInterface` — uniform random pick from a pool.
 - `getRandomSet(string $pool, int $count): array<EntityInterface>` — `$count` distinct entities drawn from a pool (raises if the pool holds fewer).

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -1676,6 +1676,15 @@ abstract class BaseFactory
 
         if (!str_contains($associationName, '.') && $data instanceof BaseFactory) {
             $associatedFactory = $data;
+            // Honor the bracket-count syntax for leaf-factory calls too.
+            // The non-factory path goes through getAssociatedFactory() which
+            // applies the bracket count via getTimeBetweenBrackets(); this
+            // branch used to skip it, so `with('Alias[3]', SomeFactory::new())`
+            // silently dropped the [3] and built 1 row instead of 3.
+            $times = $factory->getAssociationBuilder()->getTimeBetweenBrackets($associationName);
+            if ($times !== null) {
+                $associatedFactory = $associatedFactory->count($times);
+            }
         } else {
             $associatedFactory = $factory->getAssociationBuilder()->getAssociatedFactory($associationName, $data);
         }
@@ -2348,6 +2357,14 @@ abstract class BaseFactory
      * When `$alias` is null, the alias is auto-resolved by the associated
      * factory's target table — equivalent to the previous single-arg form.
      *
+     * **Pivot precedence (belongsToMany only):** `$pivot` is applied as
+     * `state(['_joinData' => $pivot])` on the passed factory just before it
+     * is registered. Because `state()` merges over earlier state, a
+     * `_joinData` value already set on the passed factory wins on a
+     * per-key basis where it overlaps; non-overlapping keys are kept from
+     * `$pivot`. For a totally pivot-only build, prefer the explicit
+     * `$pivot` argument and don't pre-load `_joinData` on the child.
+     *
      * @param \CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface> $factory Associated factory.
      * @param string|null $alias Explicit association alias on the source table; auto-resolved when null.
      * @param array<string, mixed> $pivot Pivot data for belongsToMany joins.
@@ -2606,6 +2623,12 @@ abstract class BaseFactory
     /**
      * Whether the user added explicit `with()` / `for()` / `has()` calls on
      * this factory after `configure()` registered its defaults.
+     *
+     * Note: this flag only tracks user-set *associations* (the alias-keyed
+     * association list). It does NOT track `state(['_joinData' => ...])` —
+     * pivot data is keyed inside the entity's own data, not in the
+     * association list — so a factory carrying only pivot state still
+     * reports `false` here and remains a candidate for `recycle()`.
      *
      * @internal
      */

--- a/src/Factory/DataCompiler.php
+++ b/src/Factory/DataCompiler.php
@@ -1471,6 +1471,25 @@ class DataCompiler
     }
 
     /**
+     * Reset the process-wide persist-depth counter.
+     *
+     * Normally startPersistMode()/endPersistMode() balance pair-by-pair. If
+     * something throws *between* startPersistMode() and endPersistMode()
+     * (e.g. an exception inside an `afterBuild` callback, a constraint
+     * violation in the middle of saveMany()), the counter stays incremented.
+     * Without a teardown reset, the next test in the same process boots with
+     * `isInPersistMode() === true` even at top level — quietly poisoning its
+     * association resolution. Called from the transaction strategy's
+     * setupTest()/teardownTest() to make the boundary visible.
+     *
+     * @return void
+     */
+    public static function resetPersistDepth(): void
+    {
+        self::$persistDepth = 0;
+    }
+
+    /**
      * @return array<string>
      */
     public function getEnforcedFields(): array

--- a/src/Factory/Sequence.php
+++ b/src/Factory/Sequence.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace CakephpFixtureFactories\Factory;
 
 use CakephpFixtureFactories\Generator\GeneratorInterface;
+use InvalidArgumentException;
 
 /**
  * Context passed to a `sequence()` callable.
@@ -62,6 +63,8 @@ final readonly class Sequence
      * @param int $total Total number of entities the factory will build (`BaseFactory::getTimes()`).
      * @param \CakephpFixtureFactories\Factory\BaseFactory<TEntity> $factory Owning factory.
      * @param \CakephpFixtureFactories\Generator\GeneratorInterface $generator Configured fixture generator (Faker / DummyGenerator / custom).
+     *
+     * @throws \InvalidArgumentException
      */
     public function __construct(
         public int $index,
@@ -69,6 +72,22 @@ final readonly class Sequence
         public BaseFactory $factory,
         public GeneratorInterface $generator,
     ) {
+        // Self-validating value object: catch internal-misuse early
+        // (a bad index/total contradicts the iteration semantics the rest
+        // of the file uses — `isFirst` / `isLast` derive from them).
+        if ($total < 1) {
+            throw new InvalidArgumentException(sprintf(
+                'Sequence: total must be >= 1 (received %d).',
+                $total,
+            ));
+        }
+        if ($index < 0 || $index >= $total) {
+            throw new InvalidArgumentException(sprintf(
+                'Sequence: index must be in [0, %d) (received %d).',
+                $total,
+                $index,
+            ));
+        }
         $this->position = $index + 1;
         $this->isFirst = $index === 0;
         $this->isLast = $index === $total - 1;

--- a/src/Scenario/Story.php
+++ b/src/Scenario/Story.php
@@ -93,9 +93,22 @@ abstract class Story implements FixtureScenarioInterface
      *
      * @param string $pool Pool identifier (any non-empty string).
      * @param \Cake\Datasource\EntityInterface|array<int, \Cake\Datasource\EntityInterface> $entities
+     *
+     * @throws \CakephpFixtureFactories\Error\FixtureScenarioException
      */
     protected function addToPool(string $pool, EntityInterface|array $entities): static
     {
+        // Empty pool name slips through PHP's typecheck (string accepts '')
+        // but then collides with `guardPoolExists('')` from the read side —
+        // and the read side's typo message ("Available pools: `, `foo`")
+        // is incomprehensible because of how implode renders an empty key.
+        // Refuse at write time instead.
+        if ($pool === '') {
+            throw new FixtureScenarioException(sprintf(
+                '`%s::addToPool()` requires a non-empty pool name.',
+                static::class,
+            ));
+        }
         if ($entities instanceof EntityInterface) {
             $entities = [$entities];
         }

--- a/src/TestSuite/FactoryTransactionStrategy.php
+++ b/src/TestSuite/FactoryTransactionStrategy.php
@@ -9,6 +9,7 @@ use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\Fixture\FixtureStrategyInterface;
 use CakephpFixtureFactories\Error\PersistenceException;
 use CakephpFixtureFactories\Factory\BaseFactory;
+use CakephpFixtureFactories\Factory\DataCompiler;
 use CakephpFixtureFactories\Generator\CakeGeneratorFactory;
 use RuntimeException;
 use Throwable;
@@ -102,6 +103,10 @@ class FactoryTransactionStrategy implements FixtureStrategyInterface
         CakeGeneratorFactory::clearInstances();
         BaseFactory::resetDefaultGenerator();
 
+        // Reset persist-mode depth — a previous test that threw mid-save
+        // (e.g. inside afterBuild) would have left the counter incremented.
+        DataCompiler::resetPersistDepth();
+
         // Eagerly wrap the primary test connection so direct
         // $table->save() / raw insert calls inside a test are also
         // rolled back at teardown. Subclasses that want fully lazy
@@ -152,6 +157,7 @@ class FactoryTransactionStrategy implements FixtureStrategyInterface
             FactoryTableTracker::getInstance()->clear();
             CakeGeneratorFactory::clearInstances();
             BaseFactory::resetDefaultGenerator();
+            DataCompiler::resetPersistDepth();
         }
     }
 

--- a/src/TestSuite/TableAssertionsTrait.php
+++ b/src/TestSuite/TableAssertionsTrait.php
@@ -205,12 +205,48 @@ trait TableAssertionsTrait
      * @param class-string<\CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface>>|null $factoryClass
      *     Optional factory class to scope the lookup; see {@see self::assertEntityExists()}.
      * @param string|null $message Optional custom failure message.
+     *
+     * @throws \InvalidArgumentException
      */
     public function assertEntityMissing(
         EntityInterface $entity,
         ?string $factoryClass = null,
         ?string $message = null,
     ): void {
+        // Distinguish "never saved" from "was saved, then deleted".
+        // Without this guard, an unsaved entity makes the assertion pass
+        // silently — worse than no assertion, since the test reads green
+        // and the user thinks deletion worked.
+        //
+        // Two discriminators, in order:
+        //   1. `isNew() === true` — the canonical Cake marker. `build()`
+        //      returns isNew=true entities; `save()` and `get()` return
+        //      isNew=false. This catches the application-assigned-PK
+        //      (UUID / string) case where a PK exists at build time but
+        //      the row was never written.
+        //   2. Null PK component — defensive fallback for hand-built
+        //      entities that bypassed marshalling and never had isNew
+        //      flipped (a raw `new Entity()` with no setNew() call).
+        $table = self::resolveTableForEntity($entity, $factoryClass);
+        if ($entity->isNew() === true) {
+            throw new InvalidArgumentException(sprintf(
+                'assertEntityMissing(): entity `%s` is still marked as new (isNew()=true) — '
+                . 'it was never persisted, so "missing" cannot be verified. Save the entity '
+                . 'first (then delete it) before asserting it is missing.',
+                $entity::class,
+            ));
+        }
+        foreach ((array)$table->getPrimaryKey() as $field) {
+            if ($entity->get($field) === null) {
+                throw new InvalidArgumentException(sprintf(
+                    'assertEntityMissing(): entity `%s` has no value for primary key `%s` — '
+                    . 'it was never persisted, so "missing" cannot be verified. Save the entity '
+                    . 'first (then delete it) before asserting it is missing.',
+                    $entity::class,
+                    $field,
+                ));
+            }
+        }
         $exists = self::entityExistsInDatabase($entity, $factoryClass);
         $this->assertFalse(
             $exists,

--- a/tests/TestCase/Factory/BaseFactoryAssociationsTest.php
+++ b/tests/TestCase/Factory/BaseFactoryAssociationsTest.php
@@ -292,6 +292,47 @@ class BaseFactoryAssociationsTest extends TestCase
         $this->assertSame($n, CustomerFactory::query()->count());
     }
 
+    public function testWithBracketCountOnLeafFactoryArgument(): void
+    {
+        // `with('Alias[N]', SomeFactory::new())` previously dropped the [N]
+        // because the no-dot factory-leaf branch took the passed factory
+        // verbatim, bypassing AssociationBuilder::getAssociatedFactory()
+        // (which is the path that applies the bracket count). Result was
+        // a silent 1-row build instead of N.
+        $times = 4;
+
+        $country = CountryFactory::new()
+            ->with("Cities[$times]", CityFactory::new())
+            ->save();
+
+        $country = CountryFactory::table()->get($country->id, contain: ['Cities']);
+        $this->assertCount(
+            $times,
+            $country->cities,
+            'with("Alias[N]", SomeFactory::new()) must honor [N] just like the array-data path.',
+        );
+    }
+
+    public function testWithBracketCountOnLeafFactoryRespectsExplicitChainedCount(): void
+    {
+        // When the passed factory already chains its own count, the bracket
+        // count overrides it — matching the array-path semantics where
+        // `with('Cities[3]', $array)` always builds 3 regardless of how
+        // many rows are inside `$array` (extras are dropped, fewer are recycled).
+        $bracketCount = 3;
+
+        $country = CountryFactory::new()
+            ->with("Cities[$bracketCount]", CityFactory::new()->count(1))
+            ->save();
+
+        $country = CountryFactory::table()->get($country->id, contain: ['Cities']);
+        $this->assertCount(
+            $bracketCount,
+            $country->cities,
+            'Bracket count must take precedence over the leaf factory\'s own count().',
+        );
+    }
+
     public function testSaveMultipleHasManyAssociationAndTimesWithBrackets(): void
     {
         $times = 5;

--- a/tests/TestCase/Factory/BaseFactorySequenceObjectTest.php
+++ b/tests/TestCase/Factory/BaseFactorySequenceObjectTest.php
@@ -12,8 +12,10 @@ namespace CakephpFixtureFactories\Test\TestCase\Factory;
 
 use Cake\TestSuite\TestCase;
 use CakephpFixtureFactories\Factory\Sequence;
+use CakephpFixtureFactories\Generator\CakeGeneratorFactory;
 use CakephpFixtureFactories\Test\Factory\CountryFactory;
 use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
+use InvalidArgumentException;
 
 /**
  * `BaseFactory::sequence()` callables receive a single `Sequence` context
@@ -125,6 +127,45 @@ class BaseFactorySequenceObjectTest extends TestCase
 
         $this->assertSame([0, 1, 2, 3, 4], $seenIndexes);
         $this->assertSame([1, 2, 3, 4, 5], $seenPositions);
+    }
+
+    public function testConstructorRejectsZeroOrNegativeTotal(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/total must be >= 1/');
+
+        new Sequence(
+            index: 0,
+            total: 0,
+            factory: CountryFactory::new(),
+            generator: CakeGeneratorFactory::create(),
+        );
+    }
+
+    public function testConstructorRejectsNegativeIndex(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/index must be in \[0, 3\)/');
+
+        new Sequence(
+            index: -1,
+            total: 3,
+            factory: CountryFactory::new(),
+            generator: CakeGeneratorFactory::create(),
+        );
+    }
+
+    public function testConstructorRejectsIndexAtOrAboveTotal(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/index must be in \[0, 3\)/');
+
+        new Sequence(
+            index: 3,
+            total: 3,
+            factory: CountryFactory::new(),
+            generator: CakeGeneratorFactory::create(),
+        );
     }
 
     public function testTotalReflectsCountValue(): void

--- a/tests/TestCase/Scenario/StoryTest.php
+++ b/tests/TestCase/Scenario/StoryTest.php
@@ -235,4 +235,22 @@ class StoryTest extends TestCase
 
         $this->loadFixtureScenario(AssertionFailingStory::class);
     }
+
+    public function testAddToPoolRejectsEmptyPoolName(): void
+    {
+        // An empty pool name slips past PHP's `string` type but produces
+        // a useless error on the read side (`guardPoolExists('')`). Refuse
+        // it at write time with a clear message.
+        $story = new class () extends Story {
+            protected function build(): void
+            {
+                $this->addToPool('', CountryFactory::new()->save());
+            }
+        };
+
+        $this->expectException(FixtureScenarioException::class);
+        $this->expectExceptionMessageMatches('/addToPool.* requires a non-empty pool name/');
+
+        $story->load();
+    }
 }

--- a/tests/TestCase/TestSuite/FactoryTransactionStrategyTest.php
+++ b/tests/TestCase/TestSuite/FactoryTransactionStrategyTest.php
@@ -11,6 +11,7 @@ use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use CakephpFixtureFactories\Error\PersistenceException;
 use CakephpFixtureFactories\Factory\BaseFactory;
+use CakephpFixtureFactories\Factory\DataCompiler;
 use CakephpFixtureFactories\Generator\FakerAdapter;
 use CakephpFixtureFactories\Test\Factory\ArticleFactory;
 use CakephpFixtureFactories\Test\Factory\AuthorFactory;
@@ -276,6 +277,64 @@ class FactoryTransactionStrategyTest extends TestCase
         $strategy->teardownTest();
 
         $this->assertNull(FactoryTransactionStrategy::getActiveInstance());
+    }
+
+    public function testStrategyResetsLeakedPersistDepth(): void
+    {
+        // DataCompiler::$persistDepth is process-wide. If a prior test
+        // threw between startPersistMode() and endPersistMode() (e.g.
+        // an exception inside afterBuild), the depth counter would
+        // stay incremented and the next test would boot already in
+        // persist mode — silently poisoning its association resolution.
+        // setupTest() must reset it.
+        $factory = CityFactory::new();
+        $compiler = $this->dataCompiler($factory);
+        $compiler->startPersistMode();
+        $compiler->startPersistMode();
+        $this->assertTrue($compiler->isInPersistMode(), 'Precondition: depth > 0.');
+
+        $strategy = new LazyFactoryTransactionStrategy();
+        $strategy->setupTest([]);
+
+        $this->assertFalse(
+            $compiler->isInPersistMode(),
+            'setupTest() must reset the leaked persist-depth counter to zero.',
+        );
+
+        $strategy->teardownTest();
+    }
+
+    public function testTeardownResetsLeakedPersistDepth(): void
+    {
+        // Symmetric guarantee on the teardown side: a test that throws
+        // after startPersistMode() but before endPersistMode() must not
+        // leave the counter elevated for the next test in the same process.
+        $strategy = new LazyFactoryTransactionStrategy();
+        $strategy->setupTest([]);
+
+        $factory = CityFactory::new();
+        $compiler = $this->dataCompiler($factory);
+        $compiler->startPersistMode();
+        $this->assertTrue($compiler->isInPersistMode());
+
+        $strategy->teardownTest();
+
+        $this->assertFalse(
+            $compiler->isInPersistMode(),
+            'teardownTest() must reset the leaked persist-depth counter to zero.',
+        );
+    }
+
+    /**
+     * Access a factory's private DataCompiler instance for whitebox
+     * persist-depth assertions. Reflection-only: the depth counter is
+     * not part of the public API.
+     */
+    private function dataCompiler(BaseFactory $factory): DataCompiler
+    {
+        $reflection = new ReflectionProperty(BaseFactory::class, 'dataCompiler');
+
+        return $reflection->getValue($factory);
     }
 
     public function testStrategyResetsSharedDefaultGenerator(): void

--- a/tests/TestCase/TestSuite/TableAssertionsTraitTest.php
+++ b/tests/TestCase/TestSuite/TableAssertionsTraitTest.php
@@ -15,7 +15,9 @@ use CakephpFixtureFactories\Test\Factory\CityFactory;
 use CakephpFixtureFactories\Test\Factory\CountryFactory;
 use CakephpFixtureFactories\TestSuite\TableAssertionsTrait;
 use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
+use InvalidArgumentException;
 use PHPUnit\Framework\AssertionFailedError;
+use TestApp\Model\Entity\Country;
 
 /**
  * Tests for `TableAssertionsTrait` — expressive assertions composed over
@@ -142,6 +144,52 @@ class TableAssertionsTraitTest extends TestCase
             fn () => $this->assertEntityMissing($country),
         );
         $this->assertMatchesRegularExpression('/missing.*still exists/i', $message);
+    }
+
+    public function testAssertEntityMissingRejectsNeverPersistedEntity(): void
+    {
+        // A built-but-not-saved entity has a null primary key. The previous
+        // implementation short-circuited to false on null PK and silently
+        // passed — a green test that proved nothing. The guard must instead
+        // throw so the caller knows they need to save (then delete) first.
+        $country = CountryFactory::new(['name' => 'NeverSaved'])->build();
+
+        // try/catch instead of expectException so the file-level CS rule
+        // "no assert* after expect*" stays happy — the trait method is
+        // named assertEntityMissing(), which the rule treats as an
+        // assertion call.
+        $caught = null;
+        try {
+            $this->assertEntityMissing($country);
+        } catch (InvalidArgumentException $e) {
+            $caught = $e;
+        }
+        $this->assertNotNull($caught, 'Expected InvalidArgumentException for never-persisted entity.');
+        $this->assertMatchesRegularExpression('/it was never persisted/', $caught->getMessage());
+    }
+
+    public function testAssertEntityMissingRejectsNeverPersistedEntityWithPreassignedPrimaryKey(): void
+    {
+        // Application-assigned-PK case (UUID / string IDs): the entity carries
+        // a non-null PK at build time but was never written. The null-PK guard
+        // alone would let it slip past; the isNew() guard catches it.
+        $country = new Country([
+            'id' => 999_999,
+            'name' => 'Pre-assigned but never saved',
+        ]);
+        $country->setSource('Countries');
+
+        $caught = null;
+        try {
+            $this->assertEntityMissing($country);
+        } catch (InvalidArgumentException $e) {
+            $caught = $e;
+        }
+        $this->assertNotNull(
+            $caught,
+            'Expected InvalidArgumentException for an isNew() entity even with a pre-assigned PK.',
+        );
+        $this->assertMatchesRegularExpression('/it was never persisted/', $caught->getMessage());
     }
 
     public function testAssertTableHasComposesAcrossFactoryClasses(): void


### PR DESCRIPTION
A single bundled pass over the remaining P3 audit items. Six small, orthogonal correctness fixes, each with matching tests and (where user-facing) docs.

## Source changes

- **`BaseFactory::with('Alias[N]', SomeFactory::new())` — honor the bracket count on the leaf-factory branch.**
  The no-dot factory path used to take the passed factory verbatim and bypass the bracket-aware `getAssociatedFactory()`, so `[N]` was silently dropped and only 1 row was built. Bracket count now overrides any chained `count()` on the passed factory, matching the array-data path's semantics.

- **`Sequence` value object — self-validate `index`/`total`.**
  A bad index or non-positive total contradicts the `isFirst`/`isLast`/`position` derivation; the old constructor accepted them silently and emitted nonsensical iteration context. Throws `InvalidArgumentException` instead.

- **`Story::addToPool('', ...)` — refuse empty pool names.**
  PHP's `string` type accepts `''` but the read side's `guardPoolExists('')` renders an incomprehensible "Available pools: `, ``foo``" error. Refuse at write time with a clear message.

- **`TableAssertionsTrait::assertEntityMissing()` — distinguish "never saved" from "was saved, then deleted".**
  The previous implementation short-circuited to `false` on a null PK and silently passed for never-persisted entities — green test, proved nothing. The guard now checks `isNew()` first (catches application-assigned-PK / UUID-string cases) and falls back to a null-PK check for hand-built entities that bypassed marshalling.

- **`DataCompiler::resetPersistDepth()` + transaction-strategy hook.**
  The process-wide `$persistDepth` counter could stay incremented after a prior test threw between `startPersistMode()` and `endPersistMode()` (e.g. exception inside `afterBuild`). Subsequent tests would boot already in persist mode, silently poisoning association resolution. `setupTest()` and `teardownTest()` now reset the counter alongside the existing generator/tracker resets.

- **`BaseFactory` docblocks** — clarify `has()` pivot precedence (state-merge semantics for `_joinData`) and `hasUserSetAssociations()` scope vs pivot state. No behavior change.

## Tests

Each fix gets paired coverage in the existing test file for that class:

- `BaseFactoryAssociations`: `with('Alias[N]', $factory)` honors `[N]`; bracket count overrides the leaf factory's own `count()`.
- `BaseFactorySequenceObject`: constructor rejects zero/negative total, negative index, and index-at-or-above-total.
- `Story`: `addToPool('')` is refused with `FixtureScenarioException`.
- `TableAssertionsTrait`: `assertEntityMissing` throws on a built-only entity AND on a pre-assigned-PK entity that was never saved.
- `FactoryTransactionStrategy`: setup and teardown both reset a leaked persist-depth counter.

## Docs

- `docs/guide/associations.md` — bracket count works on leaf factories and overrides chained `count()`.
- `docs/guide/queries.md` — `IMPORTANT` box on `assertEntityMissing`'s `isNew`/PK guard for never-persisted entities.
- `docs/guide/scenarios.md` — `addToPool` API note that empty pool names are refused.

## Gates

- `composer sqlite`: 753 tests, 2577 assertions, 11 skipped, 0 failures.
- `composer stan`: clean.
- `composer cs-check`: clean.
- `codex review --uncommitted`: clean on the second pass (initial pass surfaced a P2 about UUID/string-PK entities slipping past the null-PK check; addressed by switching the primary discriminator to `isNew()` with PK-null as fallback).