### PR TITLE
PHPDoc polish for v2: drop stale upstream version markers, anchor new APIs

### DIFF
--- a/src/Command/PersistCommand.php
+++ b/src/Command/PersistCommand.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
  *
  * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
  * @link https://webrider.de/
- * @since 2.3
  * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
 

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -570,6 +570,9 @@ abstract class BaseFactory
     }
 
     /**
+     * @internal Used by AssociationBuilder / DataCompiler to assemble the
+     *     marshaller's associated-config map. Not part of the public API.
+     *
      * @return array<string, mixed>
      */
     public function getMarshallerOptions(): array
@@ -977,6 +980,8 @@ abstract class BaseFactory
      *   plus `$s->factory` and `$s->generator` for the rare callable that
      *   needs them but doesn't have them in `use(...)` scope.
      *
+     * @since 2.0.0
+     *
      * @param \Cake\Datasource\EntityInterface|callable(\CakephpFixtureFactories\Factory\Sequence<TEntity>): array<string, mixed>|array<string, mixed> ...$states Sequence states
      *
      * @throws \InvalidArgumentException
@@ -1021,6 +1026,8 @@ abstract class BaseFactory
      *     ->sequenceField('priority', 1, 5, 10) // 3-cycle
      *     ->buildMany();
      * ```
+     *
+     * @since 2.0.0
      *
      * @param string $field Column to cycle.
      * @param mixed ...$values Values cycled in order. At least one is required.
@@ -1372,6 +1379,8 @@ abstract class BaseFactory
      * Get the fields that are declared are unique.
      * This should include the uniqueness of the fields in your schema.
      *
+     * @internal Used by UniquenessJanitor and the test suite.
+     *
      * @return array<string>
      */
     public function getUniqueProperties(): array
@@ -1649,6 +1658,8 @@ abstract class BaseFactory
      * the test suite of this plugin (and downstream test-helper code), so that
      * each test starts with an empty dedupe set and a freshly-resolved table
      * FK map.
+     *
+     * @internal
      */
     public static function resetForeignKeyInDefinitionDetector(): void
     {
@@ -1810,6 +1821,8 @@ abstract class BaseFactory
      * `FixtureFactoryException`. A cycle *within* the cap still throws. Opt into
      * `$strict` to turn that silent shortfall into an actionable exception at
      * call time (it also restores an actionable message for a capped cycle).
+     *
+     * @since 2.0.0
      *
      * @param array<int, string> $except Association aliases to skip.
      * @param int|null $maxDepth Cap how many *levels* of required parents are
@@ -2243,6 +2256,8 @@ abstract class BaseFactory
      * See {@see self::excludedRequiredParentAssociations()} for the symmetric
      * factory-class-level *exclude* hook.
      *
+     * @since 2.0.0
+     *
      * @return array<int, string> Additional aliases to compose.
      */
     protected function requiredParentAssociations(): array
@@ -2263,6 +2278,8 @@ abstract class BaseFactory
      * - Scoped to *this* factory class — parent factories higher up the chain
      *   each apply their own exclude list via their own resolver invocation.
      *
+     * @since 2.0.0
+     *
      * @return array<int, string> Aliases to exclude.
      */
     protected function excludedRequiredParentAssociations(): array
@@ -2282,6 +2299,8 @@ abstract class BaseFactory
      * value there is not that anti-pattern. The detector still flags every
      * genuinely managed FK — listing a managed FK column here defeats the
      * check, so don't.
+     *
+     * @since 2.0.0
      *
      * @return array<int, string> Column names exempt from the detector.
      */
@@ -2387,6 +2406,8 @@ abstract class BaseFactory
      * When `$alias` is null, the alias is auto-resolved by the associated
      * factory's target table — equivalent to the previous single-arg form.
      *
+     * @since 2.0.0
+     *
      * @param \CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface> $factory Associated belongsTo factory.
      * @param string|null $alias Explicit association alias on the source table; auto-resolved when null.
      *
@@ -2431,6 +2452,8 @@ abstract class BaseFactory
      * per-key basis where it overlaps; non-overlapping keys are kept from
      * `$pivot`. For a totally pivot-only build, prefer the explicit
      * `$pivot` argument and don't pre-load `_joinData` on the child.
+     *
+     * @since 2.0.0
      *
      * @param \CakephpFixtureFactories\Factory\BaseFactory<\Cake\Datasource\EntityInterface> $factory Associated factory.
      * @param string|null $alias Explicit association alias on the source table; auto-resolved when null.
@@ -2603,6 +2626,8 @@ abstract class BaseFactory
      * typo for "I want one of these but I'm not sure which". Across multiple
      * `recycle()` calls, last wins (a chained `->recycle($a)->recycle($b)` on
      * the same source is treated as an intentional update).
+     *
+     * @since 2.0.0
      *
      * @param \Cake\Datasource\EntityInterface ...$entities One or more
      *     already-built entities to reuse, keyed internally by source table.

--- a/src/Factory/FactoryAwareTrait.php
+++ b/src/Factory/FactoryAwareTrait.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
  *
  * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
  * @link https://webrider.de/
- * @since 2.3.0
  * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
 

--- a/src/Factory/Sequence.php
+++ b/src/Factory/Sequence.php
@@ -39,6 +39,8 @@ use InvalidArgumentException;
  * Construction is internal to the data compiler; callables never need to
  * instantiate `Sequence` themselves.
  *
+ * @since 2.0.0
+ *
  * @template TEntity of \Cake\Datasource\EntityInterface
  */
 final readonly class Sequence

--- a/src/Generator/CakeGeneratorFactory.php
+++ b/src/Generator/CakeGeneratorFactory.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
  *
  * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
  * @link https://webrider.de/
- * @since 3.1.0
  * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
 

--- a/src/Generator/DummyGeneratorAdapter.php
+++ b/src/Generator/DummyGeneratorAdapter.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
  *
  * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
  * @link https://webrider.de/
- * @since 3.1.0
  * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
 

--- a/src/Generator/DummyOptionalAdapter.php
+++ b/src/Generator/DummyOptionalAdapter.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
  *
  * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
  * @link https://webrider.de/
- * @since 3.1.0
  * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
 

--- a/src/Generator/DummyUniqueAdapter.php
+++ b/src/Generator/DummyUniqueAdapter.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
  *
  * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
  * @link https://webrider.de/
- * @since 3.1.0
  * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
 

--- a/src/Generator/FakerAdapter.php
+++ b/src/Generator/FakerAdapter.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
  *
  * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
  * @link https://webrider.de/
- * @since 3.1.0
  * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
 

--- a/src/Generator/FakerOptionalAdapter.php
+++ b/src/Generator/FakerOptionalAdapter.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
  *
  * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
  * @link https://webrider.de/
- * @since 3.1.0
  * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
 

--- a/src/Generator/FakerUniqueAdapter.php
+++ b/src/Generator/FakerUniqueAdapter.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
  *
  * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
  * @link https://webrider.de/
- * @since 3.1.0
  * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
 

--- a/src/Generator/GeneratorInterface.php
+++ b/src/Generator/GeneratorInterface.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
  *
  * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
  * @link https://webrider.de/
- * @since 3.1.0
  * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
 

--- a/src/Generator/OptionalGeneratorInterface.php
+++ b/src/Generator/OptionalGeneratorInterface.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
  *
  * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
  * @link https://webrider.de/
- * @since 3.1.0
  * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
 

--- a/src/Generator/UniqueGeneratorInterface.php
+++ b/src/Generator/UniqueGeneratorInterface.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
  *
  * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
  * @link https://webrider.de/
- * @since 3.1.0
  * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
 

--- a/src/Scenario/FixtureScenarioInterface.php
+++ b/src/Scenario/FixtureScenarioInterface.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
  *
  * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
  * @link https://webrider.de/
- * @since 2.3.0
  * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
 

--- a/src/Scenario/ScenarioAwareTrait.php
+++ b/src/Scenario/ScenarioAwareTrait.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
  *
  * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
  * @link https://webrider.de/
- * @since 2.3.0
  * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
 

--- a/src/Scenario/Story.php
+++ b/src/Scenario/Story.php
@@ -43,6 +43,8 @@ use CakephpFixtureFactories\Error\FixtureScenarioException;
  * `ScenarioAwareTrait::loadFixtureScenario(...)` resolves and calls `load()`
  * the same way it does for plain scenarios. Existing scenarios that
  * implement the interface directly keep working unchanged.
+ *
+ * @since 2.0.0
  */
 abstract class Story implements FixtureScenarioInterface
 {

--- a/src/TestSuite/FactoryTableTracker.php
+++ b/src/TestSuite/FactoryTableTracker.php
@@ -12,6 +12,8 @@ use Cake\ORM\Table;
  * This singleton class maintains a registry of all tables that have been
  * modified by fixture factories during test execution. This information can
  * be used by transaction strategies to automatically manage database state.
+ *
+ * @since 2.0.0
  */
 class FactoryTableTracker
 {

--- a/src/TestSuite/FactoryTransactionStrategy.php
+++ b/src/TestSuite/FactoryTransactionStrategy.php
@@ -60,6 +60,8 @@ use Throwable;
  *
  * Usage (CakePHP 5.0 - 5.1):
  * Use the FactoryTransactionTrait in your test cases.
+ *
+ * @since 2.0.0
  */
 class FactoryTransactionStrategy implements FixtureStrategyInterface
 {
@@ -208,6 +210,8 @@ class FactoryTransactionStrategy implements FixtureStrategyInterface
      *
      * Called from BaseFactory save operations before persistence, so transactions
      * are only started on connections that are actually used.
+     *
+     * @internal
      *
      * @param \Cake\Database\Connection $connection The connection to ensure a transaction on
      *

--- a/src/TestSuite/LazyFactoryTransactionStrategy.php
+++ b/src/TestSuite/LazyFactoryTransactionStrategy.php
@@ -39,6 +39,8 @@ namespace CakephpFixtureFactories\TestSuite;
  *         'fixtureStrategy' => \CakephpFixtureFactories\TestSuite\LazyFactoryTransactionStrategy::class,
  *     ],
  * ```
