### PR TITLE
Fix: configure()-time withRequiredParents() loses FK-column propagation

### DIFF
--- a/src/Factory/DataCompiler.php
+++ b/src/Factory/DataCompiler.php
@@ -1165,13 +1165,24 @@ class DataCompiler
 
     /**
      * Used in the Factory make in order to distinguish default associations
-     * from conscious associations
+     * from conscious associations.
+     *
+     * Anything still in `$dataFromAssociations` at the end of `setUp()` was
+     * contributed by `configure()` and is, by definition, a factory default
+     * — promote it. Anything already in `$dataFromDefaultAssociations` was
+     * placed there *during* `configure()` (e.g. via
+     * {@see self::demoteAssociationToDefault()} when `configure()` ran
+     * `$this->withRequiredParents()`); those entries must be preserved.
+     *
+     * Use a left-priority union (`+`) so a user-set alias still wins over a
+     * pre-existing default for the same alias, matching the original
+     * "explicit beats default" semantic.
      *
      * @return void
      */
     public function collectAssociationsFromDefaultTemplate(): void
     {
-        $this->dataFromDefaultAssociations = $this->dataFromAssociations;
+        $this->dataFromDefaultAssociations = $this->dataFromAssociations + $this->dataFromDefaultAssociations;
         $this->dataFromAssociations = [];
     }
 

--- a/tests/Factory/RequiredParentsAuthorConfiguredFactory.php
+++ b/tests/Factory/RequiredParentsAuthorConfiguredFactory.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace CakephpFixtureFactories\Test\Factory;
+
+use CakephpFixtureFactories\Factory\BaseFactory;
+use CakephpFixtureFactories\Generator\GeneratorInterface;
+
+/**
+ * Same as RequiredParentsAuthorFactory, but invokes withRequiredParents()
+ * from configure() (the canonical "factory-encoded default" form used by
+ * downstream consumers) rather than expecting callers to chain it on at
+ * `::new(...)` sites.
+ *
+ * @extends BaseFactory<\TestApp\Model\Entity\Author>
+ */
+class RequiredParentsAuthorConfiguredFactory extends BaseFactory
+{
+    protected function getRootTableRegistryName(): string
+    {
+        return 'Authors';
+    }
+
+    public function definition(GeneratorInterface $generator): array
+    {
+        return [
+            'name' => $generator->name(),
+        ];
+    }
+
+    protected function configure(): static
+    {
+        return $this->withRequiredParents();
+    }
+}

--- a/tests/TestCase/Factory/BaseFactoryWithRequiredParentsTest.php
+++ b/tests/TestCase/Factory/BaseFactoryWithRequiredParentsTest.php
@@ -24,6 +24,7 @@ use CakephpFixtureFactories\ORM\FactoryTableRegistry;
 use CakephpFixtureFactories\Test\Factory\AddressFactory;
 use CakephpFixtureFactories\Test\Factory\CityFactory;
 use CakephpFixtureFactories\Test\Factory\CountryFactory;
+use CakephpFixtureFactories\Test\Factory\RequiredParentsAuthorConfiguredFactory;
 use CakephpFixtureFactories\Test\Factory\RequiredParentsAuthorFactory;
 use CakephpFixtureFactories\Test\Factory\RequiredParentsCompositeOptInTableWithoutModelFactory;
 use CakephpFixtureFactories\Test\Factory\RequiredParentsExcludeAuthorFactory;
@@ -955,5 +956,36 @@ class BaseFactoryWithRequiredParentsTest extends TestCase
         );
         // Addresses still fan out (Address was not recycled).
         $this->assertSame(4, AddressFactory::query()->count());
