### PR TITLE
v2 low-risk coverage sweep: 8 regression tests + friendlier hook errors

### DIFF
--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -2064,6 +2064,8 @@ abstract class BaseFactory
      *
      * @param array<int, string> $except Association aliases to skip.
      *
+     * @throws \CakephpFixtureFactories\Error\FixtureFactoryException
+     *
      * @return array<int, string> Ordered list of belongsTo aliases to compose.
      */
     private function resolveRequiredParentAliases(array $except): array
@@ -2152,14 +2154,43 @@ abstract class BaseFactory
             if (in_array($alias, $except, true)) {
                 continue;
             }
+            // Friendly error when the hook returns an alias the schema does
+            // not declare — OR declares but as a non-belongsTo. Without this
+            // guard the user sees a raw "Class for ... could not be found"
+            // later in doWithRequiredParents() with no hint that
+            // requiredParentAssociations() is the source; or worse, a typo
+            // matching a hasMany / belongsToMany alias is silently accepted
+            // and withRequiredParents() composes a to-many edge instead of
+            // a parent (the exact mistake this hook is meant to catch).
+            if (!$this->getTable()->hasAssociation($alias)) {
+                throw new FixtureFactoryException(sprintf(
+                    '%s::requiredParentAssociations() returned "%s", but `%s` does '
+                    . 'not declare a belongsTo association with that alias. Check the '
+                    . 'spelling, or remove the entry from the hook.',
+                    static::class,
+                    $alias,
+                    $this->getTable()->getRegistryAlias(),
+                ));
+            }
+            if (!$this->getTable()->getAssociation($alias) instanceof BelongsTo) {
+                throw new FixtureFactoryException(sprintf(
+                    '%s::requiredParentAssociations() returned "%s", but `%s.%s` is a '
+                    . '%s, not a belongsTo. The hook is for belongsTo opt-in only — '
+                    . 'use ->has() / ->with() at the call site for to-many edges.',
+                    static::class,
+                    $alias,
+                    $this->getTable()->getRegistryAlias(),
+                    $alias,
+                    self::shortName($this->getTable()->getAssociation($alias)::class),
+                ));
+            }
             // Honor caller-pinned FKs for hook-opted aliases too. The
             // auto-detection loop above already skips an alias whose FK is
             // pinned; the additive hook used to bypass that check, so
             // ->withRequiredParents() would compose a fresh parent over a
             // caller-pinned id. Contract: pinned FK wins on BOTH paths.
             if (
-                $this->getTable()->hasAssociation($alias)
-                && self::belongsToFkAlreadyPinned(
+                self::belongsToFkAlreadyPinned(
                     $this->getTable()->getAssociation($alias),
                     $pinnedFields,
                     $instantiationEntity,

--- a/tests/Factory/BogusRequiredParentAliasAuthorFactory.php
+++ b/tests/Factory/BogusRequiredParentAliasAuthorFactory.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link          https://webrider.de/
+ * @since         2.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace CakephpFixtureFactories\Test\Factory;
+
+/**
+ * Returns a typo / unknown alias from requiredParentAssociations() so the
+ * friendly-error guard for withRequiredParents() can be regression-tested.
+ *
+ * @extends \CakephpFixtureFactories\Test\Factory\RequiredParentsAuthorFactory
+ */
+class BogusRequiredParentAliasAuthorFactory extends RequiredParentsAuthorFactory
+{
+    /**
+     * @return array<int, string>
+     */
+    protected function requiredParentAssociations(): array
+    {
+        return ['TotallyMadeUpAlias'];
+    }
+}

--- a/tests/Factory/NonBelongsToRequiredParentAliasAuthorFactory.php
+++ b/tests/Factory/NonBelongsToRequiredParentAliasAuthorFactory.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link          https://webrider.de/
+ * @since         2.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace CakephpFixtureFactories\Test\Factory;
+
+/**
+ * Returns a real but non-belongsTo alias ('Articles', a belongsToMany on
+ * the Authors table) from requiredParentAssociations(), so the
+ * type-check guard for withRequiredParents() can be regression-tested.
+ *
+ * @extends \CakephpFixtureFactories\Test\Factory\RequiredParentsAuthorFactory
+ */
+class NonBelongsToRequiredParentAliasAuthorFactory extends RequiredParentsAuthorFactory
+{
+    /**
+     * @return array<int, string>
+     */
+    protected function requiredParentAssociations(): array
+    {
+        return ['Articles'];
+    }
+}

--- a/tests/TestCase/Factory/BaseFactoryForHasAliasTest.php
+++ b/tests/TestCase/Factory/BaseFactoryForHasAliasTest.php
@@ -195,4 +195,28 @@ class BaseFactoryForHasAliasTest extends TestCase
         // is a mis-wire that has() should reject.
         CountryFactory::new()->has(CountryFactory::new(), 'Cities');
     }
+
+    public function testHasComposesBothBatchesAcrossDuplicateBelongsToManyAdds(): void
+    {
+        // PR #97 added the BTM-only pivot guard. PR #98 added the to-many
+        // history merge so `->has(F1, 'Authors')->has(F2, 'Authors')`
+        // composes entities from BOTH (instead of last-wins). The
+        // combination — duplicate add on a belongsToMany alias — isn't
+        // covered together. Pin it: both batches' authors compose into
+        // the same belongsToMany set so the article ends up with all
+        // three authors.
+        $article = ArticleFactory::new()
+            ->without('Authors')
+            ->has(AuthorFactory::new()->count(2), 'Authors')
+            ->has(AuthorFactory::new()->count(1), 'Authors')
+            ->save();
+
+        $this->assertNotNull($article->id);
+        $reloaded = ArticleFactory::table()->get($article->id, contain: ['Authors']);
+        $this->assertCount(
+            3,
+            $reloaded->authors,
+            'Both duplicate has(..., \'Authors\') batches compose; the history merge keeps both.',
+        );
+    }
 }

--- a/tests/TestCase/Factory/BaseFactoryForeignKeyDetectionTest.php
+++ b/tests/TestCase/Factory/BaseFactoryForeignKeyDetectionTest.php
@@ -288,6 +288,41 @@ class BaseFactoryForeignKeyDetectionTest extends TestCase
     }
 
     /**
+     * Cache invalidation must also fire when a belongsTo is REMOVED at
+     * runtime, not just when one is added. Mirror of the add-case test
+     * above. Without this, a downstream test that drops an association
+     * to suppress composition would still see the dropped alias in the
+     * detector's FK map.
+     */
+    public function testForeignKeyColumnCacheReflectsRuntimeAssociationRemoval(): void
+    {
+        $table = new Table(['table' => 'cities', 'alias' => 'FkRemovalProbe']);
+        $table->belongsTo('Countries', ['foreignKey' => 'country_id']);
+        $table->belongsTo('LateRegion', [
+            'className' => 'Countries',
+            'foreignKey' => 'late_region_id',
+        ]);
+
+        $first = BaseFactory::collectForeignKeyColumns($table);
+        $this->assertArrayHasKey('late_region_id', $first);
+
+        // Drop the association — the cache must reflect the removal.
+        $table->associations()->remove('LateRegion');
+        $second = BaseFactory::collectForeignKeyColumns($table);
+
+        $this->assertArrayNotHasKey(
+            'late_region_id',
+            $second,
+            'FK-column cache must invalidate when a belongsTo is removed at runtime.',
+        );
+        $this->assertArrayHasKey(
+            'country_id',
+            $second,
+            'Remaining associations stay in the map after a sibling is removed.',
+        );
+    }
+
+    /**
      * Shared-primary-key 1:1 associations have `child.id` as both PK and the
      * belongsTo FK column. They are still a real "FK in definition()" case
      * — pinning `id` here has the same dangling-id / silently-overwritten-

--- a/tests/TestCase/Factory/BaseFactoryRecycleTest.php
+++ b/tests/TestCase/Factory/BaseFactoryRecycleTest.php
@@ -435,4 +435,39 @@ class BaseFactoryRecycleTest extends TestCase
             'BTM Authors children must build fresh; recycle does not substitute belongsToMany edges.',
         );
     }
+
+    public function testWithBracketCountAndRecycleDoesNotSubstituteToManyChildren(): void
+    {
+        // The bracket count syntax (`with('Alias[N]', ...)`) is per the
+        // associations guide a hasMany cardinality control: build N rows of
+        // the alias. recycle() only substitutes belongsTo edges, so the N
+        // hasMany children must all be freshly built — none of them collapse
+        // into the recycled entity even though it targets the same source
+        // table. Pins both contracts in one shot.
+        $country = CountryFactory::new()->save();
+        $existingCity = CityFactory::new()->save();
+        $citiesBefore = CityFactory::query()->count();
+
+        $country = CountryFactory::table()->get($country->id);
+        $result = CityFactory::table()->find()->where(['country_id' => $country->id])->count();
+        $this->assertSame(0, $result, 'No cities exist for this country yet.');
+
+        $country = CountryFactory::new()
+            ->with('Cities[3]', CityFactory::new())
+            ->recycle($existingCity)
+            ->save();
+
+        // 3 fresh Cities built — `Cities[3]` is the cardinality, recycle does
+        // not substitute on the to-many edge. So total cities = before + 3.
+        $this->assertSame(
+            $citiesBefore + 3,
+            CityFactory::query()->count(),
+            'Bracket-count hasMany children must build fresh regardless of recycle().',
+        );
+        $this->assertSame(
+            3,
+            CityFactory::query()->where(['country_id' => $country->id])->count(),
+            'Exactly 3 cities composed under the new country.',
+        );
+    }
 }

--- a/tests/TestCase/Factory/BaseFactoryWithRequiredParentsTest.php
+++ b/tests/TestCase/Factory/BaseFactoryWithRequiredParentsTest.php
@@ -22,8 +22,10 @@ use CakephpFixtureFactories\Error\FixtureFactoryException;
 use CakephpFixtureFactories\Factory\BaseFactory;
 use CakephpFixtureFactories\ORM\FactoryTableRegistry;
 use CakephpFixtureFactories\Test\Factory\AddressFactory;
+use CakephpFixtureFactories\Test\Factory\BogusRequiredParentAliasAuthorFactory;
 use CakephpFixtureFactories\Test\Factory\CityFactory;
 use CakephpFixtureFactories\Test\Factory\CountryFactory;
+use CakephpFixtureFactories\Test\Factory\NonBelongsToRequiredParentAliasAuthorFactory;
 use CakephpFixtureFactories\Test\Factory\RequiredParentsAuthorConfiguredFactory;
 use CakephpFixtureFactories\Test\Factory\RequiredParentsAuthorFactory;
 use CakephpFixtureFactories\Test\Factory\RequiredParentsCompositeOptInTableWithoutModelFactory;
@@ -1198,5 +1200,34 @@ class BaseFactoryWithRequiredParentsTest extends TestCase
             'recycle() must NOT propagate into a foreignKey => false subtree — '
             . 'fresh Countries are built inside it. Documented limitation.',
         );
+    }
+
+    public function testHookReturningUnknownAliasRaisesFriendlyError(): void
+    {
+        // A factory whose requiredParentAssociations() returns an alias that
+        // the schema does not declare must fail loudly at chain time with a
+        // domain-specific message naming both the hook and the typo. Without
+        // this guard the user sees Cake's raw "Class for ... could not be
+        // found" later in doWithRequiredParents() — confusing and unactionable.
+        $this->expectException(FixtureFactoryException::class);
+        $this->expectExceptionMessageMatches('/requiredParentAssociations\(\) returned "TotallyMadeUpAlias"/');
+
+        BogusRequiredParentAliasAuthorFactory::new()->withRequiredParents();
+    }
+
+    public function testHookReturningNonBelongsToAliasRaisesFriendlyError(): void
+    {
+        // The hook is documented as belongsTo-only. A typo or schema-rename
+        // that happens to match a hasMany / belongsToMany alias would
+        // otherwise be silently accepted and withRequiredParents() would
+        // compose a to-many edge instead of a parent — the exact mistake the
+        // hook is meant to prevent. Refuse with a clear message that names
+        // the actual association type so the typo is obvious.
+        $this->expectException(FixtureFactoryException::class);
+        $this->expectExceptionMessageMatches(
+            '/requiredParentAssociations\(\) returned "Articles".*is a BelongsToMany, not a belongsTo/',
+        );
+
+        NonBelongsToRequiredParentAliasAuthorFactory::new()->withRequiredParents();
     }
 }

--- a/tests/TestCase/Scenario/StoryTest.php
+++ b/tests/TestCase/Scenario/StoryTest.php
@@ -253,4 +253,38 @@ class StoryTest extends TestCase
 
         $story->load();
     }
+
+    public function testGetRandomThrowsOnRegisteredButEmptyPool(): void
+    {
+        // A pool can be registered without entities (an explicit
+        // addToPool($name, []) is unusual but valid — useful for a story
+        // that conditionally seeds rows). getRandom() must refuse instead
+        // of returning null / a misleading value.
+        $story = new class () extends Story {
+            protected function build(): void
+            {
+                $this->addToPool('empty', []);
+            }
+        };
+        /** @var \CakephpFixtureFactories\Scenario\Story $story */
+        $story = $story->load();
+
+        $this->expectException(FixtureScenarioException::class);
+        $this->expectExceptionMessageMatches('/Cannot draw from empty pool .*empty/');
+
+        $story->getRandom('empty');
+    }
+
+    public function testGetRandomSetRejectsNegativeCount(): void
+    {
+        // A negative $count would be incoherent (the contract is "N distinct
+        // entities"). PHP's int type accepts it; the runtime guard refuses.
+        /** @var \CakephpFixtureFactories\Test\Scenario\BlogStory $story */
+        $story = $this->loadFixtureScenario(BlogStory::class);
+
+        $this->expectException(FixtureScenarioException::class);
+        $this->expectExceptionMessageMatches('/count must be .*got -3/');
+
+        $story->getRandomSet('countries', -3);
+    }
 }