+ *
+ * @since 2.0.0
  */
 class LazyFactoryTransactionStrategy extends FactoryTransactionStrategy
 {

--- a/src/TestSuite/LazyTransactionTrait.php
+++ b/src/TestSuite/LazyTransactionTrait.php
@@ -48,6 +48,8 @@ use PHPUnit\Framework\Attributes\Before;
  *     // persists on it.
  * }
  * ```
+ *
+ * @since 2.0.0
  */
 trait LazyTransactionTrait
 {

--- a/src/TestSuite/TableAssertionsTrait.php
+++ b/src/TestSuite/TableAssertionsTrait.php
@@ -41,6 +41,8 @@ use InvalidArgumentException;
  *     }
  * }
  * ```
+ *
+ * @since 2.0.0
  */
 trait TableAssertionsTrait
 {


### PR DESCRIPTION
Pre-stable v2 housekeeping in three buckets. **Zero runtime change**; shrinks the implicit BC promise and gives downstream tooling honest version anchors.

## Bucket A — drop 14 stale upstream-version markers

These referred to vierge-noire's version history (the upstream from which this repo was forked) and were never meaningful in this fork's own 1.x → 2.0 versioning. They actively misled anyone trying to constrain compatibility — e.g. a "since 3.1.0" marker on files that have always been in this fork's 1.0.

```
src/Generator/CakeGeneratorFactory.php          # was 3.1.0
src/Generator/DummyGeneratorAdapter.php         # was 3.1.0
src/Generator/DummyOptionalAdapter.php          # was 3.1.0
src/Generator/DummyUniqueAdapter.php            # was 3.1.0
src/Generator/FakerAdapter.php                  # was 3.1.0
src/Generator/FakerOptionalAdapter.php          # was 3.1.0
src/Generator/FakerUniqueAdapter.php            # was 3.1.0
src/Generator/GeneratorInterface.php            # was 3.1.0
src/Generator/OptionalGeneratorInterface.php    # was 3.1.0
src/Generator/UniqueGeneratorInterface.php      # was 3.1.0
src/Scenario/FixtureScenarioInterface.php       # was 2.3.0
src/Scenario/ScenarioAwareTrait.php             # was 2.3.0
src/Factory/FactoryAwareTrait.php               # was 2.3.0
src/Command/PersistCommand.php                  # was 2.3 (malformed)
```

## Bucket B — anchor 16 genuinely-v2-new surfaces with `since 2.0.0`

File-level (7 files):

```
src/Factory/Sequence.php
src/Scenario/Story.php
src/TestSuite/TableAssertionsTrait.php
src/TestSuite/FactoryTransactionStrategy.php
src/TestSuite/LazyFactoryTransactionStrategy.php
src/TestSuite/LazyTransactionTrait.php
src/TestSuite/FactoryTableTracker.php
```

Method-level on `BaseFactory` (9 methods new in this v2 cycle; class itself stays at 1.0.0):

- `withRequiredParents`
- `requiredParentAssociations` (protected hook)
- `excludedRequiredParentAssociations` (protected hook)
- `allowedForeignKeysInDefinition` (protected hook)
- `recycle`
- `for` (alias overload)
- `has` (alias overload)
- `sequenceField`
- `sequence` (signature changed in v2 — `Sequence` context object)

## Bucket C — shrink the implicit BC surface (4 safe `internal` tags)

These methods are public for plumbing reasons (called from other classes inside the package), not for user consumption. Marking them internal commits to the smaller surface in v2 and lets the package evolve them without a major bump.

- `BaseFactory::getMarshallerOptions` — assembled config consumed by `AssociationBuilder` and `DataCompiler` only.
- `BaseFactory::getUniqueProperties` — consumed by `UniquenessJanitor` and the test suite only; doc already implied internal.
- `BaseFactory::resetForeignKeyInDefinitionDetector` — doc already says "intended for the test suite of this plugin"; tag now matches.
- `FactoryTransactionStrategy::ensureTransaction` — pure plumbing called from `BaseFactory::save`.

### Deliberately NOT marked internal (defer to 2.x evaluation)

These are public-but-borderline; left as part of the v2 BC surface for now, to be re-evaluated based on real downstream use:

- `BaseFactory::getAssociatedFactories` — doc explicitly invites "advanced use cases"
- `BaseFactory::getTimes` — small public getter; users may use for factory-config assertions
- `FactoryTransactionStrategy::releaseTransactions` — doc says exposed for `LazyTransactionTrait` equivalents
- `FactoryTransactionStrategy::getActiveInstance` — static accessor used by `LazyTransactionTrait`

## Gates

- `composer sqlite`: 760 tests, 2600 assertions, 0 failures.
- `composer stan`: clean.
- `composer cs-check`: clean.

Targets `main`. Should land before tagging the next 2.0.0-rc / 2.0.0 stable.