### PR TITLE
Fix 3 pinned-FK precedence bugs in withRequiredParents() (rc.3 blockers)

### DIFF
--- a/docs/guide/foreign-keys-in-definition.md
+++ b/docs/guide/foreign-keys-in-definition.md
@@ -79,7 +79,7 @@ Sometimes the test wants a specific orphan id — to assert how the code handles
 ```php
 public function withOrphanAuthorId(): static
 {
-    return $this->patchData(['author_id' => 999999]);
+    return $this->state(['author_id' => 999999]);
 }
 ```
 
@@ -119,7 +119,7 @@ value wins:
 ```php
 // Factory composes the parent in configure()->with('Author').
 // Pinning author_id at the call site auto-skips that composition:
-$article = ArticleFactory::new(['author_id' => $author->id])->persist();
+$article = ArticleFactory::new(['author_id' => $author->id])->save();
 // $article->author_id === $author->id  (no throw-away Author row)
 ```
 

--- a/docs/guide/required-parents.md
+++ b/docs/guide/required-parents.md
@@ -225,11 +225,17 @@ parents" is just not calling `withRequiredParents()`.
   `->with('Alias', $savedEntity)` — is left completely untouched: you
   specified that exact row.
 - A FK pinned at the call site (`Factory::new(['fk' => x])`, `->state()`,
-  `->setField()`, `->patchData()`, `->sequenceField()`, or `->sequence()` when
+  `->setField()`, `->sequenceField()`, or `->sequence()` when
   every row sets it non-null) is detected: the alias is treated as already
   satisfied, so it composes cleanly with
   [`autoSkipComposeOnExplicitForeignKey`](/reference/configuration#autoskipcomposeonexplicitforeignkey)
-  and never double-composes.
+  and never double-composes. The pin check applies uniformly to
+  auto-detected NOT NULL aliases **and** to aliases opted in via the
+  [`requiredParentAssociations()`](#factory-class-hooks-add-and-exclude)
+  additive hook. An instantiation pin (`Factory::new(['fk' => x])`) is
+  only honored when no `sequence()` / `sequenceField()` touches the same
+  field; if it does, the instantiation pin can be overridden at build
+  time, so the parent is composed for safety.
 
 ## Factory-class hooks: add and exclude
 

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -20,6 +20,7 @@ use Cake\Core\Configure;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventManagerInterface;
 use Cake\I18n\I18n;
+use Cake\ORM\Association;
 use Cake\ORM\Association\BelongsTo;
 use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Query\SelectQuery;
@@ -1761,9 +1762,9 @@ abstract class BaseFactory
      * Side-effect free: like every other `with*()` / `for*()` chain method,
      * this only *composes* parent factories. Nothing is written to the
      * database until the root factory is persisted (`->save()` /
-     * `->persist()` / `->saveMany()`), so the parents are created in the same
-     * unit as the root entity — atomic, no orphan rows on a later override or
-     * a failed root save, and `->build()` stays purely in-memory.
+     * `->saveMany()`), so the parents are created in the same unit as the
+     * root entity — atomic, no orphan rows on a later override or a failed
+     * root save, and `->build()` stays purely in-memory.
      *
      * Composes cleanly with the rest of the composition layer:
      *
@@ -2007,7 +2008,16 @@ abstract class BaseFactory
             // recycle()d. Demote it to a configure()-style default so recycle
             // substitution works at every depth, while a caller-composed
             // branch keeps its intent.
-            if ($autoResolved) {
+            //
+            // Skip the demotion when the factory was instantiated from a
+            // concrete entity: the entity-injected build path intentionally
+            // ignores configure()-style defaults (the caller fully specified
+            // the row), so a demoted auto-resolved parent would silently
+            // never compose and the save would crash on NOT NULL. The
+            // trade-off: recycle() cannot substitute auto-resolved parents
+            // on an entity-injected chain — corner case (entity injection +
+            // recycle + withRequiredParents simultaneously).
+            if ($autoResolved && !$factory->isInstantiatedFromEntity()) {
                 $factory->getDataCompiler()->demoteAssociationToDefault($alias);
             }
         }
@@ -2065,6 +2075,15 @@ abstract class BaseFactory
         $instantiationEntity = $honorPinnedFks
             ? $this->getDataCompiler()->getInstantiationEntity()
             : null;
+        // Fields the build will potentially overwrite via sequence() /
+        // sequenceField() — see DataCompiler::fieldsTouchedBySequence(). The
+        // entity-pin probe below must IGNORE these fields for the same reason
+        // getPinnedFields() now does: sequence runs after instantiation, so
+        // an entity-pinned FK that sequence touches without fully pinning is
+        // not reliably set at save time. Pass the set into the helper.
+        $sequenceTouchedFields = $honorPinnedFks
+            ? $this->getDataCompiler()->fieldsTouchedBySequence()
+            : [];
 
         $aliases = [];
         foreach ($table->associations() as $association) {
@@ -2084,29 +2103,8 @@ abstract class BaseFactory
             // site: the parent is already satisfied. Composing it would
             // override the pinned value (an explicit ->with() always wins over
             // autoSkipComposeOnExplicitForeignKey), so skip the alias entirely.
-            $foreignKeysForAlias = array_values(array_filter(
-                (array)$association->getForeignKey(),
-                static fn ($fk): bool => is_string($fk) && $fk !== '',
-            ));
-            if ($foreignKeysForAlias !== []) {
-                $allPinnedNonNull = true;
-                foreach ($foreignKeysForAlias as $fkColumn) {
-                    $pinned =
-                        (array_key_exists($fkColumn, $pinnedFields) && $pinnedFields[$fkColumn] !== null)
-                        || (
-                            $instantiationEntity !== null
-                            && $instantiationEntity->has($fkColumn)
-                            && $instantiationEntity->get($fkColumn) !== null
-                        );
-                    if (!$pinned) {
-                        $allPinnedNonNull = false;
-
-                        break;
-                    }
-                }
-                if ($allPinnedNonNull) {
-                    continue;
-                }
+            if (self::belongsToFkAlreadyPinned($association, $pinnedFields, $instantiationEntity, $sequenceTouchedFields)) {
+                continue;
             }
 
             $foreignKeys = (array)$association->getForeignKey();
@@ -2137,6 +2135,22 @@ abstract class BaseFactory
             if (in_array($alias, $except, true)) {
                 continue;
             }
+            // Honor caller-pinned FKs for hook-opted aliases too. The
+            // auto-detection loop above already skips an alias whose FK is
+            // pinned; the additive hook used to bypass that check, so
+            // ->withRequiredParents() would compose a fresh parent over a
+            // caller-pinned id. Contract: pinned FK wins on BOTH paths.
+            if (
+                $this->getTable()->hasAssociation($alias)
+                && self::belongsToFkAlreadyPinned(
+                    $this->getTable()->getAssociation($alias),
+                    $pinnedFields,
+                    $instantiationEntity,
+                    $sequenceTouchedFields,
+                )
+            ) {
+                continue;
+            }
             if (!in_array($alias, $aliases, true)) {
                 $aliases[] = $alias;
             }
@@ -2150,6 +2164,58 @@ abstract class BaseFactory
         }
 
         return $aliases;
+    }
+
+    /**
+     * Return true when every FK column of the given belongsTo association
+     * is already set to a non-null value by the caller — either via patch
+     * data, sequence (fully pinned), instantiation, or the instantiation
+     * entity. Used by both the auto-detection path and the hook-opted-in
+     * path of {@see self::resolveRequiredParentAliases()} so that a
+     * caller-pinned FK uniformly wins on either side.
+     *
+     * Fields appearing in `$sequenceTouchedFields` are excluded from the
+     * entity-side probe: `sequence()` / `sequenceField()` runs AFTER
+     * instantiation at build time, so an entity-side pin that sequence
+     * touches without fully pinning is not reliably set at save time.
+     * The array side of this is already handled by
+     * {@see DataCompiler::getPinnedFields()}.
+     *
+     * @internal
+     *
+     * @param \Cake\ORM\Association $association belongsTo to inspect
+     * @param array<string, mixed> $pinnedFields {@see DataCompiler::getPinnedFields()} result
+     * @param \Cake\Datasource\EntityInterface|null $instantiationEntity Factory::new($entity) payload, if any
+     * @param array<string, true> $sequenceTouchedFields {@see DataCompiler::fieldsTouchedBySequence()} result
+     */
+    private static function belongsToFkAlreadyPinned(
+        Association $association,
+        array $pinnedFields,
+        ?EntityInterface $instantiationEntity,
+        array $sequenceTouchedFields = [],
+    ): bool {
+        $foreignKeysForAlias = array_values(array_filter(
+            (array)$association->getForeignKey(),
+            static fn ($fk): bool => is_string($fk) && $fk !== '',
+        ));
+        if ($foreignKeysForAlias === []) {
+            return false;
+        }
+        foreach ($foreignKeysForAlias as $fkColumn) {
+            $entitySidePinned =
+                $instantiationEntity !== null
+                && !array_key_exists($fkColumn, $sequenceTouchedFields)
+                && $instantiationEntity->has($fkColumn)
+                && $instantiationEntity->get($fkColumn) !== null;
+            $pinned =
+                (array_key_exists($fkColumn, $pinnedFields) && $pinnedFields[$fkColumn] !== null)
+                || $entitySidePinned;
+            if (!$pinned) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/Factory/DataCompiler.php
+++ b/src/Factory/DataCompiler.php
@@ -1545,9 +1545,73 @@ class DataCompiler
         // non-null value (present in every sequence state / every cycle
         // value) — otherwise some row would still need the parent composed.
         // Callable states are opaque pre-build and conservatively ignored.
+        $sequencePinned = $this->pinnedSequenceFields();
+
+        // Instantiation pins are overridden by sequence() / sequenceField()
+        // at build time (compileEntity runs mergeWithSequenceData AFTER
+        // mergeWithInjectedData, BEFORE mergeWithPatchedData). So an
+        // instantiation pin can ONLY be trusted for a field that sequence
+        // does NOT touch — otherwise sequence may null it out on some rows
+        // and the parent must still be composed for those rows.
+        //
+        // Patch wins over sequence (patch is the last merge step), so
+        // dataFromPatch pins are still trusted unconditionally below.
+        $touchedBySequence = $this->fieldsTouchedBySequence();
+        foreach ($touchedBySequence as $field => $_) {
+            if (!array_key_exists($field, $sequencePinned)) {
+                unset($pinned[$field]);
+            }
+        }
+
         return $this->dataFromPatch
-            + $this->pinnedSequenceFields()
+            + $sequencePinned
             + $pinned;
+    }
+
+    /**
+     * Field names that appear in *any* `sequence()` array/entity state
+     * or `sequenceField()` cycle — i.e. any field that sequence may write
+     * at build time, regardless of pin status.
+     *
+     * Callable `sequence()` states are opaque pre-build and intentionally
+     * not introspected; a build mixing callable sequence state with
+     * Factory::new([fk => x]) + withRequiredParents() may still hit the
+     * silently-overridden-pin edge.
+     *
+     * @internal Used by {@see \CakephpFixtureFactories\Factory\BaseFactory::resolveRequiredParentAliases()}
+     *     to drop entity-side FK pins for fields sequence may overwrite.
+     *
+     * @return array<string, true>
+     */
+    public function fieldsTouchedBySequence(): array
+    {
+        $fields = [];
+        foreach ($this->sequenceData as $state) {
+            if ($state instanceof EntityInterface) {
+                // toArray() omits hidden fields (`$_hidden`). That's
+                // symmetric with the build path — mergeWithSequenceData also
+                // applies the state via $state->toArray() — so a hidden FK on
+                // a sequence-state entity is invisible to BOTH the touched
+                // probe AND the actual patch, and the instantiation pin
+                // legitimately survives. No special hidden-field handling
+                // needed here.
+                foreach (array_keys($state->toArray()) as $key) {
+                    $fields[$key] = true;
+                }
+            } elseif (is_array($state)) {
+                foreach (array_keys($state) as $key) {
+                    if (is_string($key)) {
+                        $fields[$key] = true;
+                    }
+                }
+            }
+            // Callable state: cannot inspect statically. Leave untouched.
+        }
+        foreach (array_keys($this->fieldSequences) as $field) {
+            $fields[$field] = true;
+        }
+
+        return $fields;
     }
 
     /**

--- a/tests/TestCase/Factory/BaseFactoryWithRequiredParentsTest.php
+++ b/tests/TestCase/Factory/BaseFactoryWithRequiredParentsTest.php
@@ -988,4 +988,123 @@ class BaseFactoryWithRequiredParentsTest extends TestCase
             ->find()->where(['id' => $author->address_id])->first();
         $this->assertNotNull($address, 'Composed Address must be persisted and matchable by the propagated FK.');
     }
+
+    public function testInstantiationPinIsNotTrustedWhenSequenceMayOverrideIt(): void
+    {
+        // Factory::new(['address_id' => $known->id]) pins the FK via
+        // instantiation. But sequenceField('address_id', [null, null])
+        // overrides it to null on every row at build time (sequence runs
+        // AFTER instantiation in compileEntity). getPinnedFields() used to
+        // treat the instantiation pin as authoritative even when sequence
+        // touched the same field — withRequiredParents() then skipped the
+        // Address composition, sequence set the FK to null, and saveMany()
+        // failed with a NOT NULL constraint violation.
+        //
+        // Fix contract: when sequence/sequenceField touches a field AND
+        // does not itself pin it to non-null on every row, the
+        // instantiation-side pin must NOT be trusted — withRequiredParents()
+        // composes the parent so the FK is supplied through the normal
+        // belongsTo cascade after sequence runs.
+        $known = AddressFactory::new()->save();
+        $addressesBefore = AddressFactory::query()->count();
+
+        $authors = RequiredParentsAuthorFactory::new(['address_id' => $known->id])
+            ->sequenceField('address_id', null, null)
+            ->withRequiredParents()
+            ->count(2)
+            ->saveMany();
+
+        $this->assertCount(2, $authors, 'saveMany must not throw on NOT NULL violation.');
+        foreach ($authors as $author) {
+            $this->assertNotNull(
+                $author->address_id,
+                'Each saved row must have a non-null address_id (composed via withRequiredParents()).',
+            );
+        }
+        $this->assertGreaterThan(
+            $addressesBefore,
+            AddressFactory::query()->count(),
+            'New Address rows must be composed when sequenceField nulls out the instantiation-pinned FK.',
+        );
+    }
+
+    public function testEntityInstantiationPinIsNotTrustedWhenSequenceMayOverrideIt(): void
+    {
+        // Same defect as testInstantiationPinIsNotTrustedWhenSequenceMayOverrideIt
+        // but on the entity-instantiation path: Factory::new($entityWithFk)
+        // populates the DataCompiler's $instantiationEntity, which the
+        // pinned-FK check (BaseFactory::belongsToFkAlreadyPinned) probes
+        // directly. If sequence/sequenceField touches that FK at build time
+        // without pinning it non-null on every row, the entity-side pin
+        // must NOT be trusted either — same contract as the array path.
+        //
+        // Entity instantiation is single-row only (the wrapper API does not
+        // support count() > 1 on an injected entity), so this exercises the
+        // count = 1 + all-null cycle shape, which is enough to surface
+        // the bug: sequence overrides the entity-side FK pin to null and
+        // the save fails with NOT NULL.
+        $known = AddressFactory::new()->save();
+        $authorEntity = RequiredParentsAuthorFactory::new(['address_id' => $known->id])->build();
+
+        $addressesBefore = AddressFactory::query()->count();
+
+        $author = RequiredParentsAuthorFactory::new($authorEntity)
+            ->state(['name' => 'Test Author']) // keep name dirty across the re-wrap
+            ->sequenceField('address_id', null)
+            ->withRequiredParents()
+            ->save();
+
+        $this->assertNotNull(
+            $author->address_id,
+            'Saved row must have a non-null address_id (composed via withRequiredParents()).',
+        );
+        $this->assertGreaterThan(
+            $addressesBefore,
+            AddressFactory::query()->count(),
+            'A new Address row must be composed when sequenceField nulls out the entity-pinned FK.',
+        );
+    }
+
+    public function testHookOptedRequiredParentRespectsCallerPinnedForeignKey(): void
+    {
+        // RequiredParentsOverrideAuthorFactory opts BusinessAddress into
+        // withRequiredParents() via the additive requiredParentAssociations()
+        // hook. When the caller pins business_address_id explicitly, the
+        // hook-opted alias must NOT silently override the pinned value
+        // by composing a fresh BusinessAddress — that contradicts the
+        // documented "pinned FK wins" contract that the auto-detected
+        // aliases already honor.
+        //
+        // Pin address_id too (auto-detected NOT NULL required parent) so the
+        // address-row count below is unambiguous — any extra Address row would
+        // necessarily be the BusinessAddress composition we're guarding against.
+        $primary = AddressFactory::new()->save();
+        $secondary = AddressFactory::new()->save();
+        $addressesBefore = AddressFactory::query()->count();
+
+        $author = RequiredParentsOverrideAuthorFactory::new([
+            'address_id' => $primary->id,
+            'business_address_id' => $secondary->id,
+        ])
+            ->withRequiredParents()
+            ->save();
+
+        $this->assertSame(
+            $secondary->id,
+            $author->business_address_id,
+            'A caller-pinned FK on a hook-opted required parent must survive — '
+            . 'withRequiredParents() must not compose a fresh BusinessAddress over it.',
+        );
+        $this->assertSame(
+            $primary->id,
+            $author->address_id,
+            'A caller-pinned FK on an auto-detected required parent must also survive '
+            . '(existing contract; asserted alongside to keep the regression scope clear).',
+        );
+        $this->assertSame(
+            $addressesBefore,
+            AddressFactory::query()->count(),
+            'No fresh Address should be composed when both required-parent FKs are pinned.',
+        );
+    }
 }


### PR DESCRIPTION
A deep-dive audit ([codex](https://github.com/openai/codex) + manual API-surface review) for a clean **v2.0.0** release surfaced three real correctness bugs in `withRequiredParents()`'s pinned-FK detection. All three would silently produce wrong builds or NOT NULL crashes in user code that combines pinned FKs with `sequence()` / `sequenceField()`, the hook-opted parent set, or entity instantiation.

## Bugs (each: failing test → minimal fix → GREEN)

### 1. Array instantiation pin overridden by sequence
```php
Factory::new(['fk' => x])
    ->sequenceField('fk', null, ...)
    ->withRequiredParents()
    ->saveMany();
```
reported the FK as pinned and skipped composing the parent; sequence then overrode the FK to `null` at build time and `saveMany()` crashed with **NOT NULL**. `getPinnedFields()` now drops instantiation pins for fields sequence will touch (it cannot guarantee the pin survives the build's `mergeWithSequenceData` step).

### 2. Hook-opted required parent bypassed the pinned-FK check
```php
RequiredParentsOverrideAuthorFactory::new(['business_address_id' => x])
    ->withRequiredParents()
    ->save();
```
composed a fresh BusinessAddress over the caller-pinned id. The auto-detected aliases already honored the pinned-FK skip; the additive `requiredParentAssociations()` hook loop didn't. Extracted a static helper `belongsToFkAlreadyPinned()` and applied it on both paths so the contract is uniform.

### 3. Entity-instantiation pin overridden by sequence
Same defect as #1 on the `Factory::new($entity)` path, plus a related secondary issue: `doWithRequiredParents()` demotes auto-resolved parents to `dataFromDefaultAssociations` so `recycle()` can substitute them, but the entity-injected build path intentionally skips defaults — so the demoted parent was invisible and never composed. Two fixes:
- `belongsToFkAlreadyPinned()` now also takes the sequence-touched-fields set and ignores entity-side pins for fields sequence will touch.
- The demotion is skipped when the factory is entity-instantiated. **Trade-off (documented):** `recycle()` cannot substitute auto-resolved parents on an entity-injected chain. Corner case (entity injection + recycle + `withRequiredParents` simultaneously).

## Tests

Three RED → GREEN regression tests in `BaseFactoryWithRequiredParentsTest`:

- `testInstantiationPinIsNotTrustedWhenSequenceMayOverrideIt`
- `testEntityInstantiationPinIsNotTrustedWhenSequenceMayOverrideIt`
- `testHookOptedRequiredParentRespectsCallerPinnedForeignKey`

Each verifies the failure mode (NOT NULL crash or wrong FK propagation) before the fix and the correct behavior after.

## rc.3 doc polish (from the API-surface audit)

- `docs/guide/foreign-keys-in-definition.md` — stale v1 idioms `->persist()` / `->patchData()` in v2 examples replaced with `->save()` / `->state()`.
- `docs/guide/required-parents.md` — dropped `->patchData()` from the pin-list prose; added a note that hook-opted aliases honor the pinned-FK skip uniformly with auto-detected ones; added a clarification about the instantiation/sequence interaction so users understand WHY the fix composes the parent even when their pin "looks" honored.
- `src/Factory/BaseFactory.php` — stale `->persist()` reference removed from `withRequiredParents()` docblock.

## Gates

- `composer sqlite`: **760 tests, 2600 assertions, 0 failures** (11 pre-existing skips).
- `composer stan`: clean.
- `composer cs-check`: clean.
- `codex review`: clean. One additional flag from codex ("hidden FK column on a sequence-state entity") turned out to be a **false positive** — `Entity::toArray()` omits hidden fields symmetrically in BOTH the touched-detection AND the build-time patch, so the bug doesn't manifest in practice. Noted in `fieldsTouchedBySequence()` docblock.

Targets `main`. Should land in 2.0.0-rc.3.