+    }
+
+    /**
+     * The canonical downstream-consumer form: a factory whose `configure()`
+     * encodes `withRequiredParents()` as its default. Calling
+     * `Factory::new()->save()` (with no explicit chain on the call site)
+     * must compose the required parents AND propagate their ids into the
+     * child's foreign-key columns — same contract as calling
+     * `withRequiredParents()` externally on the new() result.
+     *
+     * Regression guard: a previous change demoted auto-resolved parents to
+     * the configure-defaults bucket so recycle() can substitute them; that
+     * must not lose foreign-key column propagation on the configure()-time
+     * path.
+     *
+     * @return void
+     */
+    public function testConfigureTimeWithRequiredParentsPropagatesForeignKey(): void
+    {
+        $author = RequiredParentsAuthorConfiguredFactory::new()->save();
+
+        $this->assertNotNull($author->id);
+        $this->assertNotNull(
+            $author->address_id,
+            'Required Address must be composed AND its id propagated into address_id, '
+            . 'whether withRequiredParents() is called externally or from configure().',
+        );
+        // The composed Address really persisted (id reachable via the FK).
+        $address = TableRegistry::getTableLocator()->get('Addresses')
+            ->find()->where(['id' => $author->address_id])->first();
+        $this->assertNotNull($address, 'Composed Address must be persisted and matchable by the propagated FK.');
     }
 }


### PR DESCRIPTION
## Summary

A factory whose `configure()` returns `$this->withRequiredParents()` — the canonical downstream-consumer form — fails on persist with a `NOT NULL` violation on the child's belongsTo foreign-key column. The composed parent IS built, but its id never propagates into the child's FK column. Calling `withRequiredParents()` externally on the `::new(...)` result works fine; only the `configure()`-time path is broken.

## Repro

```php
class RequiredParentsAuthorConfiguredFactory extends BaseFactory
{
    protected function getRootTableRegistryName(): string { return 'Authors'; }
    public function definition(GeneratorInterface $g): array { return ['name' => $g->name()]; }
    protected function configure(): static { return $this->withRequiredParents(); }
}

RequiredParentsAuthorConfiguredFactory::new()->save();
// SQLSTATE[23000]: NOT NULL constraint failed: authors.address_id
```

Equivalent external-call form has always worked and is already covered by `testComposesRequiredBelongsToChain`:

```php
RequiredParentsAuthorFactory::new()->withRequiredParents()->save(); // OK, address_id propagated
```

## Cause

`BaseFactory::setUp()` calls, in order:

1. `$factory = $this->configure();` — when `configure()` returns `$this->withRequiredParents()`, the auto-resolved parents are placed into `$dataFromAssociations` via `->with()`, then **demoted** into `$dataFromDefaultAssociations` by `demoteAssociationToDefault()` (the recycle-friendly path introduced in #89).
2. `$factory->getDataCompiler()->collectAssociationsFromDefaultTemplate();`

The collect step was an **overwrite** rather than a merge:

```php
$this->dataFromDefaultAssociations = $this->dataFromAssociations;  // wipes!
$this->dataFromAssociations = [];
```

At this point `$dataFromAssociations` is empty (everything is already in defaults via the demote in step 1). The assignment overwrites the default bucket with `[]`, **silently dropping every parent `withRequiredParents()` just composed**. Save then proceeds with no parents, and the child's `_id` column stays unset.

This regression was introduced by #89's demote: the demoted-to-default state is destroyed by the very next step in `setUp()`.

## Fix

Promote with a left-priority union so user-set entries still beat pre-existing defaults on alias collision (preserving the original "explicit beats default" semantic), and pre-existing defaults from `demoteAssociationToDefault()` survive `setUp()`:

```php
$this->dataFromDefaultAssociations = $this->dataFromAssociations + $this->dataFromDefaultAssociations;
$this->dataFromAssociations = [];
```

`collectAssociationsFromDefaultTemplate()` has exactly one caller (`BaseFactory::setUp()`), so the change is scoped.

## Tests

- Added `tests/Factory/RequiredParentsAuthorConfiguredFactory.php` — same as `RequiredParentsAuthorFactory` but with `configure()` returning `$this->withRequiredParents()`.
- Added `testConfigureTimeWithRequiredParentsPropagatesForeignKey()` — fails on `main` HEAD without the patch, passes with it.

Full lib suite still green: **757 tests, 2591 assertions, 0 errors, 0 failures**.

## Verified against downstream

The original report came from a CakePHP 5 app whose factories use `configure(): static { return $this->withRequiredParents(); }`. With the patch applied to the app's vendor, the 8 previously-failing classes (Goals/Outbreaks/SignificantDates/ResidentBackgrounds/TempDischarges/ActivityNames table tests + Rooms/Units controller tests) are green: **OK (33 tests, 73 assertions)** with `--fail-on-warning --fail-on-risky --fail-on-notice --fail-on-deprecation`.
