### PR TITLE
Polish v2 release docs and CS paths

### DIFF
--- a/docs/guide/queries.md
+++ b/docs/guide/queries.md
@@ -2,10 +2,22 @@
 
 
 The fixture factories are closely related to the database. The package provides several methods to conveniently
-run queries. All methods will by-pass the `beforeFind` event, enabling the direct inspection of your
+run queries. All methods bypass the `beforeFind` event, enabling the direct inspection of your
 test database.
 
-These methods are meant to help performing assertions in the "Assert" part of your tests. Do not use `::query()` in the "Act" part of your tests, e.g. to test finders.
+These methods are meant to help perform assertions in the "Assert" part of your tests. Do not use `::query()` in the "Act" part of your tests, e.g. to test finders.
+
+`Factory::query()` does not represent your application's normal query path. It queries through the factory-managed table, which intentionally disables `Model.beforeFind`. This is correct for:
+
+- asserting rows were written, updated, or deleted
+- counting records directly in the test database
+- fetching rows by criteria without app-level finder/event side effects
+
+It is the wrong tool for:
+
+- testing a custom finder
+- testing tenant scoping or soft-delete filters wired via `beforeFind`
+- testing behavior/listener code that mutates queries during reads
 
 ## `ArticleFactory::query()`
 
@@ -75,8 +87,9 @@ class ArticlesControllerTest extends AppTestCase
 - `assertEntityExists(EntityInterface $entity, ?string $factoryClass = null, ?string $message = null)` — the entity is still in the database (by primary key).
 - `assertEntityMissing(EntityInterface $entity, ?string $factoryClass = null, ?string $message = null)` — the entity is no longer in the database.
 
-> [!IMPORTANT]
-> `assertEntityMissing()` refuses entities that were never persisted — both the "no primary key" case and the application-assigned-PK case (UUID / string IDs) where the entity carries a PK at build time but was never written. The guard checks `isNew()` first and the PK as a fallback. Save the entity (then delete it) before asserting it is missing.
+::: warning
+`assertEntityMissing()` refuses entities that were never persisted — both the "no primary key" case and the application-assigned-PK case (UUID / string IDs) where the entity carries a PK at build time but was never written. The guard checks `isNew()` first and the PK as a fallback. Save the entity (then delete it) before asserting it is missing.
+:::
 
 The optional `$factoryClass` argument on the entity assertions scopes the lookup to that factory's table. Use it when several factory variants share a bare table alias on different connections — without it, the entity's `getSource()` is consulted, which may resolve to whichever factory variant most-recently registered with the locator.
 

--- a/docs/guide/required-parents.md
+++ b/docs/guide/required-parents.md
@@ -272,7 +272,8 @@ class BillFactory extends BaseFactory
 ```
 
 Resolution order: `auto-detected ∪ requiredParentAssociations() − excludedRequiredParentAssociations() − $except`.
-Exclude wins over both the additive hook and per-call `$except` (both subtract).
+The class-level exclude wins over the additive hook; the per-call `$except`
+argument subtracts from the same resolved set.
 Each is independent; either may stay at its default (`[]`).
 
 ::: tip `foreignKey => false` and composite-key opt-in are both supported

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -46,6 +46,13 @@ The bundled rules cover the safe, mechanical call-site changes:
 
 It intentionally does **not** rewrite deprecated `persist()` calls, because that return type is shape-dependent and needs a human choice between `save()` and `saveMany()`.
 
+Be careful with the static query helper rewrite:
+
+- `Factory::query()` keeps the old `Factory::find()` semantics of querying through the factory-managed table.
+- That means `Model.beforeFind` listeners are still bypassed on purpose.
+- Use it for database assertions in the "Assert" part of tests, not when you want to verify your real finder/event behavior in the "Act" part.
+- If you need normal CakePHP table/query semantics, use the real table instance instead of `Factory::query()`.
+
 Typical before/after replacements look like this:
 
 ```diff

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -4,9 +4,8 @@
     <arg value="nps"/>
 
     <file>src/</file>
+    <file>tests/Factory/</file>
     <file>tests/TestCase/</file>
