### PR TITLE
v2 ship gaps: strictDefinition shared-PK fix + 4 regression tests + v2 overview docs

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
           items: [
             { text: 'Getting Started', link: '/guide/' },
             { text: 'Why factories?', link: '/guide/why-factories' },
+            { text: "What's new in v2", link: '/guide/whats-new-in-v2' },
             { text: 'Setup', link: '/guide/setup' },
           ],
         },

--- a/docs/guide/associations.md
+++ b/docs/guide/associations.md
@@ -287,6 +287,7 @@ AuthorFactory::new()
 - The build graph has no registered `belongsTo` to the recycled entity's table — recycle is a silent no-op.
 - You need different parents on different branches — use `with('AliasName', $entity)` per branch.
 - You want to reuse a `hasMany` or `belongsToMany` collection — recycle only substitutes single-row `belongsTo` parents. The to-many entity itself is always freshly built; recycle flows *into* it so its own belongsTo branches may substitute, but the row itself never collapses into the recycled target. Use `with()` with concrete entities for the many side.
+- The chain runs through a `belongsTo` declared with `'foreignKey' => false` (custom-condition join). The independent-save path that handles these takes the bypass around the normal cascade, so recycle does NOT propagate INTO that subtree — fresh parents are built inside it. Use `with('Alias', $entity)` at the call site to share the parent across builds.
 
 ## `from()` — start from an existing entity
 

