### PR TITLE
Close hasMany-recycle follow-up: tests + doc clarification

### DIFF
--- a/docs/guide/associations.md
+++ b/docs/guide/associations.md
@@ -236,6 +236,21 @@ AddressFactory::new()
     ->saveMany();
 ```
 
+Propagation also crosses `hasMany` and `belongsToMany` edges — only the *substitution* is belongsTo-scoped (see [boundary](#when-recycle-doesnt-help) below). So a `belongsTo` branch inside a hasMany child still substitutes:
+
+```php
+$author = AuthorFactory::new()->save();
+
+// ArticlesAuthors is the junction table for Articles ↔ Authors.
+// recycle($author) flows down through the hasMany junction row into
+// ArticlesAuthor.belongsTo Authors and reuses $author instead of inserting fresh:
+ArticleFactory::new()
+    ->without('Authors') // drop the BTM default to isolate the junction path
+    ->with('ArticlesAuthors', ArticlesAuthorFactory::new()->with('Authors'))
+    ->recycle($author)
+    ->save();
+```
+
 ### Multiple recycles
 
 `recycle()` is variadic and chainable. Each call merges into the recycle map (last call wins for the same target table):
@@ -271,7 +286,7 @@ AuthorFactory::new()
 
 - The build graph has no registered `belongsTo` to the recycled entity's table — recycle is a silent no-op.
 - You need different parents on different branches — use `with('AliasName', $entity)` per branch.
-- You want to reuse a `hasMany` or `belongsToMany` collection — recycle only substitutes single-row `belongsTo` parents. Use `with()` with concrete entities for the many side.
+- You want to reuse a `hasMany` or `belongsToMany` collection — recycle only substitutes single-row `belongsTo` parents. The to-many entity itself is always freshly built; recycle flows *into* it so its own belongsTo branches may substitute, but the row itself never collapses into the recycled target. Use `with()` with concrete entities for the many side.
 
 ## `from()` — start from an existing entity
 

--- a/tests/TestCase/Factory/BaseFactoryRecycleTest.php
+++ b/tests/TestCase/Factory/BaseFactoryRecycleTest.php
@@ -13,6 +13,8 @@ namespace CakephpFixtureFactories\Test\TestCase\Factory;
 use Cake\TestSuite\TestCase;
 use CakephpFixtureFactories\Error\AssociationBuilderException;
 use CakephpFixtureFactories\Test\Factory\AddressFactory;
+use CakephpFixtureFactories\Test\Factory\ArticleFactory;
+use CakephpFixtureFactories\Test\Factory\ArticlesAuthorFactory;
 use CakephpFixtureFactories\Test\Factory\AuthorFactory;
 use CakephpFixtureFactories\Test\Factory\BillFactory;
 use CakephpFixtureFactories\Test\Factory\CityFactory;
@@ -357,5 +359,80 @@ class BaseFactoryRecycleTest extends TestCase
             ->save();
 
         $this->assertSame($second->id, $address->city_id);
+    }
+
+    public function testRecyclePropagatesThroughHasManyChildToSiblingBelongsTo(): void
+    {
+        // recycle()'s propagation contract: the recycle map flows DOWN through
+        // every child factory in the build graph, including ones reached
+        // through hasMany / belongsToMany edges. ArticlesAuthors is the
+        // junction table for the Articles ↔ Authors many-to-many; built via
+        // ArticlesAuthorFactory it has TWO belongsTo edges:
+        //   - belongsTo Articles (stripped at build time — the parent IS the
+        //     article)
+        //   - belongsTo Authors (the sibling edge we want recycle to hit)
+        //
+        // Note the explicit without('Authors'): ArticleFactory.configure()
+        // adds the BTM Authors default via hasAuthors(2). Recycle DOES NOT
+        // substitute to-many edges — only belongsTo. To isolate the
+        // belongsTo-inside-junction propagation under test, drop the
+        // default BTM so we're not asserting on a mix of recycled
+        // (junction-side) and fresh (BTM-side) authors.
+        $author = AuthorFactory::new(['name' => 'Recycled Through HasMany'])->save();
+        $authorsBefore = AuthorFactory::query()->count();
+
+        $article = ArticleFactory::new()
+            ->without('Authors')
+            ->with('ArticlesAuthors', ArticlesAuthorFactory::new()->with('Authors'))
+            ->recycle($author)
+            ->save();
+
+        $this->assertNotNull($article->id);
+
+        $junctionRows = ArticlesAuthorFactory::query()
+            ->where(['article_id' => $article->id])
+            ->toArray();
+        $this->assertCount(1, $junctionRows, 'Exactly one junction row for the article.');
+        $this->assertSame(
+            $author->id,
+            $junctionRows[0]->author_id,
+            'Junction row must reference the recycled $author, not a freshly built one.',
+        );
+
+        $this->assertSame(
+            $authorsBefore,
+            AuthorFactory::query()->count(),
+            'recycle($author) must propagate through hasMany ArticlesAuthors into '
+            . 'ArticlesAuthor.belongsTo Authors — no fresh author should be inserted.',
+        );
+    }
+
+    public function testRecycleDoesNotSubstituteDirectBelongsToManyChild(): void
+    {
+        // Contract boundary: recycle() substitutes BELONGS-TO edges only.
+        // A direct belongsToMany child (here ArticleFactory.hasAuthors(2)
+        // adds Authors via the BTM edge) keeps its factory-built identity —
+        // the recycle map flows DOWN into it so any belongsTo branch it
+        // contains may substitute, but the to-many entity itself is never
+        // swapped for the recycled one. This makes the audit-flagged
+        // hasMany-propagation test (above) load-bearing in the opposite
+        // direction too: without this boundary, recycle would silently
+        // collapse legitimate to-many builds into the recycle target.
+        $existing = AuthorFactory::new(['name' => 'Existing'])->save();
+        $authorsBefore = AuthorFactory::query()->count();
+
+        // ArticleFactory.configure() calls hasAuthors(2) by default.
+        $article = ArticleFactory::new()
+            ->recycle($existing)
+            ->save();
+
+        // The 2 default BTM Authors must each be a freshly inserted author —
+        // NOT $existing duplicated twice.
+        $this->assertNotNull($article->id);
+        $this->assertSame(
+            $authorsBefore + ArticleFactory::DEFAULT_NUMBER_OF_AUTHORS,
+            AuthorFactory::query()->count(),
+            'BTM Authors children must build fresh; recycle does not substitute belongsToMany edges.',
+        );
     }
 }


### PR DESCRIPTION
## Closes the PR #100 follow-up

PR #100 deferred hasMany / belongsToMany recycle coverage citing a TestApp-schema blocker (back-link strip + hard-wired hasMany back-FK). Re-investigated and the implementation has always supported propagation through to-many edges — `DataCompiler::mergeWithToMany()` already calls `inheritRecycledEntities()` on every to-many child:

```php
private function mergeWithToMany(EntityInterface $entity, string $associationName, array $data): void
{
    $associationData = $entity->get($associationName);
    $recycles = $this->factory->getRecycledEntities();
    foreach ($data as $factory) {
        if ($recycles !== []) {
            $factory = $factory->inheritRecycledEntities($recycles);  // ← propagation
        }
        ...
    }
}
```

So the recycle map already flows DOWN through hasMany / belongsToMany edges; only the *substitution* itself is `belongsTo`-scoped. The original test that triggered the "follow-up" almost certainly hit `ArticleFactory.configure()`'s default `hasAuthors(2)` BTM and asserted on a junction-count that silently included those defaults — i.e. the test was contradicting itself. The blocker was the test construction, not a missing capability.

## What this PR adds

Two regression tests that close the coverage gap and pin both sides of the substitution contract:

- **`testRecyclePropagatesThroughHasManyChildToSiblingBelongsTo`** —
  `ArticleFactory.with('ArticlesAuthors', ArticlesAuthorFactory::new()->with('Authors')).recycle($author)` reuses the recycled author for the junction row instead of inserting a fresh one. Uses `->without('Authors')` first to drop the BTM default so the assertion isolates the junction path.

- **`testRecycleDoesNotSubstituteDirectBelongsToManyChild`** — contract boundary:
  `recycle($author)` on an `ArticleFactory` build that uses the default `hasAuthors(2)` BTM produces two FRESH authors, not the recycled one duplicated twice. Documents that the to-many entity itself is never substituted; only `belongsTo` branches inside it are.

## Docs

- `docs/guide/associations.md` gains a hasMany propagation example.
- The existing "When `recycle()` doesn't help" bullet is tightened: recycle flows *into* to-many children for their `belongsTo` branches, but never collapses the to-many row itself.

## What this PR does NOT do

No `src/` change — pure coverage + doc tightening. The implementation is unchanged.

## Gates

- `composer sqlite`: 756 tests, 2588 assertions, 0 failures (11 pre-existing skips).
- `composer stan`: clean.
- `composer cs-check`: clean.
- `codex review --uncommitted`: clean.