-    <file>tests/TestApp/tests/Factory/</file>
-    <file>tests/TestApp/plugins/TestPlugin/tests/Factory/</file>
 
     <exclude-pattern>/templates/</exclude-pattern>
     <exclude-pattern>/tests/TestCase/Rector/Fixture/</exclude-pattern>

--- a/src/Command/BakeFixtureFactoryCommand.php
+++ b/src/Command/BakeFixtureFactoryCommand.php
@@ -136,7 +136,7 @@ class BakeFixtureFactoryCommand extends BakeCommand
      *
      * @return array<string>|string
      */
-    public function getModelPath(): string|array
+    public function getModelPath(): array|string
     {
         if ($this->plugin) {
             $path = $this->_pluginPath($this->plugin) . APP_DIR . DS . $this->pathToTableDir;
@@ -284,7 +284,7 @@ class BakeFixtureFactoryCommand extends BakeCommand
      *
      * @return int|bool
      */
-    public function bakeFixtureFactory(string $modelName, Arguments $args, ConsoleIo $io): bool|int
+    public function bakeFixtureFactory(string $modelName, Arguments $args, ConsoleIo $io): int|bool
     {
         $this->modelName = $modelName;
 

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -940,7 +940,7 @@ abstract class BaseFactory
      *
      * @return static
      */
-    public function state(array|callable|EntityInterface $data): static
+    public function state(EntityInterface|callable|array $data): static
     {
         $factory = clone $this;
         if (is_callable($data)) {
@@ -988,7 +988,7 @@ abstract class BaseFactory
      *
      * @return static
      */
-    public function sequence(array|callable|EntityInterface ...$states): static
+    public function sequence(EntityInterface|callable|array ...$states): static
     {
         if ($states === []) {
             throw new InvalidArgumentException('sequence() expects at least one array, entity or callable state.');
@@ -1354,7 +1354,7 @@ abstract class BaseFactory
      *
      * @return static
      */
-    public function setPrimaryKeyOffset(int|string|array $primaryKeyOffset): static
+    public function setPrimaryKeyOffset(array|string|int $primaryKeyOffset): static
     {
         $factory = clone $this;
         $factory->getDataCompiler()->setPrimaryKeyOffset($primaryKeyOffset);
@@ -1681,7 +1681,7 @@ abstract class BaseFactory
      *
      * @return static
      */
-    public function with(string $associationName, array|int|callable|BaseFactory|EntityInterface|string $data = []): static
+    public function with(string $associationName, BaseFactory|EntityInterface|callable|array|string|int $data = []): static
     {
         if ($this->readBootstrapMode) {
             return clone $this;

--- a/src/Factory/DataCompiler.php
+++ b/src/Factory/DataCompiler.php
@@ -395,7 +395,7 @@ class DataCompiler
      * @return \Cake\Datasource\EntityInterface
      */
     public function compileEntity(
-        array|callable|EntityInterface|string $injectedData = [],
+        EntityInterface|callable|array|string $injectedData = [],
         bool $setPrimaryKey = false,
     ): EntityInterface {
         if (is_string($injectedData)) {
@@ -574,7 +574,7 @@ class DataCompiler
      *
      * @return $this
      */
-    private function mergeWithInjectedData(EntityInterface $entity, array|callable $data)
+    private function mergeWithInjectedData(EntityInterface $entity, callable|array $data)
     {
         if (is_callable($data)) {
             $data = $data(
@@ -1261,7 +1261,7 @@ class DataCompiler
      *
      * @return \Cake\ORM\Association|bool
      */
-    public function getAssociationByPropertyName(string $propertyName): bool|Association
+    public function getAssociationByPropertyName(string $propertyName): Association|bool
     {
         try {
             return $this->getFactory()->getTable()->getAssociation(Inflector::camelize($propertyName));
@@ -1337,7 +1337,7 @@ class DataCompiler
      *
      * @return string|int
      */
-    public function generateRandomPrimaryKey(string $columnType): int|string
+    public function generateRandomPrimaryKey(string $columnType): string|int
     {
         return match ($columnType) {
             'uuid', 'string' => $this->getFactory()->getGenerator()->uuid(),

--- a/src/Factory/FactoryAwareTrait.php
+++ b/src/Factory/FactoryAwareTrait.php
@@ -39,7 +39,7 @@ trait FactoryAwareTrait
      */
     public function getFactory(
         string $name,
-        array|callable|int|EntityInterface|string|null $makeParameter = [],
+        EntityInterface|callable|array|string|int|null $makeParameter = [],
         int $times = 1,
     ): BaseFactory {
         $factoryClassName = $this->getFactoryClassName($name);

--- a/tests/Factory/AddressFactory.php
+++ b/tests/Factory/AddressFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -6,11 +7,12 @@ declare(strict_types=1);
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
- * @link          https://webrider.de/
- * @since         1.0.0
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link https://webrider.de/
+ * @since 1.0.0
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace CakephpFixtureFactories\Test\Factory;
 
 use CakephpFixtureFactories\Factory\BaseFactory;
@@ -19,7 +21,7 @@ use CakephpFixtureFactories\Generator\GeneratorInterface;
 /**
  * Class AddressFactory
  *
- * @extends BaseFactory<\TestApp\Model\Entity\Address>
+ * @extends \CakephpFixtureFactories\Factory\BaseFactory<\TestApp\Model\Entity\Address>
  */
 class AddressFactory extends BaseFactory
 {

--- a/tests/Factory/AlternativeSeedArticleFactory.php
+++ b/tests/Factory/AlternativeSeedArticleFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -6,11 +7,12 @@ declare(strict_types=1);
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
- * @link          https://webrider.de/
- * @since         1.0.0
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link https://webrider.de/
+ * @since 1.0.0
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace CakephpFixtureFactories\Test\Factory;
 
 class AlternativeSeedArticleFactory extends ArticleFactory

--- a/tests/Factory/ArticleFactory.php
+++ b/tests/Factory/ArticleFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -6,11 +7,12 @@ declare(strict_types=1);
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
- * @link          https://webrider.de/
- * @since         1.0.0
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link https://webrider.de/
+ * @since 1.0.0
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace CakephpFixtureFactories\Test\Factory;
 
 use CakephpFixtureFactories\Factory\BaseFactory;
@@ -20,10 +22,13 @@ use TestApp\Model\Entity\Article;
 /**
  * Class ArticleFactory
  *
- * @extends BaseFactory<\TestApp\Model\Entity\Article>
+ * @extends \CakephpFixtureFactories\Factory\BaseFactory<\TestApp\Model\Entity\Article>
  */
 class ArticleFactory extends BaseFactory
 {
+    /**
+     * @var int
+     */
     public const DEFAULT_NUMBER_OF_AUTHORS = 2;
 
     /**
@@ -42,7 +47,7 @@ class ArticleFactory extends BaseFactory
      * Use the patchData method to set the field values.
      * You may use methods of the factory here
      *
-     * @return void
+     * @return array<string, mixed>
      */
     public function definition(GeneratorInterface $generator): array
     {
@@ -73,7 +78,8 @@ class ArticleFactory extends BaseFactory
      *
      * @param mixed $parameter
      * @param int $n
-     * @return ArticleFactory
+     *
+     * @return self
      */
     public function hasBills(mixed $n = 1, mixed $parameter = null): self
     {
@@ -92,7 +98,8 @@ class ArticleFactory extends BaseFactory
      *
      * @param mixed $parameter
      * @param int $n
-     * @return ArticleFactory
+     *
+     * @return self
      */
     public function hasBillsWithArticle(mixed $n = 1, mixed $parameter = null): self
     {
@@ -109,7 +116,8 @@ class ArticleFactory extends BaseFactory
      * Set the Article's title
      *
      * @param string $title
-     * @return ArticleFactory
+     *
+     * @return self
      */
     public function withTitle(string $title): self
     {
@@ -119,7 +127,7 @@ class ArticleFactory extends BaseFactory
     /**
      * Set the Article's title as a random job title
      *
-     * @return ArticleFactory
+     * @return self
      */
     public function setJobTitle(): self
     {

--- a/tests/Factory/ArticleWithFiveBillsFactory.php
+++ b/tests/Factory/ArticleWithFiveBillsFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -6,16 +7,19 @@ declare(strict_types=1);
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
- * @link          https://webrider.de/
- * @since         1.0.0
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link https://webrider.de/
+ * @since 1.0.0
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace CakephpFixtureFactories\Test\Factory;
+
+use CakephpFixtureFactories\Generator\GeneratorInterface;
 
 class ArticleWithFiveBillsFactory extends ArticleFactory
 {
-    public function definition(\CakephpFixtureFactories\Generator\GeneratorInterface $generator): array
+    public function definition(GeneratorInterface $generator): array
     {
         return [
             ...parent::definition($generator),

--- a/tests/Factory/ArticlesAuthorFactory.php
+++ b/tests/Factory/ArticlesAuthorFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -6,11 +7,12 @@ declare(strict_types=1);
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
- * @link          https://webrider.de/
- * @since         1.0.0
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link https://webrider.de/
+ * @since 1.0.0
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace CakephpFixtureFactories\Test\Factory;
 
 use CakephpFixtureFactories\Factory\BaseFactory;
@@ -34,7 +36,7 @@ class ArticlesAuthorFactory extends BaseFactory
      * Use the patchData method to set the field values.
      * You may use methods of the factory here
      *
-     * @return void
+     * @return array<string, mixed>
      */
     public function definition(GeneratorInterface $generator): array
     {

--- a/tests/Factory/AuthorFactory.php
+++ b/tests/Factory/AuthorFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -6,11 +7,12 @@ declare(strict_types=1);
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
- * @link          https://webrider.de/
- * @since         1.0.0
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link https://webrider.de/
+ * @since 1.0.0
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace CakephpFixtureFactories\Test\Factory;
 
 use CakephpFixtureFactories\Factory\BaseFactory;
@@ -19,10 +21,13 @@ use CakephpFixtureFactories\Generator\GeneratorInterface;
 /**
  * Class AuthorFactory
  *
- * @extends BaseFactory<\TestApp\Model\Entity\Author>
+ * @extends \CakephpFixtureFactories\Factory\BaseFactory<\TestApp\Model\Entity\Author>
  */
 class AuthorFactory extends BaseFactory
 {
+    /**
+     * @var array
+     */
     public const JSON_FIELD_DEFAULT_VALUE = [
         'subField1' => 'subFieldValue1',
         'subField2' => 'subFieldValue2',

--- a/tests/Factory/BillFactory.php
+++ b/tests/Factory/BillFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -6,11 +7,12 @@ declare(strict_types=1);
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
- * @link          https://webrider.de/
- * @since         1.0.0
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link https://webrider.de/
+ * @since 1.0.0
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace CakephpFixtureFactories\Test\Factory;
 
 use CakephpFixtureFactories\Factory\BaseFactory;
@@ -19,7 +21,7 @@ use CakephpFixtureFactories\Generator\GeneratorInterface;
 /**
  * Class BillFactory
  *
- * @extends BaseFactory<\TestPlugin\Model\Entity\Bill>
+ * @extends \CakephpFixtureFactories\Factory\BaseFactory<\TestPlugin\Model\Entity\Bill>
  */
 class BillFactory extends BaseFactory
 {

--- a/tests/Factory/BogusRequiredParentAliasAuthorFactory.php
+++ b/tests/Factory/BogusRequiredParentAliasAuthorFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -6,11 +7,12 @@ declare(strict_types=1);
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
- * @link          https://webrider.de/
- * @since         2.0.0
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link https://webrider.de/
+ * @since 2.0.0
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace CakephpFixtureFactories\Test\Factory;
 
 /**

--- a/tests/Factory/CityFactory.php
+++ b/tests/Factory/CityFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -6,11 +7,12 @@ declare(strict_types=1);
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
- * @link          https://webrider.de/
- * @since         1.0.0
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link https://webrider.de/
+ * @since 1.0.0
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace CakephpFixtureFactories\Test\Factory;
 
 use CakephpFixtureFactories\Factory\BaseFactory;
@@ -19,7 +21,7 @@ use CakephpFixtureFactories\Generator\GeneratorInterface;
 /**
  * Class CityFactory
  *
- * @extends BaseFactory<\TestApp\Model\Entity\City>
+ * @extends \CakephpFixtureFactories\Factory\BaseFactory<\TestApp\Model\Entity\City>
  */
 class CityFactory extends BaseFactory
 {
@@ -29,7 +31,7 @@ class CityFactory extends BaseFactory
 
     protected function initialize(): void
     {
-        if (!$this->getTable()->hasAssociation('TableWithoutModel')){
+        if (!$this->getTable()->hasAssociation('TableWithoutModel')) {
             $this->getTable()->hasMany('TableWithoutModel', [
                 'foreignKey' => 'foreign_key',
             ]);
@@ -48,10 +50,6 @@ class CityFactory extends BaseFactory
         ];
     }
 
-    /**
-     * @param array|callable|null|int $parameter
-     * @return $this
-     */
     protected function configure(): static
     {
         return $this->forCountries();

--- a/tests/Factory/ConfiguredConnectionArticleFactory.php
+++ b/tests/Factory/ConfiguredConnectionArticleFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace CakephpFixtureFactories\Test\Factory;

--- a/tests/Factory/CountryFactory.php
+++ b/tests/Factory/CountryFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -6,11 +7,12 @@ declare(strict_types=1);
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
- * @link          https://webrider.de/
- * @since         1.0.0
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link https://webrider.de/
+ * @since 1.0.0
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace CakephpFixtureFactories\Test\Factory;
 
 use CakephpFixtureFactories\Factory\BaseFactory;
@@ -19,7 +21,7 @@ use CakephpFixtureFactories\Generator\GeneratorInterface;
 /**
  * Class CountryFactory
  *
- * @extends BaseFactory<\TestApp\Model\Entity\Country>
+ * @extends \CakephpFixtureFactories\Factory\BaseFactory<\TestApp\Model\Entity\Country>
  */
 class CountryFactory extends BaseFactory
 {

--- a/tests/Factory/CustomBuildHooksArticleFactory.php
+++ b/tests/Factory/CustomBuildHooksArticleFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -6,11 +7,12 @@ declare(strict_types=1);
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
- * @link          https://webrider.de/
- * @since         3.2.0
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link https://webrider.de/
+ * @since 3.2.0
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace CakephpFixtureFactories\Test\Factory;
 
 use CakephpFixtureFactories\Factory\DataCompiler;

--- a/tests/Factory/CustomerFactory.php
+++ b/tests/Factory/CustomerFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -6,11 +7,12 @@ declare(strict_types=1);
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
- * @link          https://webrider.de/
- * @since         1.0.0
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link https://webrider.de/
+ * @since 1.0.0
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace CakephpFixtureFactories\Test\Factory;
 
 use CakephpFixtureFactories\Factory\BaseFactory;
@@ -19,7 +21,7 @@ use CakephpFixtureFactories\Generator\GeneratorInterface;
 /**
  * Class CustomerFactory
  *
- * @extends BaseFactory<\TestPlugin\Model\Entity\Customer>
+ * @extends \CakephpFixtureFactories\Factory\BaseFactory<\TestPlugin\Model\Entity\Customer>
  */
 class CustomerFactory extends BaseFactory
 {
@@ -36,9 +38,10 @@ class CustomerFactory extends BaseFactory
     }
 
     /**
-     * @param array|callable|null|int|\Cake\Datasource\EntityInterface $parameter Injected data
+     * @param \Cake\Datasource\EntityInterface|callable|array|int|null $parameter Injected data
      * @param int $n
-     * @return CustomerFactory
+     *
+     * @return self
      */
     public function hasBills($n = 1, $parameter = null): self
     {
@@ -52,8 +55,9 @@ class CustomerFactory extends BaseFactory
     }
 
     /**
-     * @param array|callable|null|int|\Cake\Datasource\EntityInterface $parameter Injected data
-     * @return CustomerFactory
+     * @param \Cake\Datasource\EntityInterface|callable|array|int|null $parameter Injected data
+     *
+     * @return self
      */
     public function forAddress($parameter = null): self
     {

--- a/tests/Factory/NonBelongsToRequiredParentAliasAuthorFactory.php
+++ b/tests/Factory/NonBelongsToRequiredParentAliasAuthorFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -6,11 +7,12 @@ declare(strict_types=1);
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
- * @link          https://webrider.de/
- * @since         2.0.0
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link https://webrider.de/
+ * @since 2.0.0
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace CakephpFixtureFactories\Test\Factory;
 
 /**

--- a/tests/Factory/PremiumAuthorFactory.php
+++ b/tests/Factory/PremiumAuthorFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -6,11 +7,12 @@ declare(strict_types=1);
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
- * @link          https://webrider.de/
- * @since         1.0.0
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link https://webrider.de/
+ * @since 1.0.0
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace CakephpFixtureFactories\Test\Factory;
 
 class PremiumAuthorFactory extends AuthorFactory

--- a/tests/Factory/RequiredParentsAuthorConfiguredFactory.php
+++ b/tests/Factory/RequiredParentsAuthorConfiguredFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace CakephpFixtureFactories\Test\Factory;
@@ -12,7 +13,7 @@ use CakephpFixtureFactories\Generator\GeneratorInterface;
  * downstream consumers) rather than expecting callers to chain it on at
  * `::new(...)` sites.
  *
- * @extends BaseFactory<\TestApp\Model\Entity\Author>
+ * @extends \CakephpFixtureFactories\Factory\BaseFactory<\TestApp\Model\Entity\Author>
  */
 class RequiredParentsAuthorConfiguredFactory extends BaseFactory
 {

--- a/tests/Factory/RequiredParentsAuthorFactory.php
+++ b/tests/Factory/RequiredParentsAuthorFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -6,11 +7,12 @@ declare(strict_types=1);
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
- * @link          https://webrider.de/
- * @since         1.0.0
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link https://webrider.de/
+ * @since 1.0.0
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace CakephpFixtureFactories\Test\Factory;
 
 use CakephpFixtureFactories\Factory\BaseFactory;
@@ -22,7 +24,7 @@ use CakephpFixtureFactories\Generator\GeneratorInterface;
  * table has a NOT NULL `address_id` (Address belongsTo — required) and a
  * nullable `business_address_id` (BusinessAddress belongsTo — optional).
  *
- * @extends BaseFactory<\TestApp\Model\Entity\Author>
+ * @extends \CakephpFixtureFactories\Factory\BaseFactory<\TestApp\Model\Entity\Author>
  */
 class RequiredParentsAuthorFactory extends BaseFactory
 {

--- a/tests/Factory/RequiredParentsExcludeAuthorFactory.php
+++ b/tests/Factory/RequiredParentsExcludeAuthorFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -6,11 +7,12 @@ declare(strict_types=1);
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
- * @link          https://webrider.de/
- * @since         1.0.0
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link https://webrider.de/
+ * @since 1.0.0
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace CakephpFixtureFactories\Test\Factory;
 
 /**

--- a/tests/Factory/RequiredParentsForeignKeyFalseOptInFactory.php
+++ b/tests/Factory/RequiredParentsForeignKeyFalseOptInFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -6,11 +7,12 @@ declare(strict_types=1);
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
- * @link          https://webrider.de/
- * @since         1.0.0
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link https://webrider.de/
+ * @since 1.0.0
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace CakephpFixtureFactories\Test\Factory;
 
 /**

--- a/tests/Factory/RequiredParentsOverrideAuthorFactory.php
+++ b/tests/Factory/RequiredParentsOverrideAuthorFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -6,11 +7,12 @@ declare(strict_types=1);
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
- * @link          https://webrider.de/
- * @since         1.0.0
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link https://webrider.de/
+ * @since 1.0.0
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace CakephpFixtureFactories\Test\Factory;
 
 /**

--- a/tests/Factory/SchemaAwareCountryFactory.php
+++ b/tests/Factory/SchemaAwareCountryFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -6,11 +7,12 @@ declare(strict_types=1);
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
- * @link          https://webrider.de/
- * @since         1.0.0
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link https://webrider.de/
+ * @since 1.0.0
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace CakephpFixtureFactories\Test\Factory;
 
 use CakephpFixtureFactories\Generator\GeneratorInterface;

--- a/tests/Factory/SharedPkSmellyAddressFactory.php
+++ b/tests/Factory/SharedPkSmellyAddressFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -6,11 +7,12 @@ declare(strict_types=1);
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
- * @link          https://webrider.de/
- * @since         2.0.0
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link https://webrider.de/
+ * @since 2.0.0
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace CakephpFixtureFactories\Test\Factory;
 
 use CakephpFixtureFactories\Factory\BaseFactory;
@@ -26,7 +28,7 @@ use CakephpFixtureFactories\Generator\GeneratorInterface;
  * Production factories should never pin `id` like this when `id` is also
  * a belongsTo FK — see SmellyAddressFactory for the regular-FK variant.
  *
- * @extends BaseFactory<\TestApp\Model\Entity\Address>
+ * @extends \CakephpFixtureFactories\Factory\BaseFactory<\TestApp\Model\Entity\Address>
  */
 class SharedPkSmellyAddressFactory extends BaseFactory
 {

--- a/tests/Factory/SmellyAddressFactory.php
+++ b/tests/Factory/SmellyAddressFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -6,11 +7,12 @@ declare(strict_types=1);
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
- * @link          https://webrider.de/
- * @since         1.0.0
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link https://webrider.de/
+ * @since 1.0.0
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace CakephpFixtureFactories\Test\Factory;
 
 use CakephpFixtureFactories\Factory\BaseFactory;
@@ -21,7 +23,7 @@ use CakephpFixtureFactories\Generator\GeneratorInterface;
  * `definition()` so the FK-in-definition detector test suite has an offender
  * to assert against. Production factories should never be shaped this way.
  *
- * @extends BaseFactory<\TestApp\Model\Entity\Address>
+ * @extends \CakephpFixtureFactories\Factory\BaseFactory<\TestApp\Model\Entity\Address>
  */
 class SmellyAddressFactory extends BaseFactory
 {

--- a/tests/Factory/StrictCityFactory.php
+++ b/tests/Factory/StrictCityFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -6,11 +7,12 @@ declare(strict_types=1);
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
- * @link          https://webrider.de/
- * @since         1.0.0
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link https://webrider.de/
+ * @since 1.0.0
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace CakephpFixtureFactories\Test\Factory;
 
 class StrictCityFactory extends CityFactory

--- a/tests/Factory/SubDirectory/SubCityFactory.php
+++ b/tests/Factory/SubDirectory/SubCityFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -6,11 +7,12 @@ declare(strict_types=1);
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
- * @link          https://webrider.de/
- * @since         1.0.0
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link https://webrider.de/
+ * @since 1.0.0
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace CakephpFixtureFactories\Test\Factory\SubDirectory;
 
 use CakephpFixtureFactories\Test\Factory\CityFactory as BaseFactory;

--- a/tests/Factory/TableWithoutModelFactory.php
+++ b/tests/Factory/TableWithoutModelFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -6,11 +7,12 @@ declare(strict_types=1);
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
- * @link          https://webrider.de/
- * @since         2.5
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link https://webrider.de/
+ * @since 2.5
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace CakephpFixtureFactories\Test\Factory;
 
 use CakephpFixtureFactories\Factory\BaseFactory;
@@ -19,7 +21,7 @@ use CakephpFixtureFactories\Generator\GeneratorInterface;
 /**
  * Class TableWithoutModelFactory
  *
- * @extends BaseFactory<\Cake\ORM\Entity>
+ * @extends \CakephpFixtureFactories\Factory\BaseFactory<\Cake\ORM\Entity>
  */
 class TableWithoutModelFactory extends BaseFactory
 {
@@ -39,7 +41,7 @@ class TableWithoutModelFactory extends BaseFactory
      * Use the patchData method to set the field values.
      * You may use methods of the factory here
      *
-     * @return void
+     * @return array<string, mixed>
      */
     public function definition(GeneratorInterface $generator): array
     {


### PR DESCRIPTION
## Summary

- clarify Factory::query() docs and upgrade notes around bypassed beforeFind behavior
- use a VitePress warning container for the TableAssertionsTrait note
- fix the phpcs ruleset to scan the real tests/Factory directory instead of missing TestApp paths
- apply the resulting coding-standard fixes in src/test factories

## Verification

- composer cs-fix
- composer cs-check
- composer stan
- composer test
- npm --prefix docs run docs:build
- npm --prefix docs audit --omit=dev