--- a/tests/TestCase/TestSuite/FactoryTransactionStrategyTest.php
+++ b/tests/TestCase/TestSuite/FactoryTransactionStrategyTest.php
@@ -527,6 +527,33 @@ class FactoryTransactionStrategyTest extends TestCase
         }
     }
 
+    public function testEnsureTransactionShortCircuitsWhenConnectionAlreadyInTransaction(): void
+    {
+        // A connection wrapped by an outer test harness reports
+        // inTransaction() === true. ensureTransaction must NOT call begin()
+        // again — double-begin on the same connection is either silently
+        // dropped or rejected by the driver, and either way the strategy's
+        // bookkeeping would track a connection it didn't actually begin.
+        $connection = $this->createMock(Connection::class);
+        $connection->method('configName')->willReturn('outer-wrapped');
+        $connection->method('inTransaction')->willReturn(true);
+        $connection->expects($this->never())->method('enableSavePoints');
+        $connection->expects($this->never())->method('begin');
+
+        $strategy = new FactoryTransactionStrategy();
+        $strategy->ensureTransaction($connection);
+
+        // Strategy must not add an already-wrapped connection to its set,
+        // otherwise teardown would issue rollback(true) on a transaction
+        // the strategy did not begin.
+        $reflection = new ReflectionProperty(FactoryTransactionStrategy::class, 'connections');
+        $this->assertSame(
+            [],
+            $reflection->getValue($strategy),
+            'ensureTransaction must not track a connection it short-circuited.',
+        );
+    }
+
     public function testEnsureTransactionRethrowsPersistenceException(): void
     {
         $connection = $this->createMock(Connection::class);


### PR DESCRIPTION
Closes out the 8 deferred low-risk findings from the deep-dive audit (test-coverage agent). Each item pins a defensive path or rare interaction that was correct in code but had no regression test — so post-stable refactors can't silently break it.

## 8 regression tests

- **`testGetRandomThrowsOnRegisteredButEmptyPool`** — `Story::getRandom()` on `addToPool($name, [])` throws a clear error instead of returning null.
- **`testGetRandomSetRejectsNegativeCount`** — `Story::getRandomSet('foo', -3)` refuses negative counts.
- **`testEnsureTransactionShortCircuitsWhenConnectionAlreadyInTransaction`** — `FactoryTransactionStrategy::ensureTransaction()` skips `begin()` when the connection is already wrapped, and does NOT track a connection it didn't begin.
- **`testForeignKeyColumnCacheReflectsRuntimeAssociationRemoval`** — FK cache invalidates on `belongsTo` removal too (mirror of the existing add case).
- **`testWithBracketCountAndRecycleDoesNotSubstituteToManyChildren`** — pins the `with('Cities[3]', ...)->recycle($city)` shape: 3 fresh Cities, recycle doesn't substitute on hasMany. Pins TWO contracts at once.
- **`testHookReturningUnknownAliasRaisesFriendlyError`** — typo in `requiredParentAssociations()` now throws a domain-specific message naming the hook + the typo (was a raw "Class for ... could not be found" later).
- **`testHookReturningNonBelongsToAliasRaisesFriendlyError`** — a real alias that happens to be `hasMany` / `belongsToMany` now also fails clearly (was silently accepted, then `withRequiredParents()` would compose a to-many edge instead of a parent — the exact mistake the hook is meant to prevent).
- **`testHasComposesBothBatchesAcrossDuplicateBelongsToManyAdds`** — pins the duplicate-add × belongsToMany interaction: PR #97's pivot guard and PR #98's history merge work together; both batches' Authors compose into the same set.

## Small src enhancements

Two friendlier errors on the `requiredParentAssociations()` hook (`BaseFactory::resolveRequiredParentAliases()`):

1. **Reject aliases the schema doesn't declare** — domain-specific message instead of Cake's raw "Class for ... could not be found".
2. **Reject aliases that are real but non-belongsTo** (hasMany / belongsToMany / hasOne) — names the actual association type so the typo is obvious.

Both guards run BEFORE the pinned-FK check so the user sees the type / typo error first.

## Two new test fixtures

- `tests/Factory/BogusRequiredParentAliasAuthorFactory.php` — hook returns `'TotallyMadeUpAlias'`.
- `tests/Factory/NonBelongsToRequiredParentAliasAuthorFactory.php` — hook returns `'Articles'` (real belongsToMany alias).

Anonymous-class subclasses can't be instantiated via the protected `BaseFactory` constructor; named subclasses go through `::new()` cleanly.

## Dropped from the original scope

The Sequence multi-row `isFirst` / `isLast` shape test (audit item #6) was redundant — `testSequenceCallableReceivesSequenceObject` already asserts that exact shape over a 3-row batch.

## Gates

- `composer sqlite`: **773 tests, 2627 assertions, 0 failures** (11 pre-existing skips).
- `composer stan`: clean.
- `composer cs-check`: clean.
- `codex review --uncommitted`: clean on the second pass (first surfaced the non-belongsTo hook gap, which is now also addressed).

Targets `main`. Non-breaking; can ship in 2.0.0-rc.4 or held to a 2.x point release at your discretion.