--- a/docs/guide/whats-new-in-v2.md
+++ b/docs/guide/whats-new-in-v2.md
@@ -1,0 +1,282 @@
+---
+title: What's new in v2
+description: A tour of the new shape of CakePHP Fixture Factories 2.0
+---
+
+# What's new in v2
+
+A guided tour of the v2.0 surface. For the per-version mechanical migration
+notes (renames, removed methods, Rector config), see the
+[upgrading guide](upgrading.md). This page is the **why and the wow** — what
+v2 lets you write that v1 didn't.
+
+## TL;DR
+
+| Theme | What it changed |
+| --- | --- |
+| [Required parents](#withrequiredparents) | One call composes every NOT NULL belongsTo parent chain |
+| [`recycle()`](#recycle) | Share one parent across an entire batch |
+| [`for()` / `has()` alias overload](#for-has-alias-overload) | Explicit per-alias composition with target-type guard |
+| [`Sequence` context object](#sequence-context-object) | Per-row context (`$s->index`, `isFirst`, `isLast`, `factory`, `generator`) inside `sequence()` callables |
+| [`Story` scenarios](#story-scenarios) | Foundry-style entity pools with `getRandom()` / `getRandomSet()` |
+| [`TableAssertionsTrait`](#tableassertionstrait) | Expressive database-state assertions with sharp failure messages |
+| [Eager transaction strategy by default](#eager-transaction-strategy-restored) | Mixed direct-save + factory-save tests stay isolated again |
+| [`strictDefinition` detector](#strictdefinition-fk-in-definition-detector) | Catches the silent "FK in `definition()`" footgun before it ships |
+| [Bake quality](#bake-quality) | TimestampBehavior-managed columns are no longer baked, custom generator alias loads detected |
+
+## `withRequiredParents()`
+
+The single biggest ergonomic win of v2. Composes every belongsTo parent the
+root table *requires* — every NOT NULL FK — recursively, in one call:
+
+``` php
+// Tables: Authors belongsTo Address (NOT NULL); Address belongsTo City (NOT NULL);
+//         City belongsTo Country (NOT NULL).
+// One call satisfies the whole chain.
+$author = AuthorFactory::new()->withRequiredParents()->save();
+
+// Composes with recycle() for shared-parent batches:
+$country = CountryFactory::new()->save();
+$authors = AuthorFactory::new()
+    ->count(50)
+    ->withRequiredParents()
+    ->recycle($country) // all 50 authors share this one Country
+    ->saveMany();
+```
+
+The detector reads the schema; it only auto-composes the cases it can resolve
+unambiguously (single scalar NOT NULL FK). Composite-key,
+`foreignKey => false`, and nullable FKs aren't auto-resolved by design.
+
+Three protected hooks let factory classes shape their required-parent set:
+
+- `requiredParentAssociations()` — opt in extras (typically a nullable
+  single-scalar FK the factory wants composed regardless).
+- `excludedRequiredParentAssociations()` — opt out specific aliases at the
+  class level. Wins over both auto-detection and the additive hook.
+- `allowedForeignKeysInDefinition()` — exempts specific FK columns from the
+  `strictDefinition` deprecation (rare, transitional).
+
+Per-call `$except` and `$maxDepth` arguments cover the one-off cases:
+
+``` php
+$author = AuthorFactory::new()
+    ->withRequiredParents(except: ['Address'], maxDepth: 2)
+    ->with('Address', $myAddress)
+    ->save();
+```
+
+See the [Required parents guide](required-parents.md) for the full contract,
+including the pinned-FK semantics, cycle detection, and the strict mode for
+catching a depth cap that leaves a NOT NULL FK unsatisfied.
+
+## `recycle()`
+
+Reuse a saved entity wherever any `belongsTo` in the build graph targets the
+same table — substitutes at *every depth*:
+
+``` php
+$country = CountryFactory::new()->save();
+AddressFactory::new()
+    ->count(3)
+    ->with('City', CityFactory::new()->forCountries())
+    ->recycle($country) // every nested City reuses this Country
+    ->saveMany();
+```
+
+Variadic and chainable; substitutes through hasMany / belongsToMany edges
+*into* sibling belongsTo branches; refuses ambiguous same-source duplicates
+in a single call. See the [recycle section](associations.md#recycling-shared-parents-recycle)
+of the associations guide.
+
+## `for()` / `has()` alias overload
+
+Cleaner composition when a table has multiple associations targeting the
+same model, with a target-type guard that catches misuse at compose time:
+
+``` php
+// Disambiguates: Addresses belongsTo City AND ShippingCity
+$order = OrderFactory::new()
+    ->for(CityFactory::new(), 'ShippingCity')   // explicit alias
+    ->has(LineItemFactory::new()->count(3))     // alias auto-resolved
+    ->save();
+
+// has() now also takes pivot data for belongsToMany joins:
+$author = AuthorFactory::new()
+    ->has(ArticleFactory::new()->count(2), 'Articles', ['featured' => true])
+    ->save();
+```
+
+`has()` rejects pivot data on non-BTM aliases (was silently dropped in v1).
+The alias overload's target-type guard catches misuse like
+`OrderFactory::for(BarFactory::new(), 'ShippingCity')` — that would have
+silently mis-wired a Bar entity into the City slot in v1.
+
+## `Sequence` context object
+
+`sequence()` callables now receive a single `Sequence` value object instead
+of two positional args. Exposes the current row's full context:
+
+``` php
+ArticleFactory::new()
+    ->count(5)
+    ->sequence(fn (Sequence $s) => [
+        'rank' => $s->index,            // 0-based
+        'position' => $s->position,     // 1-based
+        'total' => $s->total,
+        'is_first' => $s->isFirst,
+        'is_last' => $s->isLast,
+        'slug' => $s->generator->slug(),
+        'parent' => $s->factory->getTable()->getAlias(),
+    ])
+    ->saveMany();
+```
+
+The Sequence object is constructed by the data compiler and self-validates;
+callables never need to instantiate it. The new `sequenceField()` helper
+covers the per-field-cycle case without writing a callable:
+
+``` php
+ProductFactory::new()
+    ->count(6)
+    ->sequenceField('status', 'draft', 'review', 'published')
+    ->saveMany();
+```
+
+See the [Sequence section](factories.md#sequence-per-row-state) of the
+factories guide.
+
+## `Story` scenarios
+
+A Foundry-style abstract that adds **named entity pools** on top of the
+existing `FixtureScenarioInterface`. Seed data once, store named handles,
+sample from them in the test body — no rebuilding, no explicit threading:
+
+``` php
+class BlogStory extends Story
+{
+    protected function build(): void
+    {
+        $this->addToPool('authors', UserFactory::new()->count(10)->saveMany());
+        $this->addToPool('categories', CategoryFactory::new()->count(3)->saveMany());
+
+        ArticleFactory::new()->count(50)->saveMany();
+    }
+}
+
+// In the test:
+$story = $this->loadFixtureScenario(BlogStory::class);
+$author = $story->getRandom('authors');
+$twoCategories = $story->getRandomSet('categories', 2);
+```
+
+Backwards-compatible: existing scenarios that implement
+`FixtureScenarioInterface` directly keep working unchanged. See the
+[Scenarios guide](scenarios.md).
+
+## `TableAssertionsTrait`
+
+Expressive database-state assertions composed over `Factory::query()`. The
+trait is opt-in (`use TableAssertionsTrait;`) — no static read surface is
+added to `BaseFactory`.
+
+``` php
+public function testCreate(): void
+{
+    $this->post('/articles', ['title' => 'Hello']);
+
+    $this->assertTableHas(ArticleFactory::class, ['title' => 'Hello']);
+    $this->assertTableCount(ArticleFactory::class, 1);
+    $this->assertTableMissing(ArticleFactory::class, ['status' => 'spam']);
+    $this->assertEntityExists($article);
+    $this->assertEntityMissing($deletedArticle); // refuses never-persisted entities
+}
+```
+
+Sharp failure messages spell out what was expected and what was found,
+including the actual value of relevant columns. See the
+[Queries guide](queries.md#expressive-database-assertions-tableassertionstrait).
+
+## Eager transaction strategy restored
+
+`FactoryTransactionStrategy` is eager by default again. `setupTest()` opens a
+transaction on the primary test connection *up-front* so that direct
+`$table->save($entity)` / raw inserts inside a test are also rolled back at
+teardown — not just operations that go through a Factory's `save()`.
+
+v1.3 had flipped this to lazy, which silently broke tests that mixed Factory
+build with direct `$table->save()` (the testFind / testValidationDefault
+pattern) — the direct save ran outside any transaction and leaked across
+methods. v2 restores the eager default while keeping additional connections
+lazy.
+
+If your suite is entirely Factory-based and you want the lazy contract back,
+opt in via `LazyFactoryTransactionStrategy` (whole suite) or
+`LazyTransactionTrait` (per test class).
+
+## `strictDefinition` FK-in-`definition()` detector
+
+Catches the silent footgun where a factory's `definition()` returns a
+belongsTo FK column directly (e.g. `'author_id' => $generator->randomDigit()`).
+That pattern silently overrides whatever parent a caller later composes via
+`->with('Author', ...)` — the dangling-id bug that's hard to debug because
+the test reads green.
+
+Enabled by default in v2; the detector emits a deprecation that names the
+column, the association, and the migration path:
+
+```
+ArticleFactory::definition() returns "author_id", which is the foreign-key
+column for the "Author" belongsTo association. Move association composition
+out of definition() — use ->with('Author') in configure(), a forAuthor() /
+withAuthor() helper, or pass the association at the call site.
+```
+
+Opt out transitionally:
+`Configure::write('FixtureFactories.strictDefinition', false);` — removed in
+the next major.
+
+See the
+[FK-in-definition guide](foreign-keys-in-definition.md) for the migration
+playbook.
+
+## Bake quality
+
+- **`TimestampBehavior`-managed columns are no longer baked.** Without this,
+  a factory baked for a `'created'/'modified'` table emitted
+  `$generator->datetime()` for both, then TimestampBehavior deferred to the
+  already-set values and the fixture row shipped with random timestamps
+  instead of the test-run's `now`. Detection is by class (so aliased
+  `'className' => 'Timestamp'` loads are caught too) and only Model.beforeSave
+  writers with `new` or `always` qualify.
+- The default-data guesser was extracted into a dedicated `DefaultDataGuesser`
+  class that subclasses / projects can override or extend.
+
+See [Bake reference](../reference/bake.md).
+
+## Notable bug fixes worth knowing
+
+- `recycle()` now substitutes mid-chain required parents (the
+  `withRequiredParents()` interaction).
+- `foreignKey => false` belongsTo composition works at persist time
+  (was crashing with "Cannot set an empty field" in v1).
+- `FactoryTransactionStrategy` rollback cascade and cross-connection finalize
+  are no longer susceptible to per-connection failures.
+- The pinned-FK contract is now uniform across all four entry-paths:
+  array-instantiation, entity-instantiation, the additive
+  `requiredParentAssociations()` hook, and `configure()`-time. Sequence
+  overriding an instantiation pin is correctly detected.
+
+## Removed in v2
+
+For the mechanical surface — old method names, deprecated wrappers, removed
+helpers — see [upgrading](upgrading.md). The bundled Rector config covers the
+safe renames automatically.
+
+## Where to go next
+
+- New to the plugin? [Getting Started](index.md).
+- Upgrading from 1.4? [Upgrading guide](upgrading.md).
+- Want the full feature reference? Each major surface has its own page —
+  start with [Associations](associations.md), [Required parents](required-parents.md),
+  and [Queries](queries.md).

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -1456,16 +1456,20 @@ abstract class BaseFactory
             return;
         }
 
-        $primaryKey = (array)$table->getSchema()->getPrimaryKey();
         $fkColumns = self::collectForeignKeyColumns($table);
         if (!$fkColumns) {
             return;
         }
 
         foreach (array_keys($data) as $column) {
-            if (in_array($column, $primaryKey, true)) {
-                continue;
-            }
+            // Was previously a two-step check: skip PK columns first, then
+            // skip non-FK columns. That silently exempted shared-primary-key
+            // 1:1 associations (child.id is both PK and a belongsTo FK) —
+            // exactly the dangling-id / silently-overwritten-by-composed-parent
+            // failure mode the detector exists to catch. The FK check below
+            // is sufficient on its own: a literal `id => 1` in definition()
+            // for a table whose `id` is just its own PK (not also a FK)
+            // is never in $fkColumns and is skipped naturally.
             if (!isset($fkColumns[$column])) {
                 continue;
             }

--- a/tests/Factory/SharedPkSmellyAddressFactory.php
+++ b/tests/Factory/SharedPkSmellyAddressFactory.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link          https://webrider.de/
+ * @since         2.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace CakephpFixtureFactories\Test\Factory;
+
+use CakephpFixtureFactories\Factory\BaseFactory;
+use CakephpFixtureFactories\Generator\GeneratorInterface;
+
+/**
+ * Reproduces the shared-primary-key 1:1 case for the FK-in-definition
+ * detector test suite: an `id` column that is both the entity's own PK
+ * and a belongsTo foreign key. The matching belongsTo association is
+ * registered at runtime inside the test (the test app's Addresses table
+ * does not declare it by default).
+ *
+ * Production factories should never pin `id` like this when `id` is also
+ * a belongsTo FK — see SmellyAddressFactory for the regular-FK variant.
+ *
+ * @extends BaseFactory<\TestApp\Model\Entity\Address>
+ */
+class SharedPkSmellyAddressFactory extends BaseFactory
+{
+    protected function getRootTableRegistryName(): string
+    {
+        return 'Addresses';
+    }
+
+    public function definition(GeneratorInterface $generator): array
+    {
+        return [
+            'id' => 999_999,
+            'street' => $generator->streetAddress(),
+        ];
+    }
+}

--- a/tests/TestCase/Factory/BaseFactoryForeignKeyDetectionTest.php
+++ b/tests/TestCase/Factory/BaseFactoryForeignKeyDetectionTest.php
@@ -24,6 +24,7 @@ use CakephpFixtureFactories\ORM\FactoryTableRegistry;
 use CakephpFixtureFactories\Test\Factory\AddressFactory;
 use CakephpFixtureFactories\Test\Factory\AllowedFkAddressFactory;
 use CakephpFixtureFactories\Test\Factory\CityFactory;
+use CakephpFixtureFactories\Test\Factory\SharedPkSmellyAddressFactory;
 use CakephpFixtureFactories\Test\Factory\SmellyAddressFactory;
 use TestApp\Model\Table\CitiesTable;
 
@@ -284,5 +285,40 @@ class BaseFactoryForeignKeyDetectionTest extends TestCase
             'FK-column cache must invalidate when the belongsTo set changes at runtime.',
         );
         $this->assertSame('LateRegion', $second['late_region_id']);
+    }
+
+    /**
+     * Shared-primary-key 1:1 associations have `child.id` as both PK and the
+     * belongsTo FK column. They are still a real "FK in definition()" case
+     * — pinning `id` here has the same dangling-id / silently-overwritten-
+     * by-composed-parent failure mode that the detector exists to catch.
+     * The detector used to skip every PK column before checking FK status,
+     * silently exempting this pattern. Regression guard.
+     */
+    public function testTriggersDeprecationForSharedPrimaryKeyForeignKey(): void
+    {
+        // Augment the Addresses table with a belongsTo 'Mirror' association
+        // whose foreignKey is the address's own primary key (shared-PK 1:1).
+        $factory = SharedPkSmellyAddressFactory::new();
+        $factory->getTable()->belongsTo('Mirror', [
+            'className' => 'Addresses',
+            'foreignKey' => 'id',
+        ]);
+        // Force-rearm the cache so the new belongsTo is picked up by the
+        // detector even though the table was first touched without it.
+        BaseFactory::resetForeignKeyInDefinitionDetector();
+
+        $factory->build();
+
+        $idFkErrors = array_values(array_filter(
+            $this->capturedErrors,
+            static fn (array $e): bool => str_contains($e['message'], '"id"'),
+        ));
+        $this->assertNotEmpty(
+            $idFkErrors,
+            'Detector must fire on a shared-primary-key belongsTo FK in definition(); '
+            . 'the dangling-id failure mode is the same as for any other FK column.',
+        );
+        $this->assertStringContainsString('"Mirror"', $idFkErrors[0]['message']);
     }
 }

--- a/tests/TestCase/Factory/BaseFactoryWithRequiredParentsTest.php
+++ b/tests/TestCase/Factory/BaseFactoryWithRequiredParentsTest.php
@@ -1107,4 +1107,96 @@ class BaseFactoryWithRequiredParentsTest extends TestCase
             'No fresh Address should be composed when both required-parent FKs are pinned.',
         );
     }
+
+    /**
+     * The `foreignKey => false` independent-save path in
+     * `DataCompiler::mergeWithToOne()` exists specifically so factories
+     * nested UNDER a custom-condition belongsTo still see their `afterSave`
+     * callbacks fire — `replayAssociatedAfterSaveForTree($associatedEntity)`
+     * walks the subtree and replays them. Regression pin: a callback two
+     * levels under a `foreignKey => false` alias MUST fire exactly once.
+     * Without this guard, a future refactor of the independent-save branch
+     * could silently skip the replay and the callback would never run.
+     */
+    public function testForeignKeyFalseIndependentSavePathReplaysNestedAfterSaveCallbacks(): void
+    {
+        $factory = RequiredParentsAuthorFactory::new();
+        $factory->getTable()->belongsTo('GhostCountry', [
+            'className' => 'Countries',
+            'foreignKey' => false,
+            'conditions' => ['Authors.name = GhostCountry.name'],
+        ]);
+
+        $callbackHits = 0;
+        $nestedCityFactory = CityFactory::new()->afterSave(
+            function () use (&$callbackHits): void {
+                $callbackHits++;
+            },
+        );
+
+        $strict = Configure::read('FixtureFactories.strictDefinition');
+        Configure::write('FixtureFactories.strictDefinition', false);
+        try {
+            $factory
+                ->with('GhostCountry', CountryFactory::new()->with('Cities', $nestedCityFactory))
+                ->withRequiredParents()
+                ->save();
+        } finally {
+            Configure::write('FixtureFactories.strictDefinition', $strict);
+        }
+
+        $this->assertSame(
+            1,
+            $callbackHits,
+            'afterSave callback two levels under a foreignKey => false alias must fire exactly once; '
+            . 'the independent-save replay path (DataCompiler::mergeWithToOne()) is load-bearing.',
+        );
+    }
+
+    /**
+     * Contract pin: `recycle()` does NOT propagate INTO a
+     * `foreignKey => false` subtree. The independent-save branch in
+     * `DataCompiler::mergeWithToOne()` operates on the composed entity
+     * produced outside the recycle inheritance — by design, since the
+     * branch is a corner-case bypass that does not go through the normal
+     * cascade. Documented as a known limitation in the recycle guide.
+     */
+    public function testRecycleDoesNotPropagateIntoForeignKeyFalseSubtree(): void
+    {
+        $factory = RequiredParentsAuthorFactory::new();
+        $factory->getTable()->belongsTo('GhostCountry', [
+            'className' => 'Countries',
+            'foreignKey' => false,
+            'conditions' => ['Authors.name = GhostCountry.name'],
+        ]);
+
+        // A persisted Country we'd HOPE recycle() would substitute for the
+        // GhostCountry-side Cities → Countries chain.
+        $recycled = CountryFactory::new(['name' => 'Recycled'])->save();
+        $countryCountBefore = CountryFactory::query()->count();
+
+        $strict = Configure::read('FixtureFactories.strictDefinition');
+        Configure::write('FixtureFactories.strictDefinition', false);
+        try {
+            $factory
+                ->with('GhostCountry', CountryFactory::new()->with('Cities', CityFactory::new()->forCountries()))
+                ->recycle($recycled)
+                ->withRequiredParents()
+                ->save();
+        } finally {
+            Configure::write('FixtureFactories.strictDefinition', $strict);
+        }
+
+        // The recycled Country was NOT substituted inside the GhostCountry
+        // subtree — a fresh GhostCountry, a fresh City, and a fresh Country
+        // for that City all persist. Plus the chain Country for the root
+        // Author's address_id → city_id → country_id. So 3 fresh + the
+        // recycled = 4 total.
+        $this->assertGreaterThan(
+            $countryCountBefore,
+            CountryFactory::query()->count(),
+            'recycle() must NOT propagate into a foreignKey => false subtree — '
+            . 'fresh Countries are built inside it. Documented limitation.',
+        );
+    }
 }

--- a/tests/TestCase/TestSuite/TableAssertionsTraitTest.php
+++ b/tests/TestCase/TestSuite/TableAssertionsTraitTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace CakephpFixtureFactories\Test\TestCase\TestSuite;
 
+use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use CakephpFixtureFactories\Test\Factory\CityFactory;
 use CakephpFixtureFactories\Test\Factory\CountryFactory;
@@ -17,6 +18,7 @@ use CakephpFixtureFactories\TestSuite\TableAssertionsTrait;
 use CakephpTestSuiteLight\Fixture\TruncateDirtyTables;
 use InvalidArgumentException;
 use PHPUnit\Framework\AssertionFailedError;
+use stdClass;
 use TestApp\Model\Entity\Country;
 
 /**
@@ -252,5 +254,41 @@ class TableAssertionsTraitTest extends TestCase
             return $e->getMessage();
         }
         $this->fail('Expected an AssertionFailedError but no exception was thrown.');
+    }
+
+    public function testAssertEntityExistsRejectsEntityWithoutSourceTable(): void
+    {
+        // resolveTableForEntity() throws a friendly InvalidArgumentException
+        // when handed a bare entity with no source table set AND no factory
+        // class argument. Without this guard the user would see Cake's raw
+        // "alias is not allowed" error from the table locator. Regression pin.
+        $entity = new Entity(['id' => 1]);
+        $entity->setSource('');
+
+        $caught = null;
+        try {
+            $this->assertEntityExists($entity);
+        } catch (InvalidArgumentException $e) {
+            $caught = $e;
+        }
+        $this->assertNotNull($caught, 'Expected InvalidArgumentException for entity with no source table.');
+        $this->assertMatchesRegularExpression('/no source table/i', $caught->getMessage());
+        $this->assertMatchesRegularExpression('/factoryClass/', $caught->getMessage());
+    }
+
+    public function testGuardFactoryClassRejectsNonBaseFactoryClassString(): void
+    {
+        // guardFactoryClass() throws when a non-BaseFactory class is passed
+        // to any of the trait's assertion methods. Documented contract; pin
+        // it so a refactor can't silently drop the friendly error in favour
+        // of a confusing static-method-not-found further down the call chain.
+        $caught = null;
+        try {
+            $this->assertTableEmpty(stdClass::class);
+        } catch (InvalidArgumentException $e) {
+            $caught = $e;
+        }
+        $this->assertNotNull($caught, 'Expected InvalidArgumentException for non-BaseFactory class.');
+        $this->assertMatchesRegularExpression('/must extend/i', $caught->getMessage());
     }
 }


### PR DESCRIPTION
A deep-dive audit ([codex](https://github.com/openai/codex) + a parallel API-surface walkthrough + a test-coverage agent) for the v2.0.0 stable ship surfaced one real correctness gap, three test-coverage gaps with ship-risk, one undocumented interaction worth pinning, and a missing single-page v2 overview for the release announcement. All addressed here in one bundle.

## Real correctness fix

**`strictDefinition` silently exempts shared-primary-key 1:1 associations.** The detector skipped every primary-key column *before* checking whether that column was ALSO a `belongsTo` FK — so a child whose `id` was both PK and FK to its parent escaped the dangling-id deprecation. **v2 is the last chance to warn those users before the v3 removal of the opt-out.**

Two-line fix in `detectForeignKeysInDefinition`: drop the PK skip entirely; the FK-membership check below is sufficient. A literal `id => 1` in `definition()` for a table whose `id` is just its own PK (not also a FK) is never in `$fkColumns` and is skipped naturally.

## Regression tests (4)

- **`testTriggersDeprecationForSharedPrimaryKeyForeignKey`** — RED before the fix, GREEN after. Pins the shared-PK case with a dedicated `SharedPkSmellyAddressFactory` fixture.
- **`testForeignKeyFalseIndependentSavePathReplaysNestedAfterSaveCallbacks`** — `DataCompiler::mergeWithToOne()` calls `replayAssociatedAfterSaveForTree()` specifically so callbacks nested under a `foreignKey => false` alias still fire. No test pinned that contract; now pinned with a callback two levels deep.
- **`testRecycleDoesNotPropagateIntoForeignKeyFalseSubtree`** — pins an undocumented but intentional behavior: `recycle()` does **not** propagate into a `foreignKey => false` subtree (the independent-save bypass doesn't go through `inheritRecycledEntities()`). Without a pin a future refactor could silently flip this either way.
- **`testAssertEntityExistsRejectsEntityWithoutSourceTable`** + **`testGuardFactoryClassRejectsNonBaseFactoryClassString`** — pin the `TableAssertionsTrait` friendly-error contract for two un-tested failure paths.

## Docs

- **`docs/guide/whats-new-in-v2.md` (new ~200 lines)** — single-page tour of the v2 surface: `withRequiredParents`, `recycle`, `for/has` alias overload, `Sequence` context, `Story`, `TableAssertionsTrait`, eager transaction strategy restored, `strictDefinition` detector, Bake quality. Wired into the sidebar between "Why factories?" and "Setup".  Designed to be linkable from the GitHub release notes for v2.0.0.
- **`docs/guide/associations.md`** — note that `recycle()` does NOT propagate into a `foreignKey => false` subtree (matches the new pin test).

## What this PR does NOT do

- The 8 low-risk coverage gaps the test-coverage agent surfaced (defensive paths, rare edge cases, narrow interaction matrices) — deferred to 2.x point releases.
- The 2 reverted `@internal` tags from PR #107 (`getMarshallerOptions`, `ensureTransaction`) — those are a deliberate review call to keep public; left as-is.

## Gates

- `composer sqlite`: 765 tests, 2609 assertions, 0 failures.
- `composer stan`: clean.
- `composer cs-check`: clean.
- `codex review --uncommitted`: clean.

Targets `main`. Should land before tagging 2.0.0-rc.4 / 2.0.0 stable.